### PR TITLE
docs: AGENTS.md best practices, agent-brief, justfile summaries, CI hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,6 @@
+Read `~/configs/GLOBAL-AGENTS.md` (fallback: https://raw.githubusercontent.com/justinmoon/configs/master/GLOBAL-AGENTS.md). Skip if both unavailable.
+Run `./scripts/agent-brief` first thing to get a live context snapshot.
+
 # AGENTS.md
 
 ## Overview
@@ -34,18 +37,3 @@ The bot listens on: `wss://relay.primal.net`, `wss://nos.lol`, `wss://relay.damu
 | openclaw-marmot | `~/code/openclaw-marmot` | OpenClaw plugin + Rust sidecar daemon for Marmot messaging. Deployed on the bot server. |
 | openclaw | `~/code/openclaw` | OpenClaw gateway. The bot framework that hosts the marmot plugin. |
 | infra | `~/code/infra` | NixOS deployment config for the Hetzner server (`openclaw-prod`). |
-
-## pika-cli usage
-
-```bash
-# Identity + key package
-pika-cli --state-dir /tmp/test --relay wss://relay.primal.net --relay wss://nos.lol --relay wss://relay.damus.io identity
-pika-cli --state-dir /tmp/test --relay wss://relay.primal.net --relay wss://nos.lol --relay wss://relay.damus.io publish-kp
-
-# Invite the bot and chat
-pika-cli ... invite --peer npub1rtrxx9eyvag0ap3v73c4dvsqq5d2yxwe5d72qxrfpwe5svr96wuqed4p38
-pika-cli ... send --group <hex> --content "hello"
-pika-cli ... listen --timeout 60
-```
-
-Each command connects, does its operation, prints JSON to stdout, and exits. State persists in `--state-dir` between runs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,25 @@
+---
+summary: High-level architecture — Rust core, iOS/Android apps, MLS over Nostr
+read_when:
+  - starting work on the project
+  - need to understand how components fit together
+---
+
+# Architecture
+
+Pika is an MLS-encrypted messaging app for iOS and Android, built on the Marmot protocol over Nostr.
+
+## Components
+
+- **Rust core** (`rust/`) — MLS state machine, Nostr transport, UniFFI bindings
+- **iOS app** (`ios/`) — Swift UI, uses PikaCore.xcframework
+- **Android app** (`android/`) — Kotlin, uses JNI bindings via cargo-ndk
+- **pika-cli** (`cli/`) — Command-line interface for testing and agent automation
+- **MDK** (external, `~/code/mdk`) — Marmot Development Kit, the MLS library
+
+## Data flow
+
+1. App calls Rust core via UniFFI (Swift) or JNI (Kotlin)
+2. Rust core uses MDK for MLS group operations (create, invite, encrypt, decrypt)
+3. Rust core uses nostr-sdk to publish/subscribe Nostr events on relays
+4. Key packages (kind 443) enable async peer discovery

--- a/scripts/agent-brief
+++ b/scripts/agent-brief
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+titles=()
+cmds=()
+descs=()
+
+# --- Commands ---
+
+titles+=("just commands")
+cmds+=("just --list")
+descs+=("Available tasks.")
+
+# --- Docs ---
+
+if [[ -d "${repo_root}/docs" ]]; then
+  titles+=("Docs")
+  cmds+=("npx -y @justinmoon/agent-tools list-docs")
+  descs+=("Project documentation index.")
+fi
+
+# --- CLI help ---
+
+titles+=("pika-cli help")
+cmds+=("cargo run -q -p pika-cli -- --help")
+descs+=("Marmot protocol CLI for testing and agent automation.")
+
+# --- Device automation ---
+
+titles+=("agent-device help")
+cmds+=("npx --yes agent-device --help")
+descs+=("Device automation for manual QA on iOS/Android.")
+
+# --- Run all in parallel ---
+
+outs=()
+pids=()
+for i in "${!cmds[@]}"; do
+  out="${tmpdir}/out_${i}"
+  outs+=("${out}")
+  bash -c "${cmds[$i]}" >"${out}" 2>&1 &
+  pids+=($!)
+done
+
+statuses=()
+for i in "${!pids[@]}"; do
+  status=0
+  if ! wait "${pids[$i]}"; then
+    status=$?
+  fi
+  statuses+=("${status}")
+done
+
+# --- Output ---
+
+printf "# Agent Brief\n\n"
+printf "Live context snapshot for AI agents.\n\n"
+printf "_Generated:_ %s\n\n" "$(date -u +"%Y-%m-%d %H:%M:%SZ")"
+
+for i in "${!cmds[@]}"; do
+  printf '## %s\n\n' "${titles[$i]}"
+  printf '_Command:_ `%s`\n\n' "${cmds[$i]}"
+  printf '_Purpose:_ %s\n\n' "${descs[$i]}"
+  if [[ "${statuses[$i]}" -ne 0 ]]; then
+    printf '_Status:_ failed (exit %s)\n\n' "${statuses[$i]}"
+  fi
+  printf '```\n'
+  cat "${outs[$i]}"
+  printf '\n```\n\n'
+done


### PR DESCRIPTION
## Changes

- **AGENTS.md**: global reference line with GitHub raw URL fallback, agent-brief instruction, removed stale inline CLI examples
- **scripts/agent-brief**: live context snapshot for AI agents (just --list, docs, pika-cli --help, agent-device --help)
- **docs/architecture.md**: starter doc with frontmatter for `agent-tools list-docs`
- **justfile**: summary comments on all 36 recipes
- **pre-merge**: added `agent-tools check-docs` and `agent-tools check-justfile` CI checks
- **CLAUDE.md**: symlink → AGENTS.md for Claude Code compatibility