### PR TITLE
test(ios): verify file fallback is denied in production mode

### DIFF
--- a/ios/Pika.xcodeproj/project.pbxproj
+++ b/ios/Pika.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		02D9A491B498E051D46EC648 /* KeychainNsecStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F912C4C8861A3FB74085329 /* KeychainNsecStore.swift */; };
 		2A9B2872E6ADB03F5A8FA173 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53159E06C561F50F6EC97A61 /* LoginView.swift */; };
+		38BA65C125C5EE3586248416 /* KeychainNsecStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F1BF02C1AAAEAA33532732 /* KeychainNsecStoreTests.swift */; };
 		3B614972940C843FB662920B /* PikaCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CD38D8437B178B873D96238 /* PikaCore.xcframework */; };
 		502171B59272A56AB36AECCF /* PeerKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B7DE0FCF7AB984004968F9 /* PeerKeyValidator.swift */; };
 		5EA0CD4191E6688471F8FAB5 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FE3F3E8BA33932B132B693 /* ChatView.swift */; };
@@ -33,6 +34,13 @@
 			remoteGlobalIDString = 2D0071299F035AA1EAC2CE97;
 			remoteInfo = Pika;
 		};
+		BAEED11EFCDF192E0546F109 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B1881FA49A49A0E38D54E33D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D0071299F035AA1EAC2CE97;
+			remoteInfo = Pika;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +48,7 @@
 		0705B2EA2A82DFC41EFF9DCF /* MyNpubQrSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNpubQrSheet.swift; sourceTree = "<group>"; };
 		2510455883E1CDFB6D589F5C /* pika_core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pika_core.swift; sourceTree = "<group>"; };
 		276F120E43A9DF389448FE5C /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		28F1BF02C1AAAEAA33532732 /* KeychainNsecStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainNsecStoreTests.swift; sourceTree = "<group>"; };
 		366C05B721835967C3BE5418 /* ChatListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListView.swift; sourceTree = "<group>"; };
 		3CD38D8437B178B873D96238 /* PikaCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PikaCore.xcframework; path = Frameworks/PikaCore.xcframework; sourceTree = "<group>"; };
 		42E962F7911EF0441F706C10 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -51,6 +60,7 @@
 		A62170468ABECD8AAA8B6B6A /* NewChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewChatView.swift; sourceTree = "<group>"; };
 		B083A8885A5C0BDDEFCF5EAC /* QrScannerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrScannerSheet.swift; sourceTree = "<group>"; };
 		B2FE3F3E8BA33932B132B693 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
+		E366BE398C3E8FAA39A15A33 /* PikaTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PikaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9B7DE0FCF7AB984004968F9 /* PeerKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerKeyValidator.swift; sourceTree = "<group>"; };
 		EF35ECCAE3B37C651F88A150 /* PikaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PikaApp.swift; sourceTree = "<group>"; };
 		F4FAE9ECBDFC0A976452024F /* TestIds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestIds.swift; sourceTree = "<group>"; };
@@ -88,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				F8FB9846E26624B7638DDA90 /* Pika.app */,
+				E366BE398C3E8FAA39A15A33 /* PikaTests.xctest */,
 				4F340333EBF85C4097106B1C /* PikaUITests.xctest */,
 			);
 			name = Products;
@@ -119,10 +130,19 @@
 			children = (
 				BAA4EBAEE8697870859AE04F /* Bindings */,
 				0EABA8FCDA9629FB8AF736CE /* Sources */,
+				7057FD8757F4DE461D8A3C27 /* Tests */,
 				3ECF7FFD917DF02854E9843D /* UITests */,
 				B14ADF193CAEABB2B0D1CC72 /* Frameworks */,
 				15FBA42EAE7F72462927B6FC /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		7057FD8757F4DE461D8A3C27 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				28F1BF02C1AAAEAA33532732 /* KeychainNsecStoreTests.swift */,
+			);
+			path = Tests;
 			sourceTree = "<group>";
 		};
 		B14ADF193CAEABB2B0D1CC72 /* Frameworks */ = {
@@ -182,6 +202,24 @@
 			productReference = 4F340333EBF85C4097106B1C /* PikaUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		B6D8ED6879409A76FCD25AD8 /* PikaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 70A4F2CE4633826C511B2B55 /* Build configuration list for PBXNativeTarget "PikaTests" */;
+			buildPhases = (
+				7E3D650FCF9955C047D2D9E7 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4D4482F0E5D02BD1919A8640 /* PBXTargetDependency */,
+			);
+			name = PikaTests;
+			packageProductDependencies = (
+			);
+			productName = PikaTests;
+			productReference = E366BE398C3E8FAA39A15A33 /* PikaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -211,6 +249,7 @@
 			projectRoot = "";
 			targets = (
 				2D0071299F035AA1EAC2CE97 /* Pika */,
+				B6D8ED6879409A76FCD25AD8 /* PikaTests */,
 				AEA02C6ADF42DA084E4281FA /* PikaUITests */,
 			);
 		};
@@ -233,6 +272,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				77E9D3F87F29E747F53DD5F0 /* PikaUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7E3D650FCF9955C047D2D9E7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				38BA65C125C5EE3586248416 /* KeychainNsecStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -263,6 +310,11 @@
 			isa = PBXTargetDependency;
 			target = 2D0071299F035AA1EAC2CE97 /* Pika */;
 			targetProxy = A9FEB1E744F3D43539C6D78D /* PBXContainerItemProxy */;
+		};
+		4D4482F0E5D02BD1919A8640 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D0071299F035AA1EAC2CE97 /* Pika */;
+			targetProxy = BAEED11EFCDF192E0546F109 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -382,6 +434,21 @@
 			};
 			name = Release;
 		};
+		A8BF38A644809A48AF3AAA5F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pika.app/Pika";
+			};
+			name = Debug;
+		};
 		BF2578637802091049530134 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -460,6 +527,21 @@
 			};
 			name = Debug;
 		};
+		D18F35409181D225BDE31F1A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pika.app/Pika";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -468,6 +550,15 @@
 			buildConfigurations = (
 				C89710F1EAB626E3BF0F8BF5 /* Debug */,
 				4A74CAEB00421F778BF1C026 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		70A4F2CE4633826C511B2B55 /* Build configuration list for PBXNativeTarget "PikaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A8BF38A644809A48AF3AAA5F /* Debug */,
+				D18F35409181D225BDE31F1A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/ios/Pika.xcodeproj/xcshareddata/xcschemes/Pika.xcscheme
+++ b/ios/Pika.xcodeproj/xcshareddata/xcschemes/Pika.xcscheme
@@ -45,6 +45,18 @@
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B6D8ED6879409A76FCD25AD8"
+               BuildableName = "PikaTests.xctest"
+               BlueprintName = "PikaTests"
+               ReferencedContainer = "container:Pika.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "AEA02C6ADF42DA084E4281FA"
                BuildableName = "PikaUITests.xctest"
                BlueprintName = "PikaUITests"

--- a/ios/Tests/KeychainNsecStoreTests.swift
+++ b/ios/Tests/KeychainNsecStoreTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import Pika
+
+final class KeychainNsecStoreTests: XCTestCase {
+
+    // MARK: - Production mode: file fallback must be denied
+
+    /// Simulates the production (device) code path: `fileFallbackAllowed: false`.
+    /// When the keychain is unavailable (-34018, which is the case on simulator builds
+    /// without entitlements), the store must trigger the crash handler rather than
+    /// silently writing the nsec to a plaintext file.
+    func testProductionModeDeniesFileFallback_onSet() {
+        let store = KeychainNsecStore(fileFallbackAllowed: false)
+
+        var deniedMessage: String?
+        store.onFileFallbackDenied = { msg in
+            deniedMessage = msg
+        }
+
+        // On the simulator the keychain returns -34018, which triggers switchToFileFallback.
+        // With fileFallbackAllowed=false this must call onFileFallbackDenied (or fatalError).
+        store.setNsec("nsec1testproductioncrash")
+
+        XCTAssertNotNil(deniedMessage,
+            "Production mode must trigger crash handler when keychain is unavailable, not silently fall back to file")
+        XCTAssertTrue(deniedMessage?.contains("must not happen in a production build") == true)
+    }
+
+    func testProductionModeDeniesFileFallback_onGet() {
+        let store = KeychainNsecStore(fileFallbackAllowed: false)
+
+        var deniedMessage: String?
+        store.onFileFallbackDenied = { msg in
+            deniedMessage = msg
+        }
+
+        // getNsec hits the keychain first (-34018 on sim) → switchToFileFallback → denied.
+        let result = store.getNsec()
+
+        XCTAssertNotNil(deniedMessage,
+            "Production mode must trigger crash handler on get when keychain is unavailable")
+        XCTAssertNil(result, "getNsec must not return a value when fallback is denied")
+    }
+
+    // MARK: - Simulator mode: file fallback works
+
+    func testSimulatorModeFallsBackToFile() {
+        let store = KeychainNsecStore(fileFallbackAllowed: true)
+
+        store.setNsec("nsec1simfallbacktest")
+
+        let store2 = KeychainNsecStore(fileFallbackAllowed: true)
+        let restored = store2.getNsec()
+
+        // On simulator with -34018 both stores fall back to file.
+        // The nsec should round-trip.
+        XCTAssertEqual(restored, "nsec1simfallbacktest",
+            "Simulator file fallback must persist and restore the nsec")
+
+        // Cleanup
+        store2.clearNsec()
+        XCTAssertNil(KeychainNsecStore(fileFallbackAllowed: true).getNsec())
+    }
+
+    // MARK: - Default init resolves correctly
+
+    func testDefaultInitAllowsFallbackOnSimulator() {
+        // We're running on the simulator, so the default should allow fallback.
+        let store = KeychainNsecStore()
+        XCTAssertTrue(store.fileFallbackAllowed,
+            "Default init on simulator must allow file fallback")
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -35,6 +35,14 @@ targets:
       - framework: Frameworks/PikaCore.xcframework
         embed: false
 
+  PikaTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: Tests
+    dependencies:
+      - target: Pika
+
   PikaUITests:
     type: bundle.ui-testing
     platform: iOS
@@ -50,5 +58,7 @@ schemes:
         Pika: all
     test:
       targets:
+        - name: PikaTests
+          randomExecutionOrder: true
         - name: PikaUITests
           randomExecutionOrder: true


### PR DESCRIPTION
## What

Adds test coverage proving that the plaintext nsec file fallback **cannot** activate in a production build.

## How

Refactors `KeychainNsecStore` so the fallback gate is injectable:

- `fileFallbackAllowed`: defaults to `true` on simulator (`#if targetEnvironment(simulator)`), `false` on device — **compile-time**. Tests can pass `false` to simulate the device path.
- `onFileFallbackDenied`: closure invoked instead of `fatalError()` when fallback is denied. Defaults to `nil` → `fatalError()`. Tests intercept it.

New `PikaTests` unit test target with 4 tests:

| Test | Asserts |
|------|---------|
| `testProductionModeDeniesFileFallback_onSet` | `setNsec` with `fileFallbackAllowed=false` triggers crash handler, not file write |
| `testProductionModeDeniesFileFallback_onGet` | `getNsec` with `fileFallbackAllowed=false` triggers crash handler, returns nil |
| `testSimulatorModeFallsBackToFile` | Round-trip set/get/clear works via file fallback |
| `testDefaultInitAllowsFallbackOnSimulator` | Default init resolves to `fileFallbackAllowed=true` on sim |

## Production safety unchanged

On a real device the default init sets `fileFallbackAllowed=false` and `onFileFallbackDenied` is `nil`, so any `-34018` hits `fatalError()` — the test-only escape hatch does not exist in the shipped binary.