### PR TITLE
feat: QR for my npub + scan peer npub

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -95,11 +95,17 @@ dependencies {
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
     implementation("com.google.android.material:material:1.12.0")
+    implementation("com.google.zxing:core:3.5.3")
 
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material-icons-extended")
+
+    implementation("androidx.camera:camera-camera2:1.3.4")
+    implementation("androidx.camera:camera-lifecycle:1.3.4")
+    implementation("androidx.camera:camera-view:1.3.4")
+    implementation("com.google.mlkit:barcode-scanning:17.2.0")
 
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <!-- Required for Nostr relay connections + MDK network operations. -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:allowBackup="true"

--- a/android/app/src/main/java/com/pika/app/ui/PeerKeyNormalizer.kt
+++ b/android/app/src/main/java/com/pika/app/ui/PeerKeyNormalizer.kt
@@ -1,0 +1,13 @@
+package com.pika.app.ui
+
+object PeerKeyNormalizer {
+    fun normalize(input: String): String {
+        var s = input.trim()
+        s = s.lowercase()
+        if (s.startsWith("nostr:")) {
+            s = s.removePrefix("nostr:")
+        }
+        return s
+    }
+}
+

--- a/android/app/src/main/java/com/pika/app/ui/QrCode.kt
+++ b/android/app/src/main/java/com/pika/app/ui/QrCode.kt
@@ -1,0 +1,21 @@
+package com.pika.app.ui
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+
+object QrCode {
+    fun encode(text: String, sizePx: Int): Bitmap {
+        val writer = QRCodeWriter()
+        val matrix = writer.encode(text, BarcodeFormat.QR_CODE, sizePx, sizePx)
+        val bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+        for (y in 0 until sizePx) {
+            for (x in 0 until sizePx) {
+                bmp.setPixel(x, y, if (matrix.get(x, y)) Color.BLACK else Color.WHITE)
+            }
+        }
+        return bmp
+    }
+}
+

--- a/android/app/src/main/java/com/pika/app/ui/TestTags.kt
+++ b/android/app/src/main/java/com/pika/app/ui/TestTags.kt
@@ -7,6 +7,8 @@ object TestTags {
 
     const val NEWCHAT_PEER_NPUB = "newchat_peer_npub"
     const val NEWCHAT_START = "newchat_start"
+    const val NEWCHAT_SCAN_QR = "newchat_scan_qr"
+    const val NEWCHAT_PASTE = "newchat_paste"
 
     const val CHAT_MESSAGE_LIST = "chat_message_list"
     const val CHAT_MESSAGE_INPUT = "chat_message_input"

--- a/android/app/src/main/java/com/pika/app/ui/screens/ChatListScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/ChatListScreen.kt
@@ -31,11 +31,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.foundation.Image
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -45,6 +47,7 @@ import com.pika.app.rust.AuthState
 import com.pika.app.rust.ChatSummary
 import com.pika.app.rust.Screen
 import com.pika.app.ui.theme.PikaBlue
+import com.pika.app.ui.QrCode
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.Add
@@ -100,10 +103,20 @@ fun ChatListScreen(manager: AppManager, padding: PaddingValues) {
     }
 
     if (showMyNpub && myNpub != null) {
+        val qr = remember(myNpub) { QrCode.encode(myNpub, 512).asImageBitmap() }
         AlertDialog(
             onDismissRequest = { setShowMyNpub(false) },
             title = { Text("My npub") },
-            text = { Text(myNpub) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Image(
+                        bitmap = qr,
+                        contentDescription = "My npub QR",
+                        modifier = Modifier.size(220.dp).clip(MaterialTheme.shapes.medium),
+                    )
+                    Text(myNpub)
+                }
+            },
             confirmButton = {
                 TextButton(
                     onClick = {

--- a/android/app/src/main/java/com/pika/app/ui/screens/QrScannerDialog.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/QrScannerDialog.kt
@@ -1,0 +1,210 @@
+package com.pika.app.ui.screens
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+import com.pika.app.ui.PeerKeyNormalizer
+import com.pika.app.ui.PeerKeyValidator
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Composable
+fun QrScannerDialog(
+    onDismiss: () -> Unit,
+    onScanned: (String) -> Unit,
+) {
+    val ctx = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    var error by remember { mutableStateOf<String?>(null) }
+    var hasPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(ctx, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED,
+        )
+    }
+
+    val permissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            hasPermission = granted
+            if (!granted) {
+                error = "Camera permission is required to scan QR codes."
+            }
+        }
+
+    LaunchedEffect(Unit) {
+        if (!hasPermission) permissionLauncher.launch(Manifest.permission.CAMERA)
+    }
+
+    if (!hasPermission) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text("Scan QR") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(error ?: "Requesting camera permission…", color = MaterialTheme.colorScheme.error)
+                    Text("Use Paste as a fallback.", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { permissionLauncher.launch(Manifest.permission.CAMERA) }) { Text("Retry") }
+            },
+            dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+        )
+        return
+    }
+
+    val previewView = remember {
+        PreviewView(ctx).apply {
+            scaleType = PreviewView.ScaleType.FILL_CENTER
+        }
+    }
+
+    val didEmit = remember { AtomicBoolean(false) }
+    val inFlight = remember { AtomicBoolean(false) }
+    val scanner =
+        remember {
+            val opts =
+                BarcodeScannerOptions.Builder()
+                    .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+                    .build()
+            BarcodeScanning.getClient(opts)
+        }
+
+    // CameraX analyzer prefers a dedicated executor.
+    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+
+    var cameraProvider: ProcessCameraProvider? by remember { mutableStateOf(null) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            runCatching { cameraProvider?.unbindAll() }
+            runCatching { analysisExecutor.shutdown() }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        val future = ProcessCameraProvider.getInstance(ctx)
+        future.addListener(
+            {
+                cameraProvider = future.get()
+            },
+            ContextCompat.getMainExecutor(ctx),
+        )
+    }
+
+    LaunchedEffect(cameraProvider) {
+        val provider = cameraProvider ?: return@LaunchedEffect
+        didEmit.set(false)
+        inFlight.set(false)
+        error = null
+
+        val preview = Preview.Builder().build()
+        preview.setSurfaceProvider(previewView.surfaceProvider)
+
+        val analysis =
+            ImageAnalysis.Builder()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
+
+        analysis.setAnalyzer(analysisExecutor) { imageProxy ->
+            val mediaImage = imageProxy.image
+            if (mediaImage == null) {
+                imageProxy.close()
+                return@setAnalyzer
+            }
+
+            if (!inFlight.compareAndSet(false, true)) {
+                imageProxy.close()
+                return@setAnalyzer
+            }
+
+            val img = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
+            scanner.process(img)
+                .addOnSuccessListener { barcodes ->
+                    val raw = barcodes.firstOrNull()?.rawValue?.trim().orEmpty()
+                    if (raw.isBlank()) return@addOnSuccessListener
+                    if (!didEmit.compareAndSet(false, true)) return@addOnSuccessListener
+
+                    val normalized = PeerKeyNormalizer.normalize(raw)
+                    if (PeerKeyValidator.isValidPeer(normalized)) {
+                        onScanned(normalized)
+                    } else {
+                        // Allow retry without closing the dialog.
+                        didEmit.set(false)
+                        error = "Scanned QR is not a valid npub."
+                    }
+                }
+                .addOnFailureListener {
+                    // Best-effort; keep scanning.
+                }
+                .addOnCompleteListener {
+                    inFlight.set(false)
+                    imageProxy.close()
+                }
+        }
+
+        runCatching { provider.unbindAll() }
+        provider.bindToLifecycle(
+            lifecycleOwner,
+            CameraSelector.DEFAULT_BACK_CAMERA,
+            preview,
+            analysis,
+        )
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Scan QR") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                if (error != null) {
+                    Text(error!!, color = MaterialTheme.colorScheme.error)
+                }
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    AndroidView(
+                        factory = { previewView },
+                        modifier = Modifier.size(280.dp),
+                    )
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+    )
+}

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -22,6 +22,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Scan QR codes to start new chats.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/Pika.xcodeproj/project.pbxproj
+++ b/ios/Pika.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		9581B9688EDC90BCBC177E47 /* TestIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FAE9ECBDFC0A976452024F /* TestIds.swift */; };
 		970D12403533E203A33FBEFC /* NewChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62170468ABECD8AAA8B6B6A /* NewChatView.swift */; };
 		A15307C1B4692DC5925858CE /* AppManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B2B1856254D8FE240BC93A /* AppManager.swift */; };
+		DE799DF1E97151C517647E61 /* QrScannerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B083A8885A5C0BDDEFCF5EAC /* QrScannerSheet.swift */; };
+		EDAE180A5D3FEED3C801658F /* MyNpubQrSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0705B2EA2A82DFC41EFF9DCF /* MyNpubQrSheet.swift */; };
 		F2A2C56251354A67641CA82F /* pika_core.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2510455883E1CDFB6D589F5C /* pika_core.swift */; };
 		F308786C219CC1D169ABFC50 /* PikaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF35ECCAE3B37C651F88A150 /* PikaApp.swift */; };
 		FE739725B724B1944145C8EF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E962F7911EF0441F706C10 /* ContentView.swift */; };
@@ -35,6 +37,7 @@
 
 /* Begin PBXFileReference section */
 		05B2B1856254D8FE240BC93A /* AppManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppManager.swift; sourceTree = "<group>"; };
+		0705B2EA2A82DFC41EFF9DCF /* MyNpubQrSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNpubQrSheet.swift; sourceTree = "<group>"; };
 		2510455883E1CDFB6D589F5C /* pika_core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pika_core.swift; sourceTree = "<group>"; };
 		276F120E43A9DF389448FE5C /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		366C05B721835967C3BE5418 /* ChatListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListView.swift; sourceTree = "<group>"; };
@@ -46,6 +49,7 @@
 		5F912C4C8861A3FB74085329 /* KeychainNsecStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainNsecStore.swift; sourceTree = "<group>"; };
 		8600EE3AFD44A8B726A64716 /* PikaUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PikaUITests.swift; sourceTree = "<group>"; };
 		A62170468ABECD8AAA8B6B6A /* NewChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewChatView.swift; sourceTree = "<group>"; };
+		B083A8885A5C0BDDEFCF5EAC /* QrScannerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrScannerSheet.swift; sourceTree = "<group>"; };
 		B2FE3F3E8BA33932B132B693 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		E9B7DE0FCF7AB984004968F9 /* PeerKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerKeyValidator.swift; sourceTree = "<group>"; };
 		EF35ECCAE3B37C651F88A150 /* PikaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PikaApp.swift; sourceTree = "<group>"; };
@@ -95,7 +99,9 @@
 				366C05B721835967C3BE5418 /* ChatListView.swift */,
 				B2FE3F3E8BA33932B132B693 /* ChatView.swift */,
 				53159E06C561F50F6EC97A61 /* LoginView.swift */,
+				0705B2EA2A82DFC41EFF9DCF /* MyNpubQrSheet.swift */,
 				A62170468ABECD8AAA8B6B6A /* NewChatView.swift */,
+				B083A8885A5C0BDDEFCF5EAC /* QrScannerSheet.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -240,9 +246,11 @@
 				FE739725B724B1944145C8EF /* ContentView.swift in Sources */,
 				02D9A491B498E051D46EC648 /* KeychainNsecStore.swift in Sources */,
 				2A9B2872E6ADB03F5A8FA173 /* LoginView.swift in Sources */,
+				EDAE180A5D3FEED3C801658F /* MyNpubQrSheet.swift in Sources */,
 				970D12403533E203A33FBEFC /* NewChatView.swift in Sources */,
 				502171B59272A56AB36AECCF /* PeerKeyValidator.swift in Sources */,
 				F308786C219CC1D169ABFC50 /* PikaApp.swift in Sources */,
+				DE799DF1E97151C517647E61 /* QrScannerSheet.swift in Sources */,
 				9581B9688EDC90BCBC177E47 /* TestIds.swift in Sources */,
 				F2A2C56251354A67641CA82F /* pika_core.swift in Sources */,
 			);

--- a/ios/Sources/PeerKeyValidator.swift
+++ b/ios/Sources/PeerKeyValidator.swift
@@ -1,6 +1,15 @@
 import Foundation
 
 enum PeerKeyValidator {
+    static func normalize(_ input: String) -> String {
+        var s = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        s = s.lowercased()
+        if s.hasPrefix("nostr:") {
+            s.removeFirst("nostr:".count)
+        }
+        return s
+    }
+
     // Minimal UX validation. Real parsing happens in Rust, but this prevents common operator errors
     // like pasting the bech32 payload without the "npub1" prefix.
     static func isValidPeer(_ s: String) -> Bool {
@@ -32,4 +41,3 @@ enum PeerKeyValidator {
         return payload.allSatisfy { allowed.contains($0) }
     }
 }
-

--- a/ios/Sources/TestIds.swift
+++ b/ios/Sources/TestIds.swift
@@ -11,13 +11,17 @@ enum TestIds {
     static let chatListNewChat = "chatlist_new_chat"
     static let chatListMyNpub = "chatlist_my_npub"
     static let chatListMyNpubValue = "chatlist_my_npub_value"
+    static let chatListMyNpubQr = "chatlist_my_npub_qr"
+    static let chatListMyNpubCopy = "chatlist_my_npub_copy"
+    static let chatListMyNpubClose = "chatlist_my_npub_close"
 
     // New chat
     static let newChatPeerNpub = "newchat_peer_npub"
     static let newChatStart = "newchat_start"
+    static let newChatScanQr = "newchat_scan_qr"
+    static let newChatPaste = "newchat_paste"
 
     // Chat
     static let chatMessageInput = "chat_message_input"
     static let chatSend = "chat_send"
 }
-

--- a/ios/Sources/Views/ChatListView.swift
+++ b/ios/Sources/Views/ChatListView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 struct ChatListView: View {
     let manager: AppManager
@@ -43,13 +42,8 @@ struct ChatListView: View {
                     }
                     .accessibilityLabel("My npub")
                     .accessibilityIdentifier(TestIds.chatListMyNpub)
-                    .alert("My npub", isPresented: $showMyNpub) {
-                        Button("Copy") {
-                            UIPasteboard.general.string = npub
-                        }
-                        Button("Close", role: .cancel) {}
-                    } message: {
-                        Text(npub).accessibilityIdentifier(TestIds.chatListMyNpubValue)
+                    .sheet(isPresented: $showMyNpub) {
+                        MyNpubQrSheet(npub: npub)
                     }
                 }
             }

--- a/ios/Sources/Views/MyNpubQrSheet.swift
+++ b/ios/Sources/Views/MyNpubQrSheet.swift
@@ -1,0 +1,67 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+import UIKit
+
+struct MyNpubQrSheet: View {
+    let npub: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                if let img = qrImage(from: npub) {
+                    Image(uiImage: img)
+                        .interpolation(.none)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: 240, maxHeight: 240)
+                        .background(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .accessibilityIdentifier(TestIds.chatListMyNpubQr)
+                } else {
+                    Text("Could not generate QR code.")
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(npub)
+                    .font(.system(.footnote, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .background(.thinMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .accessibilityIdentifier(TestIds.chatListMyNpubValue)
+
+                Button("Copy") {
+                    UIPasteboard.general.string = npub
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier(TestIds.chatListMyNpubCopy)
+
+                Spacer()
+            }
+            .padding(16)
+            .navigationTitle("My npub")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Close") { dismiss() }
+                        .accessibilityIdentifier(TestIds.chatListMyNpubClose)
+                }
+            }
+        }
+    }
+
+    private func qrImage(from text: String) -> UIImage? {
+        let data = Data(text.utf8)
+        let filter = CIFilter.qrCodeGenerator()
+        filter.setValue(data, forKey: "inputMessage")
+        // Crisp edges, no blur.
+        guard var output = filter.outputImage else { return nil }
+        output = output.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+        let ctx = CIContext()
+        guard let cg = ctx.createCGImage(output, from: output.extent) else { return nil }
+        return UIImage(cgImage: cg)
+    }
+}
+

--- a/ios/Sources/Views/NewChatView.swift
+++ b/ios/Sources/Views/NewChatView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
+import UIKit
 
 struct NewChatView: View {
     let manager: AppManager
     @State private var npubInput = ""
+    @State private var showScanner = false
 
     var body: some View {
-        let peer = npubInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let peer = PeerKeyValidator.normalize(npubInput)
         let isValidPeer = PeerKeyValidator.isValidPeer(peer)
         let isLoading = manager.state.busy.creatingChat
 
@@ -16,6 +18,23 @@ struct NewChatView: View {
                 .textFieldStyle(.roundedBorder)
                 .disabled(isLoading)
                 .accessibilityIdentifier(TestIds.newChatPeerNpub)
+
+            HStack(spacing: 12) {
+                Button("Scan QR") { showScanner = true }
+                    .buttonStyle(.bordered)
+                    .disabled(isLoading)
+                    .accessibilityIdentifier(TestIds.newChatScanQr)
+
+                Button("Paste") {
+                    let raw = UIPasteboard.general.string ?? ""
+                    npubInput = PeerKeyValidator.normalize(raw)
+                }
+                .buttonStyle(.bordered)
+                .disabled(isLoading)
+                .accessibilityIdentifier(TestIds.newChatPaste)
+
+                Spacer()
+            }
 
             if !peer.isEmpty && !isValidPeer {
                 Text("Enter a valid npub1… or 64-char hex pubkey.")
@@ -45,5 +64,10 @@ struct NewChatView: View {
         }
         .padding(16)
         .navigationTitle("New Chat")
+        .sheet(isPresented: $showScanner) {
+            QrScannerSheet { scanned in
+                npubInput = scanned
+            }
+        }
     }
 }

--- a/ios/Sources/Views/QrScannerSheet.swift
+++ b/ios/Sources/Views/QrScannerSheet.swift
@@ -1,0 +1,164 @@
+import AVFoundation
+import SwiftUI
+
+struct QrScannerSheet: View {
+    let onScanned: (String) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var authStatus = AVCaptureDevice.authorizationStatus(for: .video)
+    @State private var errorMessage: String?
+    @State private var scannerNonce = UUID()
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 12) {
+                if let msg = errorMessage {
+                    Text(msg)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                content
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(.secondary.opacity(0.3), lineWidth: 1)
+                    )
+
+                Spacer()
+            }
+            .padding(16)
+            .navigationTitle("Scan QR")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            .onAppear { ensureCameraPermission() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch authStatus {
+        case .authorized:
+            QrScannerView { raw in
+                let normalized = PeerKeyValidator.normalize(raw)
+                if PeerKeyValidator.isValidPeer(normalized) {
+                    onScanned(normalized)
+                    dismiss()
+                } else {
+                    errorMessage = "Scanned QR is not a valid npub."
+                    // Restart capture (avoid being stuck after an invalid scan).
+                    scannerNonce = UUID()
+                }
+            }
+            .id(scannerNonce)
+            .frame(maxWidth: .infinity)
+            .aspectRatio(1, contentMode: .fit)
+
+        case .notDetermined:
+            ProgressView("Requesting camera permission…")
+                .frame(maxWidth: .infinity, minHeight: 240)
+
+        case .denied, .restricted:
+            VStack(spacing: 8) {
+                Text("Camera permission is required to scan QR codes.")
+                    .foregroundStyle(.secondary)
+                Text("Use Paste on the New Chat screen instead.")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, minHeight: 240)
+
+        @unknown default:
+            Text("Camera unavailable.")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 240)
+        }
+    }
+
+    private func ensureCameraPermission() {
+        let status = AVCaptureDevice.authorizationStatus(for: .video)
+        authStatus = status
+        guard status == .notDetermined else { return }
+        AVCaptureDevice.requestAccess(for: .video) { granted in
+            DispatchQueue.main.async {
+                authStatus = granted ? .authorized : .denied
+            }
+        }
+    }
+}
+
+private struct QrScannerView: UIViewControllerRepresentable {
+    let onCode: (String) -> Void
+
+    func makeUIViewController(context: Context) -> QrScannerViewController {
+        let vc = QrScannerViewController()
+        vc.onCode = onCode
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: QrScannerViewController, context: Context) {}
+}
+
+private final class QrScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+    var onCode: ((String) -> Void)?
+    private let session = AVCaptureSession()
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var didEmit = false
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+
+        guard let device = AVCaptureDevice.default(for: .video) else { return }
+        guard let input = try? AVCaptureDeviceInput(device: device) else { return }
+        guard session.canAddInput(input) else { return }
+        session.addInput(input)
+
+        let output = AVCaptureMetadataOutput()
+        guard session.canAddOutput(output) else { return }
+        session.addOutput(output)
+        output.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
+        output.metadataObjectTypes = [.qr]
+
+        let layer = AVCaptureVideoPreviewLayer(session: session)
+        layer.videoGravity = .resizeAspectFill
+        previewLayer = layer
+        view.layer.addSublayer(layer)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        didEmit = false
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.session.startRunning()
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.session.stopRunning()
+        }
+    }
+
+    func metadataOutput(
+        _ output: AVCaptureMetadataOutput,
+        didOutput metadataObjects: [AVMetadataObject],
+        from connection: AVCaptureConnection
+    ) {
+        guard !didEmit else { return }
+        guard let obj = metadataObjects.first as? AVMetadataMachineReadableCodeObject else { return }
+        guard obj.type == .qr, let value = obj.stringValue, !value.isEmpty else { return }
+        didEmit = true
+        onCode?(value)
+    }
+}
+

--- a/ios/UITests/PikaUITests.swift
+++ b/ios/UITests/PikaUITests.swift
@@ -57,24 +57,23 @@ final class PikaUITests: XCTestCase {
         let chatsNavBar = app.navigationBars["Chats"]
         XCTAssertTrue(chatsNavBar.waitForExistence(timeout: 15))
 
-        // Fetch our npub from the "My npub" alert (avoid clipboard access from UI tests).
+        // Fetch our npub from the "My npub" sheet (avoid clipboard access from UI tests).
         let myNpubBtn = app.buttons.matching(identifier: "chatlist_my_npub").firstMatch
         XCTAssertTrue(myNpubBtn.waitForExistence(timeout: 5))
         myNpubBtn.tap()
 
-        let alert = app.alerts["My npub"]
-        XCTAssertTrue(alert.waitForExistence(timeout: 5))
-        // SwiftUI alert accessibility identifiers can be unreliable across iOS versions; match by label.
-        let npubValue =
-            alert.staticTexts.matching(NSPredicate(format: "label BEGINSWITH %@", "npub1")).firstMatch
+        let myNpubNavBar = app.navigationBars["My npub"]
+        XCTAssertTrue(myNpubNavBar.waitForExistence(timeout: 5))
+
+        let npubValue = app.staticTexts.matching(identifier: "chatlist_my_npub_value").firstMatch
         XCTAssertTrue(npubValue.waitForExistence(timeout: 5))
         let myNpub = npubValue.label
         XCTAssertTrue(myNpub.hasPrefix("npub1"), "Expected npub1..., got: \(myNpub)")
 
-        // Close the alert.
-        let close = alert.buttons["Close"]
+        // Close the sheet.
+        let close = app.buttons.matching(identifier: "chatlist_my_npub_close").firstMatch
         if close.exists { close.tap() }
-        else { alert.buttons.element(boundBy: 0).tap() }
+        else { myNpubNavBar.buttons.element(boundBy: 0).tap() }
 
         // New chat.
         let newChat = app.buttons.matching(identifier: "chatlist_new_chat").firstMatch


### PR DESCRIPTION
Implements QR code display for "My npub" and adds Scan QR + Paste to New Chat (iOS + Android).\n\n- iOS: QR sheet + AVFoundation scanner; adds NSCameraUsageDescription; updates UITest.\n- Android: QR dialog + CameraX/MLKit scanner; adds camera permission + deps.\n- Normalizes scanned/pasted peer keys: trims/lowers, strips "nostr:".