### PR TITLE
feat: platform-native logging (oslog, logcat, file fallback)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,29 +1751,6 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.5.3"
-dependencies = [
- "blurhash",
- "chacha20poly1305",
- "hex",
- "hkdf",
- "image",
- "kamadak-exif",
- "mdk-storage-traits 0.5.1",
- "nostr",
- "openmls",
- "openmls_basic_credential",
- "openmls_rust_crypto",
- "openmls_traits",
- "serde",
- "sha2",
- "thiserror 2.0.18",
- "tls_codec",
- "tracing",
-]
-
-[[package]]
-name = "mdk-core"
-version = "0.5.3"
 source = "git+https://github.com/marmot-protocol/mdk?rev=1ad73229ab712018c078d5295e11ec38e10d6a24#1ad73229ab712018c078d5295e11ec38e10d6a24"
 dependencies = [
  "blurhash",
@@ -1782,7 +1759,7 @@ dependencies = [
  "hkdf",
  "image",
  "kamadak-exif",
- "mdk-storage-traits 0.5.1 (git+https://github.com/marmot-protocol/mdk?rev=1ad73229ab712018c078d5295e11ec38e10d6a24)",
+ "mdk-storage-traits",
  "nostr",
  "openmls",
  "openmls_basic_credential",
@@ -1798,32 +1775,12 @@ dependencies = [
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.5.1"
-dependencies = [
- "getrandom 0.3.4",
- "hex",
- "keyring-core",
- "mdk-storage-traits 0.5.1",
- "nostr",
- "openmls",
- "openmls_traits",
- "refinery",
- "rusqlite",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "mdk-sqlite-storage"
-version = "0.5.1"
 source = "git+https://github.com/marmot-protocol/mdk?rev=1ad73229ab712018c078d5295e11ec38e10d6a24#1ad73229ab712018c078d5295e11ec38e10d6a24"
 dependencies = [
  "getrandom 0.3.4",
  "hex",
  "keyring-core",
- "mdk-storage-traits 0.5.1 (git+https://github.com/marmot-protocol/mdk?rev=1ad73229ab712018c078d5295e11ec38e10d6a24)",
+ "mdk-storage-traits",
  "nostr",
  "openmls",
  "openmls_traits",
@@ -1834,19 +1791,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "mdk-storage-traits"
-version = "0.5.1"
-dependencies = [
- "nostr",
- "openmls",
- "openmls_traits",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "zeroize",
 ]
 
 [[package]]
@@ -1926,6 +1870,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "negentropy"
@@ -2199,6 +2152,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "paranoid-android"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101795d63d371b43e38d6e7254677657be82f17022f7f7893c268f33ac0caadc"
+dependencies = [
+ "lazy_static",
+ "ndk-sys",
+ "sharded-slab",
+ "smallvec",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,9 +2237,9 @@ dependencies = [
  "anyhow",
  "clap",
  "hex",
- "mdk-core 0.5.3",
- "mdk-sqlite-storage 0.5.1",
- "mdk-storage-traits 0.5.1",
+ "mdk-core",
+ "mdk-sqlite-storage",
+ "mdk-storage-traits",
  "nostr-sdk",
  "rand 0.8.5",
  "serde",
@@ -2296,17 +2263,19 @@ dependencies = [
  "jni",
  "keyring-core",
  "libsqlite3-sys",
- "mdk-core 0.5.3 (git+https://github.com/marmot-protocol/mdk?rev=1ad73229ab712018c078d5295e11ec38e10d6a24)",
- "mdk-sqlite-storage 0.5.1 (git+https://github.com/marmot-protocol/mdk?rev=1ad73229ab712018c078d5295e11ec38e10d6a24)",
- "mdk-storage-traits 0.5.1 (git+https://github.com/marmot-protocol/mdk?rev=1ad73229ab712018c078d5295e11ec38e10d6a24)",
+ "mdk-core",
+ "mdk-sqlite-storage",
+ "mdk-storage-traits",
  "ndk-context",
  "nostr-sdk",
+ "paranoid-android",
  "rand 0.8.5",
  "serde_json",
  "tempfile",
  "tokio",
  "tokio-tungstenite 0.27.0",
  "tracing",
+ "tracing-oslog",
  "tracing-subscriber",
  "uniffi",
 ]
@@ -3445,6 +3414,18 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-oslog"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.8"
 serde_json = "1"
 tokio = { version = "1.47", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 uniffi = "0.31.0"
 
 [dev-dependencies]
@@ -38,6 +38,8 @@ tokio-tungstenite = "0.27"
 android-native-keyring-store = "0.5.0"
 jni = "0.21"
 ndk-context = "0.1.1"
+paranoid-android = "0.2"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 apple-native-keyring-store = { version = "0.2.2", features = ["protected"] }
+tracing-oslog = "0.3"

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -317,7 +317,10 @@ impl AppCore {
 
     pub fn handle_message(&mut self, msg: CoreMsg) {
         match msg {
-            CoreMsg::Action(action) => self.handle_action(action),
+            CoreMsg::Action(ref action) => {
+                tracing::info!(?action, "dispatch");
+                self.handle_action(action.clone());
+            }
             CoreMsg::Internal(internal) => self.handle_internal(*internal),
             CoreMsg::Request(req) => self.handle_request(req),
         }
@@ -333,12 +336,17 @@ impl AppCore {
 
     fn handle_internal(&mut self, internal: InternalEvent) {
         match internal {
-            InternalEvent::Toast(msg) => self.toast(msg),
-            InternalEvent::KeyPackagePublished { ok, error } => {
+            InternalEvent::Toast(ref msg) => {
+                tracing::info!(msg, "toast");
+                self.toast(msg.clone());
+                return;
+            }
+            InternalEvent::KeyPackagePublished { ok, ref error } => {
+                tracing::info!(ok, ?error, "key_package_published");
                 if !ok {
                     self.toast(format!(
                         "Key package publish failed: {}",
-                        error.unwrap_or_else(|| "unknown error".into())
+                        error.clone().unwrap_or_else(|| "unknown error".into())
                     ));
                 }
             }
@@ -372,6 +380,13 @@ impl AppCore {
                 error,
             } => {
                 let network_enabled = self.network_enabled();
+                tracing::info!(
+                    peer = %peer_pubkey.to_hex(),
+                    kp_found = key_package_event.is_some(),
+                    ?error,
+                    kp_relays = ?candidate_kp_relays.iter().map(|r| r.to_string()).collect::<Vec<_>>(),
+                    "peer_key_package_fetched"
+                );
                 if let Some(err) = error {
                     self.toast(err);
                     return;
@@ -470,23 +485,38 @@ impl AppCore {
                 self.emit_router();
             }
             InternalEvent::GiftWrapReceived { wrapper, rumor } => {
+                tracing::info!(
+                    wrapper_id = %wrapper.id.to_hex(),
+                    rumor_kind = rumor.kind.as_u16(),
+                    "giftwrap_received"
+                );
                 let Some(sess) = self.session.as_mut() else {
+                    tracing::warn!("giftwrap_received but no session");
                     return;
                 };
 
                 if rumor.kind != Kind::MlsWelcome {
+                    tracing::debug!(kind = rumor.kind.as_u16(), "giftwrap ignored (not MlsWelcome)");
                     return;
                 }
 
                 let welcome = match sess.mdk.process_welcome(&wrapper.id, &rumor) {
                     Ok(w) => w,
                     Err(e) => {
+                        tracing::error!(%e, "process_welcome failed");
                         self.toast(format!("Welcome processing failed: {e}"));
                         return;
                     }
                 };
 
+                tracing::info!(
+                    nostr_group_id = %hex::encode(&welcome.nostr_group_id),
+                    group_name = %welcome.group_name,
+                    "welcome_accepted"
+                );
+
                 if let Err(e) = sess.mdk.accept_welcome(&welcome) {
+                    tracing::error!(%e, "accept_welcome failed");
                     self.toast(format!("Welcome accept failed: {e}"));
                     return;
                 }
@@ -502,12 +532,15 @@ impl AppCore {
                 self.refresh_all_from_storage();
             }
             InternalEvent::GroupMessageReceived { event } => {
+                tracing::debug!(event_id = %event.id.to_hex(), "group_message_received");
                 let Some(sess) = self.session.as_mut() else {
+                    tracing::warn!("group_message but no session");
                     return;
                 };
                 let result = match sess.mdk.process_message(&event) {
                     Ok(r) => r,
                     Err(e) => {
+                        tracing::error!(event_id = %event.id.to_hex(), %e, "process_message failed");
                         self.toast(format!("Message decrypt failed: {e}"));
                         return;
                     }
@@ -722,9 +755,11 @@ impl AppCore {
                 // - plus our "popular" relays to support peers that only publish key packages there.
                 let fallback_kp_relays = self.key_package_relays();
                 let fallback_popular_relays = self.default_relays();
+                tracing::info!(peer = %peer_pubkey.to_hex(), "create_chat: fetching peer key package");
                 self.runtime.spawn(async move {
                     // 1) Discover the peer's key-package relays (kind 10051), per NIP-104.
                     // These events are not protected, so they can live on "popular" relays.
+                    tracing::info!(peer = %peer_pubkey.to_hex(), "fetching kind 10051 (MlsKeyPackageRelays)");
                     let kp_relay_list_filter = Filter::new()
                         .author(peer_pubkey)
                         .kind(Kind::MlsKeyPackageRelays)
@@ -752,6 +787,7 @@ impl AppCore {
                     }
 
                     if candidate_kp_relays.is_empty() {
+                        tracing::info!("no kind 10051 found, using fallback relays");
                         let mut s: BTreeSet<RelayUrl> = BTreeSet::new();
                         for r in fallback_kp_relays.iter().cloned() {
                             s.insert(r);
@@ -761,6 +797,11 @@ impl AppCore {
                         }
                         candidate_kp_relays = s.into_iter().collect();
                     }
+
+                    tracing::info!(
+                        kp_relays = ?candidate_kp_relays.iter().map(|r| r.to_string()).collect::<Vec<_>>(),
+                        "fetching kind 443 from relays"
+                    );
 
                     // Ensure these relays exist in the pool and are connected before requesting from them.
                     for r in candidate_kp_relays.iter().cloned() {
@@ -1144,13 +1185,17 @@ impl AppCore {
         let pubkey_hex = pubkey.to_hex();
         let npub = pubkey.to_bech32().unwrap_or(pubkey_hex.clone());
 
+        tracing::info!(pubkey = %pubkey_hex, npub = %npub, "start_session");
+
         // MDK per-identity encrypted sqlite DB.
         let mdk = open_mdk(&self.data_dir, &pubkey)?;
+        tracing::info!("mdk opened");
 
         let client = Client::new(keys.clone());
 
         if self.network_enabled() {
             let relays = self.all_session_relays();
+            tracing::info!(relays = ?relays.iter().map(|r| r.to_string()).collect::<Vec<_>>(), "connecting_relays");
             let c = client.clone();
             self.runtime.block_on(async move {
                 for r in relays {
@@ -1158,6 +1203,7 @@ impl AppCore {
                 }
                 c.connect().await;
             });
+            tracing::info!("relays connected");
         }
 
         let sess = Session {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -36,7 +36,8 @@ pub struct FfiApp {
 impl FfiApp {
     #[uniffi::constructor]
     pub fn new(data_dir: String) -> Arc<Self> {
-        logging::init_logging();
+        logging::init_logging(&data_dir);
+        tracing::info!(data_dir = %data_dir, "FfiApp::new() starting");
 
         let (update_tx, update_rx) = flume::unbounded();
         let (core_tx, core_rx) = flume::unbounded::<CoreMsg>();

--- a/rust/src/logging.rs
+++ b/rust/src/logging.rs
@@ -1,7 +1,70 @@
-pub fn init_logging() {
-    // Keep this simple for MVP.
-    // Native platforms can swap in platform loggers later.
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter("pika_core=debug,info")
-        .try_init();
+/// Platform-native logging initialization.
+///
+/// - iOS: tracing-oslog → Apple unified logging (os_log) + file fallback
+/// - Android: paranoid-android → logcat
+/// - Tests / desktop: tracing-subscriber::fmt → stderr
+///
+/// Called once at the start of `FfiApp::new()`, before anything else.
+///
+/// On iOS the file fallback writes to `<data_dir>/pika.log` so logs are always
+/// retrievable from the simulator filesystem even if os_log filtering hides them.
+pub fn init_logging(#[allow(unused)] data_dir: &str) {
+    #[cfg(target_os = "ios")]
+    {
+        use tracing_subscriber::prelude::*;
+
+        let os_log = tracing_oslog::OsLogger::new("com.pika.app", "default");
+
+        // Also write to a file inside the app data dir for easy retrieval.
+        let log_path = std::path::Path::new(data_dir).join("pika.log");
+        let _ = std::fs::create_dir_all(data_dir);
+        let env_filter = tracing_subscriber::EnvFilter::new(
+            "pika_core=debug,mdk_core=info,openmls=warn,nostr_relay_pool=info,info",
+        );
+
+        let file_layer = if let Ok(file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+        {
+            Some(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(std::sync::Mutex::new(file))
+                    .with_ansi(false)
+                    .with_target(true),
+            )
+        } else {
+            None
+        };
+
+        let _ = tracing_subscriber::registry()
+            .with(env_filter)
+            .with(os_log)
+            .with(file_layer)
+            .try_init();
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        use tracing_subscriber::prelude::*;
+
+        let android_layer = paranoid_android::layer("pika")
+            .with_filter(tracing_subscriber::EnvFilter::new(
+                "pika_core=debug,mdk_core=info,openmls=warn,nostr_relay_pool=info,info",
+            ));
+
+        let _ = tracing_subscriber::registry()
+            .with(android_layer)
+            .try_init();
+    }
+
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| "pika_core=debug,info".into()),
+            )
+            .try_init();
+    }
 }


### PR DESCRIPTION
## Summary

Platform-native logging for the Rust core, per spec-v1 logging section.

### Per-platform behavior

| Platform | Backend | How to read |
|----------|---------|-------------|
| iOS | `tracing-oslog` → Apple unified logging | `log show --predicate 'subsystem == "com.pika.app"'` |
| iOS | file fallback | `<app_container>/Library/Application Support/pika.log` |
| Android | `paranoid-android` → logcat | `adb logcat -s pika:*` |
| Desktop/tests | `tracing-subscriber::fmt` → stderr | terminal output |

### Filter

`pika_core=debug,mdk_core=info,openmls=warn,nostr_relay_pool=info,info`

### Instrumentation added to core.rs

- Every AppAction dispatch
- start_session: identity, relay list, connection status
- Key package publish results
- Peer key package fetch (kind 10051 + 443)
- GiftWrap/Welcome processing
- Group message processing
- All errors and toasts

### Tested on
- iOS simulator — oslog + file logging confirmed
- Android emulator — logcat confirmed