### PR TITLE
fix: use TextEditor for reliable multi-line chat input

### DIFF
--- a/ios/Sources/Views/ChatView.swift
+++ b/ios/Sources/Views/ChatView.swift
@@ -154,6 +154,13 @@ struct ChatView: View {
                     .frame(minHeight: 36, maxHeight: 150)
                     .fixedSize(horizontal: false, vertical: true)
                     .scrollContentBackground(.hidden)
+                    .onKeyPress(.return, phases: .down) { keyPress in
+                        if keyPress.modifiers.contains(.shift) {
+                            return .ignored
+                        }
+                        sendMessage()
+                        return .handled
+                    }
                     .overlay(alignment: .topLeading) {
                         if messageText.isEmpty {
                             Text("Message")


### PR DESCRIPTION
TextField with axis: .vertical was not producing multiline behavior on device. Switch to TextEditor which reliably supports newlines via Return key and multiline paste.