### PR TITLE
feat: Nostr profile avatars and display names in chat list

### DIFF
--- a/android/app/src/main/java/com/pika/app/rust/pika_core.kt
+++ b/android/app/src/main/java/com/pika/app/rust/pika_core.kt
@@ -1638,6 +1638,8 @@ data class ChatSummary (
     , 
     var `peerName`: kotlin.String?
     , 
+    var `peerPictureUrl`: kotlin.String?
+    , 
     var `lastMessage`: kotlin.String?
     , 
     var `lastMessageAt`: kotlin.Long?
@@ -1663,6 +1665,7 @@ public object FfiConverterTypeChatSummary: FfiConverterRustBuffer<ChatSummary> {
             FfiConverterString.read(buf),
             FfiConverterOptionalString.read(buf),
             FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
             FfiConverterOptionalLong.read(buf),
             FfiConverterUInt.read(buf),
         )
@@ -1672,6 +1675,7 @@ public object FfiConverterTypeChatSummary: FfiConverterRustBuffer<ChatSummary> {
             FfiConverterString.allocationSize(value.`chatId`) +
             FfiConverterString.allocationSize(value.`peerNpub`) +
             FfiConverterOptionalString.allocationSize(value.`peerName`) +
+            FfiConverterOptionalString.allocationSize(value.`peerPictureUrl`) +
             FfiConverterOptionalString.allocationSize(value.`lastMessage`) +
             FfiConverterOptionalLong.allocationSize(value.`lastMessageAt`) +
             FfiConverterUInt.allocationSize(value.`unreadCount`)
@@ -1681,6 +1685,7 @@ public object FfiConverterTypeChatSummary: FfiConverterRustBuffer<ChatSummary> {
             FfiConverterString.write(value.`chatId`, buf)
             FfiConverterString.write(value.`peerNpub`, buf)
             FfiConverterOptionalString.write(value.`peerName`, buf)
+            FfiConverterOptionalString.write(value.`peerPictureUrl`, buf)
             FfiConverterOptionalString.write(value.`lastMessage`, buf)
             FfiConverterOptionalLong.write(value.`lastMessageAt`, buf)
             FfiConverterUInt.write(value.`unreadCount`, buf)
@@ -1695,6 +1700,8 @@ data class ChatViewState (
     var `peerNpub`: kotlin.String
     , 
     var `peerName`: kotlin.String?
+    , 
+    var `peerPictureUrl`: kotlin.String?
     , 
     var `messages`: List<ChatMessage>
     , 
@@ -1718,6 +1725,7 @@ public object FfiConverterTypeChatViewState: FfiConverterRustBuffer<ChatViewStat
             FfiConverterString.read(buf),
             FfiConverterString.read(buf),
             FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
             FfiConverterSequenceTypeChatMessage.read(buf),
             FfiConverterBoolean.read(buf),
         )
@@ -1727,6 +1735,7 @@ public object FfiConverterTypeChatViewState: FfiConverterRustBuffer<ChatViewStat
             FfiConverterString.allocationSize(value.`chatId`) +
             FfiConverterString.allocationSize(value.`peerNpub`) +
             FfiConverterOptionalString.allocationSize(value.`peerName`) +
+            FfiConverterOptionalString.allocationSize(value.`peerPictureUrl`) +
             FfiConverterSequenceTypeChatMessage.allocationSize(value.`messages`) +
             FfiConverterBoolean.allocationSize(value.`canLoadOlder`)
     )
@@ -1735,6 +1744,7 @@ public object FfiConverterTypeChatViewState: FfiConverterRustBuffer<ChatViewStat
             FfiConverterString.write(value.`chatId`, buf)
             FfiConverterString.write(value.`peerNpub`, buf)
             FfiConverterOptionalString.write(value.`peerName`, buf)
+            FfiConverterOptionalString.write(value.`peerPictureUrl`, buf)
             FfiConverterSequenceTypeChatMessage.write(value.`messages`, buf)
             FfiConverterBoolean.write(value.`canLoadOlder`, buf)
     }

--- a/ios/Bindings/pika_core.swift
+++ b/ios/Bindings/pika_core.swift
@@ -893,16 +893,18 @@ public struct ChatSummary: Equatable, Hashable {
     public var chatId: String
     public var peerNpub: String
     public var peerName: String?
+    public var peerPictureUrl: String?
     public var lastMessage: String?
     public var lastMessageAt: Int64?
     public var unreadCount: UInt32
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(chatId: String, peerNpub: String, peerName: String?, lastMessage: String?, lastMessageAt: Int64?, unreadCount: UInt32) {
+    public init(chatId: String, peerNpub: String, peerName: String?, peerPictureUrl: String?, lastMessage: String?, lastMessageAt: Int64?, unreadCount: UInt32) {
         self.chatId = chatId
         self.peerNpub = peerNpub
         self.peerName = peerName
+        self.peerPictureUrl = peerPictureUrl
         self.lastMessage = lastMessage
         self.lastMessageAt = lastMessageAt
         self.unreadCount = unreadCount
@@ -927,6 +929,7 @@ public struct FfiConverterTypeChatSummary: FfiConverterRustBuffer {
                 chatId: FfiConverterString.read(from: &buf), 
                 peerNpub: FfiConverterString.read(from: &buf), 
                 peerName: FfiConverterOptionString.read(from: &buf), 
+                peerPictureUrl: FfiConverterOptionString.read(from: &buf), 
                 lastMessage: FfiConverterOptionString.read(from: &buf), 
                 lastMessageAt: FfiConverterOptionInt64.read(from: &buf), 
                 unreadCount: FfiConverterUInt32.read(from: &buf)
@@ -937,6 +940,7 @@ public struct FfiConverterTypeChatSummary: FfiConverterRustBuffer {
         FfiConverterString.write(value.chatId, into: &buf)
         FfiConverterString.write(value.peerNpub, into: &buf)
         FfiConverterOptionString.write(value.peerName, into: &buf)
+        FfiConverterOptionString.write(value.peerPictureUrl, into: &buf)
         FfiConverterOptionString.write(value.lastMessage, into: &buf)
         FfiConverterOptionInt64.write(value.lastMessageAt, into: &buf)
         FfiConverterUInt32.write(value.unreadCount, into: &buf)
@@ -963,15 +967,17 @@ public struct ChatViewState: Equatable, Hashable {
     public var chatId: String
     public var peerNpub: String
     public var peerName: String?
+    public var peerPictureUrl: String?
     public var messages: [ChatMessage]
     public var canLoadOlder: Bool
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(chatId: String, peerNpub: String, peerName: String?, messages: [ChatMessage], canLoadOlder: Bool) {
+    public init(chatId: String, peerNpub: String, peerName: String?, peerPictureUrl: String?, messages: [ChatMessage], canLoadOlder: Bool) {
         self.chatId = chatId
         self.peerNpub = peerNpub
         self.peerName = peerName
+        self.peerPictureUrl = peerPictureUrl
         self.messages = messages
         self.canLoadOlder = canLoadOlder
     }
@@ -995,6 +1001,7 @@ public struct FfiConverterTypeChatViewState: FfiConverterRustBuffer {
                 chatId: FfiConverterString.read(from: &buf), 
                 peerNpub: FfiConverterString.read(from: &buf), 
                 peerName: FfiConverterOptionString.read(from: &buf), 
+                peerPictureUrl: FfiConverterOptionString.read(from: &buf), 
                 messages: FfiConverterSequenceTypeChatMessage.read(from: &buf), 
                 canLoadOlder: FfiConverterBool.read(from: &buf)
         )
@@ -1004,6 +1011,7 @@ public struct FfiConverterTypeChatViewState: FfiConverterRustBuffer {
         FfiConverterString.write(value.chatId, into: &buf)
         FfiConverterString.write(value.peerNpub, into: &buf)
         FfiConverterOptionString.write(value.peerName, into: &buf)
+        FfiConverterOptionString.write(value.peerPictureUrl, into: &buf)
         FfiConverterSequenceTypeChatMessage.write(value.messages, into: &buf)
         FfiConverterBool.write(value.canLoadOlder, into: &buf)
     }

--- a/ios/Pika.xcodeproj/project.pbxproj
+++ b/ios/Pika.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		EDAE180A5D3FEED3C801658F /* MyNpubQrSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0705B2EA2A82DFC41EFF9DCF /* MyNpubQrSheet.swift */; };
 		F2A2C56251354A67641CA82F /* pika_core.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2510455883E1CDFB6D589F5C /* pika_core.swift */; };
 		F308786C219CC1D169ABFC50 /* PikaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF35ECCAE3B37C651F88A150 /* PikaApp.swift */; };
+		F69233C493C4DF364AB6B468 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB0FD903A8B9CBC1D80EB16D /* AvatarView.swift */; };
 		FE739725B724B1944145C8EF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E962F7911EF0441F706C10 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
@@ -62,6 +63,7 @@
 		B2FE3F3E8BA33932B132B693 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		E366BE398C3E8FAA39A15A33 /* PikaTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PikaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9B7DE0FCF7AB984004968F9 /* PeerKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerKeyValidator.swift; sourceTree = "<group>"; };
+		EB0FD903A8B9CBC1D80EB16D /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		EF35ECCAE3B37C651F88A150 /* PikaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PikaApp.swift; sourceTree = "<group>"; };
 		F4FAE9ECBDFC0A976452024F /* TestIds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestIds.swift; sourceTree = "<group>"; };
 		F8FB9846E26624B7638DDA90 /* Pika.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Pika.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -107,6 +109,7 @@
 		3020E60167D2F29F544518EE /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				EB0FD903A8B9CBC1D80EB16D /* AvatarView.swift */,
 				366C05B721835967C3BE5418 /* ChatListView.swift */,
 				B2FE3F3E8BA33932B132B693 /* ChatView.swift */,
 				53159E06C561F50F6EC97A61 /* LoginView.swift */,
@@ -288,6 +291,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A15307C1B4692DC5925858CE /* AppManager.swift in Sources */,
+				F69233C493C4DF364AB6B468 /* AvatarView.swift in Sources */,
 				783CBC6C2A48969656021CD8 /* ChatListView.swift in Sources */,
 				5EA0CD4191E6688471F8FAB5 /* ChatView.swift in Sources */,
 				FE739725B724B1944145C8EF /* ContentView.swift in Sources */,

--- a/ios/Sources/Views/AvatarView.swift
+++ b/ios/Sources/Views/AvatarView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct AvatarView: View {
+    let name: String?
+    let npub: String
+    let pictureUrl: String?
+    var size: CGFloat = 44
+
+    var body: some View {
+        if let url = pictureUrl.flatMap({ URL(string: $0) }) {
+            AsyncImage(url: url) { image in
+                image.resizable().scaledToFill()
+            } placeholder: {
+                initialsCircle
+            }
+            .frame(width: size, height: size)
+            .clipShape(Circle())
+        } else {
+            initialsCircle
+        }
+    }
+
+    private var initialsCircle: some View {
+        Circle()
+            .fill(Color.blue.opacity(0.12))
+            .frame(width: size, height: size)
+            .overlay {
+                Text(initials)
+                    .font(.system(size: size * 0.4, weight: .medium))
+                    .foregroundStyle(.blue)
+            }
+    }
+
+    private var initials: String {
+        let source = name ?? npub
+        return String(source.prefix(1)).uppercased()
+    }
+}

--- a/ios/Sources/Views/ChatListView.swift
+++ b/ios/Sources/Views/ChatListView.swift
@@ -6,13 +6,31 @@ struct ChatListView: View {
 
     var body: some View {
         List(manager.state.chatList, id: \.chatId) { chat in
-            let row = VStack(alignment: .leading, spacing: 4) {
-                Text(chat.peerName ?? chat.peerNpub)
-                    .font(.headline)
-                Text(chat.lastMessage ?? "No messages yet")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+            let displayName = chat.peerName ?? truncatedNpub(chat.peerNpub)
+            let subtitle = chat.peerName != nil ? truncatedNpub(chat.peerNpub) : nil
+
+            let row = HStack(spacing: 12) {
+                AvatarView(
+                    name: chat.peerName,
+                    npub: chat.peerNpub,
+                    pictureUrl: chat.peerPictureUrl
+                )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(displayName)
+                        .font(.headline)
+                        .lineLimit(1)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                    Text(chat.lastMessage ?? "No messages yet")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
 
             Group {
@@ -66,5 +84,10 @@ struct ChatListView: View {
         default:
             return nil
         }
+    }
+
+    private func truncatedNpub(_ npub: String) -> String {
+        if npub.count <= 16 { return npub }
+        return String(npub.prefix(12)) + "..."
     }
 }

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -73,6 +73,7 @@ pub struct ChatSummary {
     pub chat_id: String,
     pub peer_npub: String,
     pub peer_name: Option<String>,
+    pub peer_picture_url: Option<String>,
     pub last_message: Option<String>,
     pub last_message_at: Option<i64>,
     pub unread_count: u32,
@@ -83,6 +84,7 @@ pub struct ChatViewState {
     pub chat_id: String,
     pub peer_npub: String,
     pub peer_name: Option<String>,
+    pub peer_picture_url: Option<String>,
     pub messages: Vec<ChatMessage>,
     pub can_load_older: bool,
 }

--- a/rust/src/updates.rs
+++ b/rust/src/updates.rs
@@ -2,6 +2,7 @@ use crate::state::AppState;
 use crate::AppAction;
 
 #[derive(uniffi::Enum, Clone, Debug)]
+#[allow(clippy::large_enum_variant)] // uniffi enums cannot use Box<T> indirection
 pub enum AppUpdate {
     /// Primary update stream: always send a full state snapshot.
     ///
@@ -71,5 +72,10 @@ pub enum InternalEvent {
         token: u64,
         giftwrap_sub: Option<nostr_sdk::prelude::SubscriptionId>,
         group_sub: Option<nostr_sdk::prelude::SubscriptionId>,
+    },
+
+    // Nostr kind:0 profile metadata fetched for peers.
+    ProfilesFetched {
+        profiles: Vec<(String, Option<String>, Option<String>)>, // (hex_pubkey, name, picture_url)
     },
 }


### PR DESCRIPTION
## Summary

- Fetch Nostr kind:0 metadata (NIP-01) for each chat peer in the Rust core, with an in-memory cache (1hr staleness TTL)
- Surface `peer_picture_url` alongside existing `peer_name` through the uniffi FFI to iOS/Android
- New `AvatarView` SwiftUI component with `AsyncImage` profile pictures and initials-circle fallback
- Updated `ChatListView` rows to show avatar, display name (with truncated npub subtitle), and message preview

## Test plan

- [ ] Build Rust: `cargo build -p pika_core`
- [ ] Build iOS for simulator and verify chat list shows initials avatars immediately
- [ ] Chat with a peer that has a kind:0 profile (e.g. the bot npub) — verify name + picture load after a moment
- [ ] Chat with a peer without a profile — verify graceful fallback to initials + truncated npub
- [ ] Verify Android still builds (new fields are optional, no Kotlin UI changes yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)