### PR TITLE
fix(ios): remove iOS 26 APIs for Xcode 16 compatibility

### DIFF
--- a/ios/Sources/Views/ChatView.swift
+++ b/ios/Sources/Views/ChatView.swift
@@ -57,19 +57,11 @@ struct ChatView: View {
 
 private struct GlassInputModifier: ViewModifier {
     func body(content: Content) -> some View {
-        if #available(iOS 26.0, *) {
-            content
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .glassEffect(.regular.interactive(), in: .capsule)
-                .padding(12)
-        } else {
-            content
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(.ultraThinMaterial, in: Capsule())
-                .padding(12)
-        }
+        content
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.ultraThinMaterial, in: Capsule())
+            .padding(12)
     }
 }
 
@@ -77,14 +69,10 @@ private struct FloatingInputBarModifier<Bar: View>: ViewModifier {
     @ViewBuilder var content: Bar
 
     func body(content view: Content) -> some View {
-        if #available(iOS 26.0, *) {
-            view.safeAreaBar(edge: .bottom) { content }
-        } else {
-            view.safeAreaInset(edge: .bottom) {
-                VStack(spacing: 0) {
-                    Divider()
-                    content
-                }
+        view.safeAreaInset(edge: .bottom) {
+            VStack(spacing: 0) {
+                Divider()
+                content
             }
         }
     }


### PR DESCRIPTION
The `glassEffect` and `safeAreaBar` APIs are only available in the Xcode 26 beta SDK. Using `#available` checks doesn't help since older Xcode versions (like Xcode 16.x) don't have these symbols in the SDK headers at all, causing compilation failures.

This PR removes the iOS 26 conditional branches and uses the fallback `ultraThinMaterial` and `safeAreaInset` APIs which work across all supported Xcode versions.