### PR TITLE
Add markdown rendering with extensible custom UI blocks (iOS + Android)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -119,4 +119,7 @@ dependencies {
 
     // UniFFI Kotlin bindings default to JNA.
     implementation("net.java.dev.jna:jna:5.14.0@aar")
+
+    // Markdown rendering in Compose
+    implementation("com.github.jeziellago:compose-markdown:0.5.4")
 }

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://jitpack.io")
     }
 }
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -17,6 +17,11 @@ settings:
     Debug:
       PRODUCT_BUNDLE_IDENTIFIER: com.justinmoon.pika.dev
 
+packages:
+  MarkdownUI:
+    url: https://github.com/gonzalezreal/swift-markdown-ui
+    from: "2.4.0"
+
 targets:
   Pika:
     type: application
@@ -34,6 +39,7 @@ targets:
     dependencies:
       - framework: Frameworks/PikaCore.xcframework
         embed: false
+      - package: MarkdownUI
 
   PikaTests:
     type: bundle.unit-test


### PR DESCRIPTION
- iOS: Add MarkdownUI SPM dependency, replace Text with Markdown renderer, add pika-prompt custom code block support with tappable buttons
- Android: Add compose-markdown dependency, replace Text with MarkdownText, add pika-prompt parsing and PikaPromptCard composable
- Architecture: Messages parsed into segments (markdown + pika-* blocks) for extensible custom UI rendering