### PR TITLE
docs: refine architecture doc wording

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ Pika is an MLS-encrypted messaging app for iOS and Android, built on the Marmot 
 - **iOS app** (`ios/`) — Swift UI, uses PikaCore.xcframework
 - **Android app** (`android/`) — Kotlin, uses JNI bindings via cargo-ndk
 - **pika-cli** (`cli/`) — Command-line interface for testing and agent automation
-- **MDK** (external, `~/code/mdk`) — Marmot Development Kit, the MLS library
+- **MDK** (external, `https://github.com/marmot-protocol/mdk`) — Marmot Development Kit, the MLS library
 
 ## Data flow
 
@@ -26,15 +26,17 @@ Pika is an MLS-encrypted messaging app for iOS and Android, built on the Marmot 
 
 ## State Management (v1/v2 Specs)
 
-Goal: Rust owns all app state + business logic. Native UI layers are thin renderers.
+Goal: Rust owns core app state + business logic. iOS/Android mostly render Rust-owned state slices and forward user actions.
+
+iOS/Android may keep UI-only ephemeral state (text inputs, focus, scroll position, local toggles). iOS/Android should not own core state that affects app behavior or routing (for example, "loading"/in-flight state for a login/create-chat flow should be Rust-owned).
 
 ### One-Way Data Flow
 
 1. UI dispatches an `AppAction` to Rust (`dispatch(action)` is enqueue-only and must not block the UI thread)
 2. Rust mutates its internal state in a single-threaded actor (`AppCore`)
 3. Rust emits an `AppUpdate` with a monotonic `rev`
-4. Native applies updates on the main thread and re-renders
-5. If native detects a `rev` gap, it resyncs via `state()`
+4. iOS/Android applies updates on the main thread and re-renders
+5. If iOS/Android detects a `rev` gap, it resyncs via `state()`
 
 ### Router Is Location, Slices Are Render Data
 
@@ -43,16 +45,16 @@ Goal: Rust owns all app state + business logic. Native UI layers are thin render
 - `default_screen`: root (e.g. `Login` vs `ChatList`)
 - `screen_stack`: pushed screens (e.g. `Chat { chat_id }`)
 
-Everything needed to render a screen lives in `AppState` slices, not in native state:
+Everything needed to render a screen lives in `AppState` slices, not in iOS/Android-owned core state:
 
 - `chat_list`: chat list screen
 - `current_chat`: chat screen render model (messages, title, delivery status)
 - `toast`: transient user-visible messages
 
 Invariant: when the top route is `Screen::Chat { chat_id }`, Rust keeps `current_chat` populated for that `chat_id`.
-Native never "fetches" chat data; it only renders `AppState`.
+iOS/Android never "fetches" chat data; it only renders `AppState`.
 
 ### Busy / In-Flight Operations
 
 Long-ish operation state that affects UX lives in Rust as `AppState.busy` (e.g. `creating_chat`, `logging_in`).
-This avoids native heuristics like "stop spinner when a toast appears" and keeps UI purely reactive to Rust state.
+This avoids iOS/Android heuristics like "stop spinner when a toast appears" and keeps UI purely reactive to Rust state.


### PR DESCRIPTION
- Replace MDK local path with GitHub link
- Clarify iOS/Android may keep ephemeral UI-only state (inputs/scroll/focus)
- Replace 'native' wording with 'iOS/Android' and keep core state Rust-owned