### PR TITLE
feat(ios): long-press context menu to copy messages

### DIFF
--- a/ios/Sources/Views/ChatView.swift
+++ b/ios/Sources/Views/ChatView.swift
@@ -62,6 +62,13 @@ private struct MessageRow: View {
                     .background(message.isMine ? Color.blue : Color.gray.opacity(0.2))
                     .foregroundStyle(message.isMine ? Color.white : Color.primary)
                     .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .contextMenu {
+                        Button {
+                            UIPasteboard.general.string = message.content
+                        } label: {
+                            Label("Copy", systemImage: "doc.on.doc")
+                        }
+                    }
 
                 if message.isMine {
                     Text(deliveryText(message.delivery))


### PR DESCRIPTION
## Summary
- Adds a SwiftUI `.contextMenu` to message bubbles in `ChatView`
- Press and hold any message to get a "Copy" action that copies the text to the clipboard
- Easy to extend with additional actions in the future

## Test plan
- [ ] Long-press a received message → context menu appears with "Copy"
- [ ] Long-press a sent message → context menu appears with "Copy"
- [ ] Tap "Copy" → message text is copied to clipboard
- [ ] Paste elsewhere to verify clipboard content

🤖 Generated with [Claude Code](https://claude.com/claude-code)