### PR TITLE
feat: add @mention support in group chats

### DIFF
--- a/ios/Sources/PreviewData.swift
+++ b/ios/Sources/PreviewData.swift
@@ -217,6 +217,8 @@ enum PreviewAppState {
                 senderPubkey: samplePubkey,
                 senderName: nil,
                 content: "Hey! Are we still on for today?",
+                displayContent: "Hey! Are we still on for today?",
+                mentions: [],
                 timestamp: 1_709_000_001,
                 isMine: true,
                 delivery: .sent
@@ -226,6 +228,8 @@ enum PreviewAppState {
                 senderPubkey: samplePeerPubkey,
                 senderName: name,
                 content: "Yep. See you at the relay.",
+                displayContent: "Yep. See you at the relay.",
+                mentions: [],
                 timestamp: 1_709_000_050,
                 isMine: false,
                 delivery: .sent
@@ -235,6 +239,8 @@ enum PreviewAppState {
                 senderPubkey: samplePubkey,
                 senderName: nil,
                 content: failed ? "This one failed to send." : "On my way.",
+                displayContent: failed ? "This one failed to send." : "On my way.",
+                mentions: [],
                 timestamp: 1_709_000_100,
                 isMine: true,
                 delivery: failed ? .failed(reason: "Network timeout") : .pending
@@ -254,13 +260,16 @@ enum PreviewAppState {
 
     private static func chatViewStateLongThread() -> ChatViewState {
         let messages = (0..<20).map { idx in
-            ChatMessage(
+            let text = idx.isMultiple(of: 3)
+                ? "A long message intended to wrap across multiple lines for layout validation."
+                : "Message \(idx + 1)"
+            return ChatMessage(
                 id: "m\(idx)",
                 senderPubkey: idx.isMultiple(of: 2) ? samplePubkey : samplePeerPubkey,
                 senderName: idx.isMultiple(of: 2) ? nil : "Peer",
-                content: idx.isMultiple(of: 3)
-                    ? "A long message intended to wrap across multiple lines for layout validation."
-                    : "Message \(idx + 1)",
+                content: text,
+                displayContent: text,
+                mentions: [],
                 timestamp: Int64(1_709_000_200 + idx),
                 isMine: idx.isMultiple(of: 2),
                 delivery: .sent

--- a/rust/src/core/storage.rs
+++ b/rust/src/core/storage.rs
@@ -1,7 +1,7 @@
 // Storage-derived state refresh + paging.
 
 use super::*;
-use crate::state::MemberInfo;
+use crate::state::{resolve_mentions, MemberInfo};
 
 impl AppCore {
     pub(super) fn refresh_all_from_storage(&mut self) {
@@ -290,11 +290,14 @@ impl AppCore {
                     .and_then(|map| map.get(&id))
                     .cloned()
                     .unwrap_or(MessageDeliveryState::Sent);
+                let (display_content, mentions) = resolve_mentions(&m.content, &sender_names);
                 ChatMessage {
                     id,
                     sender_pubkey: sender_hex,
                     sender_name,
                     content: m.content,
+                    display_content,
+                    mentions,
                     timestamp: m.created_at.as_secs() as i64,
                     is_mine,
                     delivery,
@@ -319,11 +322,14 @@ impl AppCore {
                     .and_then(|map| map.get(&id))
                     .cloned()
                     .unwrap_or(MessageDeliveryState::Pending);
+                let (display_content, mentions) = resolve_mentions(&lm.content, &sender_names);
                 msgs.push(ChatMessage {
                     id,
                     sender_pubkey: lm.sender_pubkey,
                     sender_name: None,
                     content: lm.content,
+                    display_content,
+                    mentions,
                     timestamp: lm.timestamp,
                     is_mine: true,
                     delivery,
@@ -420,11 +426,14 @@ impl AppCore {
                     .and_then(|map| map.get(&id))
                     .cloned()
                     .unwrap_or(MessageDeliveryState::Sent);
+                let (display_content, mentions) = resolve_mentions(&m.content, &sender_names);
                 ChatMessage {
                     id,
                     sender_pubkey: sender_hex,
                     sender_name,
                     content: m.content,
+                    display_content,
+                    mentions,
                     timestamp: m.created_at.as_secs() as i64,
                     is_mine,
                     delivery,


### PR DESCRIPTION
## Summary

Adds @mention support for group chats. Users can mention group members by typing `@`, which shows an inline member picker. Mentions are sent as `nostr:npub1...` on the wire but rendered as styled `@name` in the UI.

## Rust Changes

- New `Mention` struct with `npub`, `display_name`, `start`, `end` fields
- `ChatMessage` gains `display_content` and `mentions: Vec<Mention>` fields
- `resolve_mentions()` scans content for `nostr:npub1...` tokens, resolves display names from member/profile cache, returns display text with mention ranges
- All message construction sites (current chat, local outbox, load older) resolve mentions

## iOS Changes

- `MessageRow`: renders mentions as bold/colored inline text via `Text` concatenation
- `ChatView` input: typing `@` triggers an inline member picker popup above the input bar
- Selecting a member inserts `@DisplayName` in the text field
- On send, display names are substituted back to `nostr:npub1...` wire format
- Popup auto-dismisses on backspace

## Testing

- `cargo fmt` / `cargo clippy`: clean
- `cargo test`: all pass
- iOS `xcodebuild`: build succeeded