### PR TITLE
feat(ios): add nsec export on profile page

### DIFF
--- a/ios/Sources/AppManager.swift
+++ b/ios/Sources/AppManager.swift
@@ -124,6 +124,10 @@ final class AppManager: AppReconciler {
         // Foreground is a lifecycle action; Rust owns state changes and side effects.
         dispatch(.foregrounded)
     }
+
+    func getNsec() -> String? {
+        nsecStore.getNsec()
+    }
 }
 
 private extension AppUpdate {

--- a/ios/Sources/TestIds.swift
+++ b/ios/Sources/TestIds.swift
@@ -15,6 +15,11 @@ enum TestIds {
     static let chatListMyNpubCopy = "chatlist_my_npub_copy"
     static let chatListMyNpubClose = "chatlist_my_npub_close"
 
+    // My Profile (nsec export)
+    static let myNpubNsecValue = "my_npub_nsec_value"
+    static let myNpubNsecToggle = "my_npub_nsec_toggle"
+    static let myNpubNsecCopy = "my_npub_nsec_copy"
+
     // New chat
     static let newChatPeerNpub = "newchat_peer_npub"
     static let newChatStart = "newchat_start"

--- a/ios/Sources/Views/ChatListView.swift
+++ b/ios/Sources/Views/ChatListView.swift
@@ -61,7 +61,7 @@ struct ChatListView: View {
                     .accessibilityLabel("My npub")
                     .accessibilityIdentifier(TestIds.chatListMyNpub)
                     .sheet(isPresented: $showMyNpub) {
-                        MyNpubQrSheet(npub: npub)
+                        MyNpubQrSheet(npub: npub, manager: manager)
                     }
                 }
             }

--- a/ios/Sources/Views/MyNpubQrSheet.swift
+++ b/ios/Sources/Views/MyNpubQrSheet.swift
@@ -5,7 +5,9 @@ import UIKit
 
 struct MyNpubQrSheet: View {
     let npub: String
+    let manager: AppManager
     @Environment(\.dismiss) private var dismiss
+    @State private var showNsec = false
 
     var body: some View {
         NavigationStack {
@@ -33,16 +35,56 @@ struct MyNpubQrSheet: View {
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                     .accessibilityIdentifier(TestIds.chatListMyNpubValue)
 
-                Button("Copy") {
+                Button("Copy npub") {
                     UIPasteboard.general.string = npub
                 }
                 .buttonStyle(.borderedProminent)
                 .accessibilityIdentifier(TestIds.chatListMyNpubCopy)
 
+                if let nsec = manager.getNsec() {
+                    Divider()
+                        .padding(.vertical, 8)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Private Key (nsec)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        HStack {
+                            if showNsec {
+                                Text(nsec)
+                                    .font(.system(.footnote, design: .monospaced))
+                                    .textSelection(.enabled)
+                            } else {
+                                Text(String(repeating: "•", count: 24))
+                                    .font(.system(.footnote, design: .monospaced))
+                            }
+                            Spacer()
+                            Button {
+                                showNsec.toggle()
+                            } label: {
+                                Image(systemName: showNsec ? "eye.slash" : "eye")
+                            }
+                            .accessibilityIdentifier(TestIds.myNpubNsecToggle)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(12)
+                        .background(.thinMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .accessibilityIdentifier(TestIds.myNpubNsecValue)
+
+                        Button("Copy nsec") {
+                            UIPasteboard.general.string = nsec
+                        }
+                        .buttonStyle(.bordered)
+                        .accessibilityIdentifier(TestIds.myNpubNsecCopy)
+                    }
+                }
+
                 Spacer()
             }
             .padding(16)
-            .navigationTitle("My npub")
+            .navigationTitle("My Profile")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Close") { dismiss() }


### PR DESCRIPTION
Adds the ability to view and copy the private key (nsec) from the profile sheet.

**Features:**
- nsec is hidden by default with a toggle button (eye icon) to reveal it
- Dedicated "Copy nsec" button
- Located below the npub on the profile/QR code sheet

**Screenshot preview:**
The profile sheet now shows:
- QR code
- npub with copy button
- Divider
- nsec (hidden by default) with reveal toggle and copy button