### PR TITLE
fix: show npub prefix for unnamed mention fallback

### DIFF
--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -157,7 +157,7 @@ pub fn resolve_mentions(
             lookup
                 .get(&hex)
                 .cloned()
-                .unwrap_or_else(|| hex[..8].to_string())
+                .unwrap_or_else(|| npub[..npub.len().min(13)].to_string())
         } else {
             npub[..npub.len().min(12)].to_string()
         };


### PR DESCRIPTION
When a mentioned user has no display name set, show `@npub1abcdefgh` instead of `@abcd1234` (raw hex).