### PR TITLE
refactor: simplify justfile runners

### DIFF
--- a/scripts/agent-brief
+++ b/scripts/agent-brief
@@ -21,7 +21,7 @@ descs+=("Available tasks.")
 
 if [[ -d "${repo_root}/docs" ]]; then
   titles+=("Docs")
-  cmds+=("npx -y @justinmoon/agent-tools list-docs")
+  cmds+=("npx --yes @justinmoon/agent-tools list-docs")
   descs+=("Project documentation index.")
 fi
 
@@ -64,11 +64,11 @@ done
 
 statuses=()
 for i in "${!pids[@]}"; do
-  status=0
-  if ! wait "${pids[$i]}"; then
-    status=$?
+  if wait "${pids[$i]}"; then
+    statuses+=("0")
+  else
+    statuses+=("$?")
   fi
-  statuses+=("${status}")
 done
 
 # --- Output ---

--- a/tools/agent-device
+++ b/tools/agent-device
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # Ensure iOS tooling works even when `xcode-select -p` points at CommandLineTools or a Nix SDK.
-DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1 || true)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_DIR="$("$ROOT/tools/xcode-dev-dir" 2>/dev/null || true)"
 if [ -n "${DEV_DIR:-}" ]; then
   export DEVELOPER_DIR="$DEV_DIR"
 fi

--- a/tools/android-ensure-debug-installable
+++ b/tools/android-ensure-debug-installable
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fixes a common local failure for instrumentation tests:
+#   INSTALL_FAILED_UPDATE_INCOMPATIBLE (signature mismatch)
+#
+# By default, only uninstalls on emulators (serial starts with "emulator-").
+# For physical devices, require:
+#   PIKA_ANDROID_ALLOW_UNINSTALL_ON_DEVICE=1
+#
+# Serial selection:
+# - If PIKA_ANDROID_SERIAL is set, use it.
+# - Else if exactly one emulator is connected, use it.
+# - Else error (to avoid uninstalling the wrong device).
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+ADB="${ADB:-adb}"
+APP_ID="${PIKA_ANDROID_APP_ID:-com.justinmoon.pika.dev}"
+SERIAL="${PIKA_ANDROID_SERIAL:-}"
+
+pick_emulators() {
+  "$ADB" devices 2>/dev/null | awk 'NR>1 && $2=="device" && $1 ~ /^emulator-/ {print $1}'
+}
+
+pick_one_or_empty() {
+  local items="$1"
+  local count
+  count="$(echo "$items" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+  if [ "${count:-0}" = "1" ]; then
+    echo "$items" | sed '/^$/d' | head -n 1
+  else
+    echo ""
+  fi
+}
+
+if [ -z "${SERIAL:-}" ]; then
+  SERIAL="$(pick_one_or_empty "$(pick_emulators)")"
+fi
+
+if [ -z "${SERIAL:-}" ]; then
+  echo "error: could not pick a single android emulator serial for uninstall step" >&2
+  echo "hint: set PIKA_ANDROID_SERIAL=<serial> (see: adb devices)" >&2
+  exit 2
+fi
+
+allow_uninstall=0
+if echo "$SERIAL" | grep -q '^emulator-'; then
+  allow_uninstall=1
+elif [ "${PIKA_ANDROID_ALLOW_UNINSTALL_ON_DEVICE:-0}" = "1" ]; then
+  allow_uninstall=1
+fi
+
+if [ "$allow_uninstall" != "1" ]; then
+  echo "error: refusing to uninstall $APP_ID on non-emulator target ($SERIAL)" >&2
+  echo "hint: set PIKA_ANDROID_ALLOW_UNINSTALL_ON_DEVICE=1 if you really want this" >&2
+  exit 2
+fi
+
+if "$ADB" -s "$SERIAL" shell pm path "$APP_ID" >/dev/null 2>&1; then
+  echo "uninstalling existing $APP_ID from $SERIAL (to avoid signature mismatch)"
+  "$ADB" -s "$SERIAL" uninstall "$APP_ID" >/dev/null 2>&1 || true
+fi
+

--- a/tools/android-pick-serial
+++ b/tools/android-pick-serial
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print a single Android device/emulator serial for running connected tests.
+# Prefers an emulator.
+#
+# Selection:
+# - If PIKA_ANDROID_SERIAL is set, use it (must exist).
+# - Else if exactly one emulator is connected, use it.
+# - Else error and list targets.
+
+ADB="${ADB:-adb}"
+SERIAL="${PIKA_ANDROID_SERIAL:-}"
+
+list_targets() {
+  "$ADB" devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}'
+}
+
+serial_exists() {
+  list_targets | grep -Fxq "$1"
+}
+
+pick_emulators() {
+  list_targets | awk '$1 ~ /^emulator-/ {print $1}'
+}
+
+pick_one_or_empty() {
+  local items="$1"
+  local count
+  count="$(echo "$items" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+  if [ "${count:-0}" = "1" ]; then
+    echo "$items" | sed '/^$/d' | head -n 1
+  else
+    echo ""
+  fi
+}
+
+if [ -n "${SERIAL:-}" ]; then
+  if ! serial_exists "$SERIAL"; then
+    echo "error: requested android serial not connected: $SERIAL" >&2
+    echo "connected targets:" >&2
+    list_targets | sed '/^$/d' | sed 's/^/  /' >&2
+    exit 2
+  fi
+  echo "$SERIAL"
+  exit 0
+fi
+
+SERIAL="$(pick_one_or_empty "$(pick_emulators)")"
+if [ -n "${SERIAL:-}" ]; then
+  echo "$SERIAL"
+  exit 0
+fi
+
+echo "error: multiple (or zero) android emulators connected; set PIKA_ANDROID_SERIAL=<serial>" >&2
+echo "connected targets:" >&2
+list_targets | sed '/^$/d' | sed 's/^/  /' >&2
+exit 2
+

--- a/tools/cli-smoke
+++ b/tools/cli-smoke
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Quick smoke test: two users, local relay, send+receive.
+#
+# Replaces the long inline `cli-smoke` recipe in `justfile`.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+relay="ws://127.0.0.1:7777"
+
+usage() {
+  cat >&2 <<EOF
+usage: ./tools/cli-smoke [--relay <ws://...>]
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --relay)
+      relay="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+CLI="cargo run -q -p pika-cli --"
+
+json_get() {
+  local expr="$1"
+  python3 - <<PY
+import json,sys
+obj=json.load(sys.stdin)
+print($expr)
+PY
+}
+
+echo "=== Alice: create identity ==="
+ALICE="$($CLI --state-dir "$TMPDIR/alice" --relay "$relay" identity)"
+ALICE_PK="$(echo "$ALICE" | json_get "obj['pubkey']")"
+echo "Alice pubkey: $ALICE_PK"
+
+echo "=== Bob: create identity ==="
+BOB="$($CLI --state-dir "$TMPDIR/bob" --relay "$relay" identity)"
+BOB_PK="$(echo "$BOB" | json_get "obj['pubkey']")"
+echo "Bob pubkey: $BOB_PK"
+
+echo "=== Both: publish key packages ==="
+$CLI --state-dir "$TMPDIR/alice" --relay "$relay" publish-kp
+$CLI --state-dir "$TMPDIR/bob" --relay "$relay" publish-kp
+
+echo "=== Alice: invite Bob ==="
+INVITE="$($CLI --state-dir "$TMPDIR/alice" --relay "$relay" invite --peer "$BOB_PK")"
+GROUP="$(echo "$INVITE" | json_get "obj['nostr_group_id']")"
+echo "Group: $GROUP"
+
+echo "=== Bob: check welcomes ==="
+WELCOMES="$($CLI --state-dir "$TMPDIR/bob" --relay "$relay" welcomes)"
+echo "$WELCOMES"
+WRAPPER="$(echo "$WELCOMES" | json_get "obj['welcomes'][0]['wrapper_event_id']")"
+
+echo "=== Bob: accept welcome ==="
+$CLI --state-dir "$TMPDIR/bob" --relay "$relay" accept-welcome --wrapper-event-id "$WRAPPER"
+
+echo "=== Alice: send message ==="
+$CLI --state-dir "$TMPDIR/alice" --relay "$relay" send --group "$GROUP" --content "hello from alice"
+
+echo "=== Bob: read messages ==="
+$CLI --state-dir "$TMPDIR/bob" --relay "$relay" messages --group "$GROUP"
+
+echo "=== SMOKE TEST PASSED ==="
+

--- a/tools/lib/dotenv.sh
+++ b/tools/lib/dotenv.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Load .env and .env.local without overriding existing environment variables.
+# Intended for local dev/test runners (not production config parsing).
+load_dotenv_no_override() {
+  local root="${1:-.}"
+  local f line key val
+
+  for f in "$root/.env" "$root/.env.local"; do
+    if [ ! -f "$f" ]; then
+      continue
+    fi
+    while IFS= read -r line || [ -n "$line" ]; do
+      # Trim whitespace.
+      line="$(echo "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+      if [ -z "${line:-}" ] || echo "$line" | grep -q '^#'; then
+        continue
+      fi
+      if ! echo "$line" | grep -q '='; then
+        continue
+      fi
+      key="${line%%=*}"
+      val="${line#*=}"
+      key="$(echo "$key" | tr -d '[:space:]')"
+      # Allow `export KEY=...` in dev env files.
+      if echo "$key" | grep -q '^export[[:space:]]'; then
+        key="$(echo "$key" | sed -E 's/^export[[:space:]]+//')"
+      fi
+      if [ -z "${key:-}" ]; then
+        continue
+      fi
+      # Strip a single pair of matching quotes.
+      if [ "${#val}" -ge 2 ]; then
+        case "$val" in
+          \"*\")
+            val="${val#\"}"
+            val="${val%\"}"
+            ;;
+          \'*\')
+            val="${val#\'}"
+            val="${val%\'}"
+            ;;
+        esac
+      fi
+      # Indirect expansion: if already set, do not override.
+      if eval "[ -z \"\${$key+x}\" ]"; then
+        export "$key=$val"
+      fi
+    done <"$f"
+  done
+}

--- a/tools/run-android
+++ b/tools/run-android
@@ -9,37 +9,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-load_dotenv() {
-  # Dev-only config. `.env` and `.env.local` are gitignored.
-  for f in .env .env.local; do
-    if [ -f "$f" ]; then
-      # Only set vars that aren't already present in the environment so callers can override via:
-      #   PIKA_ANDROID_SERIAL=... ./tools/run-android
-      while IFS= read -r line || [ -n "$line" ]; do
-        # Trim leading/trailing whitespace (basic).
-        line="$(echo "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-        if [ -z "${line:-}" ] || echo "$line" | grep -q '^#'; then
-          continue
-        fi
-        if ! echo "$line" | grep -q '='; then
-          continue
-        fi
-        key="${line%%=*}"
-        val="${line#*=}"
-        key="$(echo "$key" | tr -d '[:space:]')"
-        if [ -z "${key:-}" ]; then
-          continue
-        fi
-        # Indirect expansion: if already set, do not override.
-        if eval "[ -z \"\${$key+x}\" ]"; then
-          export "$key=$val"
-        fi
-      done <"$f"
-    fi
-  done
-}
-
-load_dotenv
+# shellcheck disable=SC1091
+source "$ROOT/tools/lib/dotenv.sh"
+load_dotenv_no_override "$ROOT"
 
 # If the user isn't in the devShell, re-exec under Nix for a consistent toolchain.
 if [ -z "${IN_NIX_SHELL:-}" ] && [ "${PIKA_RUN_ANDROID_NO_NIX:-0}" != "1" ]; then

--- a/tools/run-ios
+++ b/tools/run-ios
@@ -23,37 +23,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-load_dotenv() {
-  # Dev-only config. `.env` and `.env.local` are gitignored.
-  for f in .env .env.local; do
-    if [ -f "$f" ]; then
-      # Only set vars that aren't already present in the environment so callers can override via:
-      #   PIKA_IOS_DEVICE=0 ./tools/run-ios
-      while IFS= read -r line || [ -n "$line" ]; do
-        # Trim leading/trailing whitespace (basic).
-        line="$(echo "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-        if [ -z "${line:-}" ] || echo "$line" | grep -q '^#'; then
-          continue
-        fi
-        if ! echo "$line" | grep -q '='; then
-          continue
-        fi
-        key="${line%%=*}"
-        val="${line#*=}"
-        key="$(echo "$key" | tr -d '[:space:]')"
-        if [ -z "${key:-}" ]; then
-          continue
-        fi
-        # Indirect expansion: if already set, do not override.
-        if eval "[ -z \"\${$key+x}\" ]"; then
-          export "$key=$val"
-        fi
-      done <"$f"
-    fi
-  done
-}
-
-load_dotenv
+# shellcheck disable=SC1091
+source "$ROOT/tools/lib/dotenv.sh"
+load_dotenv_no_override "$ROOT"
 
 # If the user isn't in the devShell, re-exec under Nix for a consistent toolchain.
 if [ -z "${IN_NIX_SHELL:-}" ] && [ "${PIKA_RUN_IOS_NO_NIX:-0}" != "1" ]; then
@@ -87,12 +59,7 @@ EOF
 }
 
 list_connected_iphones() {
-  DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1 || true)"
-  if [ -z "${DEV_DIR:-}" ]; then
-    echo "error: Xcode not found under /Applications" >&2
-    exit 1
-  fi
-  DEVELOPER_DIR="$DEV_DIR" xcrun xctrace list devices 2>/dev/null | awk '
+  ./tools/xcode-run xcrun xctrace list devices 2>/dev/null | awk '
     $0 == "== Devices ==" { in_devices = 1; next }
     $0 == "== Simulators ==" { in_devices = 0; next }
     in_devices && $0 ~ /iPhone/ {
@@ -183,11 +150,8 @@ PY
 
 # Fail fast if iOS Simulator runtimes/devices are missing.
 if [ "$MODE" = "device" ]; then
-  DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1 || true)"
-  if [ -z "${DEV_DIR:-}" ]; then
-    echo "error: Xcode not found under /Applications" >&2
-    exit 1
-  fi
+  # Ensure Xcode is installed.
+  ./tools/xcode-dev-dir >/dev/null
 
   if [ -z "${IOS_TEAM_ID:-}" ]; then
     echo "error: PIKA_IOS_DEVELOPMENT_TEAM is required for --device" >&2
@@ -216,7 +180,7 @@ if [ "$MODE" = "device" ]; then
   signing_settings+=("DEVELOPMENT_TEAM=$IOS_TEAM_ID")
   signing_settings+=("CODE_SIGN_STYLE=Automatic")
 
-  env -u LD -u CC -u CXX DEVELOPER_DIR="$DEV_DIR" xcodebuild \
+  ./tools/xcode-run xcodebuild \
     -project ios/Pika.xcodeproj \
     -scheme Pika \
     -configuration Debug \
@@ -234,7 +198,7 @@ if [ "$MODE" = "device" ]; then
   fi
 
   echo "installing app to device: $UDID"
-  DEVELOPER_DIR="$DEV_DIR" xcrun devicectl device install app -d "$UDID" "$app_path"
+  ./tools/xcode-run xcrun devicectl device install app -d "$UDID" "$app_path"
 
   env_json="$(env_json_for_device)"
 
@@ -245,7 +209,7 @@ if [ "$MODE" = "device" ]; then
     tmp="$(mktemp)"
     for i in $(seq 1 120); do
       rm -f "$tmp" >/dev/null 2>&1 || true
-      if DEVELOPER_DIR="$DEV_DIR" xcrun devicectl device info lockState -d "$UDID" --json-output "$tmp" >/dev/null 2>&1; then
+      if ./tools/xcode-run xcrun devicectl device info lockState -d "$UDID" --json-output "$tmp" >/dev/null 2>&1; then
         locked="$(python3 - <<PY 2>/dev/null || true
 import json
 p="${tmp}"
@@ -292,14 +256,14 @@ PY
 
   if [ "$CONSOLE" = "1" ]; then
     echo "launching $IOS_BUNDLE_ID (console attached)"
-    DEVELOPER_DIR="$DEV_DIR" xcrun devicectl device process launch -d "$UDID" \
+    ./tools/xcode-run xcrun devicectl device process launch -d "$UDID" \
       --environment-variables "$env_json" \
       --terminate-existing \
       --console \
       "$IOS_BUNDLE_ID"
   else
     echo "launching $IOS_BUNDLE_ID"
-    DEVELOPER_DIR="$DEV_DIR" xcrun devicectl device process launch -d "$UDID" \
+    ./tools/xcode-run xcrun devicectl device process launch -d "$UDID" \
       --environment-variables "$env_json" \
       --terminate-existing \
       "$IOS_BUNDLE_ID" >/dev/null

--- a/tools/ui-e2e-local
+++ b/tools/ui-e2e-local
@@ -186,11 +186,6 @@ case "$platform" in
     ;;
   ios)
     just ios-xcframework ios-xcodeproj >/dev/null
-    DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1)"
-    if [ -z "${DEV_DIR:-}" ]; then
-      echo "error: Xcode not found under /Applications" >&2
-      exit 1
-    fi
     udid="$(
       PIKA_UI_E2E_NSEC="${CLIENT_NSEC}" \
       PIKA_UI_E2E_BOT_NPUB="${BOT_NPUB}" \
@@ -207,8 +202,7 @@ case "$platform" in
       PIKA_UI_E2E_RELAYS="${RELAY_URL}" \
       PIKA_UI_E2E_KP_RELAYS="${RELAY_URL}" \
       PIKA_UI_E2E_NSEC="${CLIENT_NSEC}" \
-      env -u LD -u CC -u CXX DEVELOPER_DIR="$DEV_DIR" \
-        xcodebuild -project ios/Pika.xcodeproj -scheme Pika -destination "id=$udid" test CODE_SIGNING_ALLOWED=NO \
+      ./tools/xcode-run xcodebuild -project ios/Pika.xcodeproj -scheme Pika -destination "id=$udid" test CODE_SIGNING_ALLOWED=NO \
           -only-testing:PikaUITests/PikaUITests/testE2E_deployedRustBot_pingPong
     ;;
   *)

--- a/tools/ui-e2e-public
+++ b/tools/ui-e2e-public
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# UI E2E runner against public relays + deployed bot (nondeterministic).
+#
+# Replaces the long inline bash in `justfile` recipes:
+# - e2e-public-relays
+# - ios-ui-e2e
+# - android-ui-e2e
+#
+# Usage:
+#   ./tools/ui-e2e-public --platform all
+#   ./tools/ui-e2e-public --platform ios
+#   ./tools/ui-e2e-public --platform android
+#
+# Env (typically via .env / .env.local):
+#   PIKA_TEST_NSEC
+#   PIKA_UI_E2E_BOT_NPUB
+#   PIKA_UI_E2E_RELAYS
+#   PIKA_UI_E2E_KP_RELAYS
+# Optional:
+#   PIKA_UI_E2E_NSEC           (defaults to PIKA_TEST_NSEC)
+#   PIKA_UI_E2E_RUN_RUST=1     (run rust-level e2e-public first; default for --platform all)
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# shellcheck disable=SC1091
+source "$ROOT/tools/lib/dotenv.sh"
+load_dotenv_no_override "$ROOT"
+
+platform=""
+
+usage() {
+  cat >&2 <<EOF
+usage: ./tools/ui-e2e-public --platform ios|android|all
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --platform)
+      platform="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "${platform:-}" ]; then
+  usage
+  exit 2
+fi
+
+: "${PIKA_TEST_NSEC:?missing (put it in ./.env or ./.env.local)}"
+: "${PIKA_UI_E2E_BOT_NPUB:?missing (put it in ./.env or ./.env.local)}"
+: "${PIKA_UI_E2E_RELAYS:?missing (put it in ./.env or ./.env.local)}"
+: "${PIKA_UI_E2E_KP_RELAYS:?missing (put it in ./.env or ./.env.local)}"
+
+peer="${PIKA_UI_E2E_BOT_NPUB}"
+relays="${PIKA_UI_E2E_RELAYS}"
+kp_relays="${PIKA_UI_E2E_KP_RELAYS}"
+nsec="${PIKA_UI_E2E_NSEC:-${PIKA_TEST_NSEC}}"
+
+maybe_run_rust() {
+  if [ "${platform}" = "all" ] || [ "${PIKA_UI_E2E_RUN_RUST:-0}" = "1" ]; then
+    just e2e-public
+  fi
+}
+
+run_android() {
+  ./tools/android-emulator-ensure
+  just gen-kotlin android-rust android-local-properties >/dev/null
+
+  (cd android && ./gradlew :app:connectedDebugAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.class=com.pika.app.PikaE2eUiTest \
+    -Pandroid.testInstrumentationRunnerArguments.pika_e2e=1 \
+    -Pandroid.testInstrumentationRunnerArguments.pika_disable_network=false \
+    -Pandroid.testInstrumentationRunnerArguments.pika_reset=1 \
+    -Pandroid.testInstrumentationRunnerArguments.pika_peer_npub="$peer" \
+    -Pandroid.testInstrumentationRunnerArguments.pika_relay_urls="$relays" \
+    -Pandroid.testInstrumentationRunnerArguments.pika_key_package_relay_urls="$kp_relays" \
+    -Pandroid.testInstrumentationRunnerArguments.pika_nsec="$nsec")
+}
+
+run_ios() {
+  just ios-xcframework ios-xcodeproj >/dev/null
+
+  # Ensure the simulator test runner can see this value (tools/ios-sim-ensure propagates it).
+  udid="$(
+    PIKA_UI_E2E_NSEC="$nsec" \
+      ./tools/ios-sim-ensure | sed -n 's/^ok: ios simulator ready (udid=\(.*\))$/\1/p'
+  )"
+  if [ -z "${udid:-}" ]; then
+    echo "error: could not determine simulator udid" >&2
+    exit 1
+  fi
+
+  PIKA_UI_E2E=1 \
+    PIKA_UI_E2E_BOT_NPUB="$peer" \
+    PIKA_UI_E2E_RELAYS="$relays" \
+    PIKA_UI_E2E_KP_RELAYS="$kp_relays" \
+    PIKA_UI_E2E_NSEC="$nsec" \
+    ./tools/xcode-run xcodebuild -project ios/Pika.xcodeproj -scheme Pika -destination "id=$udid" test CODE_SIGNING_ALLOWED=NO \
+      PRODUCT_BUNDLE_IDENTIFIER="${PIKA_IOS_BUNDLE_ID:-com.justinmoon.pika.dev}" \
+      -only-testing:PikaUITests/PikaUITests/testE2E_deployedRustBot_pingPong
+}
+
+maybe_run_rust
+
+case "$platform" in
+  all)
+    run_ios
+    run_android
+    ;;
+  ios)
+    run_ios
+    ;;
+  android)
+    run_android
+    ;;
+  *)
+    echo "error: invalid --platform: $platform" >&2
+    exit 2
+    ;;
+esac

--- a/tools/xcode-dev-dir
+++ b/tools/xcode-dev-dir
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print the most recent Xcode Developer directory under /Applications.
+# Errors if not found.
+
+DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1 || true)"
+if [ -z "${DEV_DIR:-}" ]; then
+  echo "error: Xcode not found under /Applications" >&2
+  exit 1
+fi
+echo "$DEV_DIR"
+

--- a/tools/xcode-run
+++ b/tools/xcode-run
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run a command with a working Xcode toolchain env even inside Nix/direnv shells:
+# - chooses /Applications/Xcode*.app Developer dir
+# - unsets common Nix compiler env vars that break xcodebuild
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEV_DIR="$("$TOOLS_DIR/xcode-dev-dir")"
+exec env -u LD -u CC -u CXX DEVELOPER_DIR="$DEV_DIR" "$@"


### PR DESCRIPTION
Summary:
- Move long inline bash blocks out of justfile into tools scripts (public UI E2E + cli smoke).
- Centralize dotenv loading and Xcode env setup.
- Fix scripts/agent-brief exit status reporting.
- Make Android connected tests more reliable locally (uninstall-on-emulator for signature mismatch; pin to a single emulator).

Tested locally:
- nix develop -c just qa
- nix develop -c just ios-ui-test
- nix develop -c just android-ui-test
- nix develop -c just pre-merge
