### PR TITLE
Improve chat UI/profile UX and switch Blossom host

### DIFF
--- a/ios/Pika.xcodeproj/project.pbxproj
+++ b/ios/Pika.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,6 +11,7 @@
 		2A9B2872E6ADB03F5A8FA173 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53159E06C561F50F6EC97A61 /* LoginView.swift */; };
 		38BA65C125C5EE3586248416 /* KeychainNsecStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F1BF02C1AAAEAA33532732 /* KeychainNsecStoreTests.swift */; };
 		3B614972940C843FB662920B /* PikaCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CD38D8437B178B873D96238 /* PikaCore.xcframework */; };
+		4486E2DC2719F40214340777 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 653509E9220610E2699954CB /* MarkdownUI */; };
 		4E79E8EB78FF3FEB6FA4E4E4 /* AppManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B07F038CF3D6A3DC2F37122 /* AppManagerTests.swift */; };
 		502171B59272A56AB36AECCF /* PeerKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B7DE0FCF7AB984004968F9 /* PeerKeyValidator.swift */; };
 		5EA0CD4191E6688471F8FAB5 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FE3F3E8BA33932B132B693 /* ChatView.swift */; };
@@ -22,8 +23,10 @@
 		9581B9688EDC90BCBC177E47 /* TestIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FAE9ECBDFC0A976452024F /* TestIds.swift */; };
 		970D12403533E203A33FBEFC /* NewChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62170468ABECD8AAA8B6B6A /* NewChatView.swift */; };
 		A15307C1B4692DC5925858CE /* AppManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B2B1856254D8FE240BC93A /* AppManager.swift */; };
+		B5F90A17C2DF56BF2B42736E /* NewGroupChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BE97F6BA133265DB078F8A /* NewGroupChatView.swift */; };
 		DE799DF1E97151C517647E61 /* QrScannerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B083A8885A5C0BDDEFCF5EAC /* QrScannerSheet.swift */; };
 		EDAE180A5D3FEED3C801658F /* MyNpubQrSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0705B2EA2A82DFC41EFF9DCF /* MyNpubQrSheet.swift */; };
+		EEE2F54DC181C7C91E5F7848 /* GroupInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04278E7A5E984011D10BE79F /* GroupInfoView.swift */; };
 		F2A2C56251354A67641CA82F /* pika_core.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2510455883E1CDFB6D589F5C /* pika_core.swift */; };
 		F308786C219CC1D169ABFC50 /* PikaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF35ECCAE3B37C651F88A150 /* PikaApp.swift */; };
 		F69233C493C4DF364AB6B468 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB0FD903A8B9CBC1D80EB16D /* AvatarView.swift */; };
@@ -48,8 +51,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04278E7A5E984011D10BE79F /* GroupInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupInfoView.swift; sourceTree = "<group>"; };
 		05B2B1856254D8FE240BC93A /* AppManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppManager.swift; sourceTree = "<group>"; };
 		0705B2EA2A82DFC41EFF9DCF /* MyNpubQrSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNpubQrSheet.swift; sourceTree = "<group>"; };
+		09BE97F6BA133265DB078F8A /* NewGroupChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGroupChatView.swift; sourceTree = "<group>"; };
 		2510455883E1CDFB6D589F5C /* pika_core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pika_core.swift; sourceTree = "<group>"; };
 		276F120E43A9DF389448FE5C /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		28F1BF02C1AAAEAA33532732 /* KeychainNsecStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainNsecStoreTests.swift; sourceTree = "<group>"; };
@@ -81,6 +86,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3B614972940C843FB662920B /* PikaCore.xcframework in Frameworks */,
+				4486E2DC2719F40214340777 /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,9 +126,11 @@
 				EB0FD903A8B9CBC1D80EB16D /* AvatarView.swift */,
 				366C05B721835967C3BE5418 /* ChatListView.swift */,
 				B2FE3F3E8BA33932B132B693 /* ChatView.swift */,
+				04278E7A5E984011D10BE79F /* GroupInfoView.swift */,
 				53159E06C561F50F6EC97A61 /* LoginView.swift */,
 				0705B2EA2A82DFC41EFF9DCF /* MyNpubQrSheet.swift */,
 				A62170468ABECD8AAA8B6B6A /* NewChatView.swift */,
+				09BE97F6BA133265DB078F8A /* NewGroupChatView.swift */,
 				B083A8885A5C0BDDEFCF5EAC /* QrScannerSheet.swift */,
 			);
 			path = Views;
@@ -191,6 +199,7 @@
 			);
 			name = Pika;
 			packageProductDependencies = (
+				653509E9220610E2699954CB /* MarkdownUI */,
 			);
 			productName = Pika;
 			productReference = F8FB9846E26624B7638DDA90 /* Pika.app */;
@@ -208,8 +217,6 @@
 				2D7897E510D89D22A02C8676 /* PBXTargetDependency */,
 			);
 			name = PikaUITests;
-			packageProductDependencies = (
-			);
 			productName = PikaUITests;
 			productReference = 4F340333EBF85C4097106B1C /* PikaUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -226,8 +233,6 @@
 				4D4482F0E5D02BD1919A8640 /* PBXTargetDependency */,
 			);
 			name = PikaTests;
-			packageProductDependencies = (
-			);
 			productName = PikaTests;
 			productReference = E366BE398C3E8FAA39A15A33 /* PikaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -255,8 +260,9 @@
 				en,
 			);
 			mainGroup = 4BBB9BACF657E4516B7350AD;
-			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
+			packageReferences = (
+				6944C0C3491C1AC429CFFC75 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
+			);
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -305,10 +311,12 @@
 				783CBC6C2A48969656021CD8 /* ChatListView.swift in Sources */,
 				5EA0CD4191E6688471F8FAB5 /* ChatView.swift in Sources */,
 				FE739725B724B1944145C8EF /* ContentView.swift in Sources */,
+				EEE2F54DC181C7C91E5F7848 /* GroupInfoView.swift in Sources */,
 				02D9A491B498E051D46EC648 /* KeychainNsecStore.swift in Sources */,
 				2A9B2872E6ADB03F5A8FA173 /* LoginView.swift in Sources */,
 				EDAE180A5D3FEED3C801658F /* MyNpubQrSheet.swift in Sources */,
 				970D12403533E203A33FBEFC /* NewChatView.swift in Sources */,
+				B5F90A17C2DF56BF2B42736E /* NewGroupChatView.swift in Sources */,
 				502171B59272A56AB36AECCF /* PeerKeyValidator.swift in Sources */,
 				F308786C219CC1D169ABFC50 /* PikaApp.swift in Sources */,
 				940959C521A572B47CCDC852 /* PreviewData.swift in Sources */,
@@ -338,65 +346,11 @@
 		27C4480534ED35A5AC0E9819 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"DEBUG=1",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 0.1.0;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.justinmoon.pika.dev;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -404,14 +358,6 @@
 		30829372611B0B0AC9B9996E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Pika;
 			};
 			name = Debug;
@@ -420,32 +366,18 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
 				);
 				INFOPLIST_FILE = Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
 		};
 		75EA72DF19BD41FA82284ADC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Pika;
 			};
 			name = Release;
@@ -453,14 +385,6 @@
 		A8BF38A644809A48AF3AAA5F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pika.app/Pika";
 			};
 			name = Debug;
@@ -468,58 +392,11 @@
 		BF2578637802091049530134 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 0.1.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.justinmoon.pika;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -528,32 +405,18 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
 				);
 				INFOPLIST_FILE = Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
 		};
 		D18F35409181D225BDE31F1A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pika.app/Pika";
 			};
 			name = Release;
@@ -598,6 +461,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		6944C0C3491C1AC429CFFC75 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		653509E9220610E2699954CB /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6944C0C3491C1AC429CFFC75 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = B1881FA49A49A0E38D54E33D /* Project object */;
 }

--- a/ios/Sources/PreviewData.swift
+++ b/ios/Sources/PreviewData.swift
@@ -177,6 +177,16 @@ enum PreviewAppState {
         )
     }
 
+    static var chatDetailGrouped: AppState {
+        base(
+            rev: 34,
+            router: Router(defaultScreen: .chat(chatId: "chat-grouped"), screenStack: [.chat(chatId: "chat-grouped")]),
+            auth: .loggedIn(npub: sampleNpub, pubkey: samplePubkey),
+            myProfile: sampleProfile,
+            currentChat: chatViewStateGrouped()
+        )
+    }
+
     static var toastVisible: AppState {
         base(
             rev: 40,
@@ -299,10 +309,117 @@ enum PreviewAppState {
         )
     }
 
+    private static func chatViewStateGrouped() -> ChatViewState {
+        let messages: [ChatMessage] = [
+            ChatMessage(
+                id: "gm1",
+                senderPubkey: samplePeerPubkey,
+                senderName: "Anthony",
+                content: "hello",
+                displayContent: "hello",
+                mentions: [],
+                timestamp: 1_709_001_000,
+                isMine: false,
+                delivery: .sent
+            ),
+            ChatMessage(
+                id: "gm2",
+                senderPubkey: samplePeerPubkey,
+                senderName: "Anthony",
+                content: "how are you",
+                displayContent: "how are you",
+                mentions: [],
+                timestamp: 1_709_001_005,
+                isMine: false,
+                delivery: .sent
+            ),
+            ChatMessage(
+                id: "gm3",
+                senderPubkey: samplePubkey,
+                senderName: nil,
+                content: "lmk when you are here and I will find you",
+                displayContent: "lmk when you are here and I will find you",
+                mentions: [],
+                timestamp: 1_709_001_020,
+                isMine: true,
+                delivery: .sent
+            ),
+            ChatMessage(
+                id: "gm4",
+                senderPubkey: samplePubkey,
+                senderName: nil,
+                content: "I am out by ana's market",
+                displayContent: "I am out by ana's market",
+                mentions: [],
+                timestamp: 1_709_001_030,
+                isMine: true,
+                delivery: .pending
+            ),
+            ChatMessage(
+                id: "gm5",
+                senderPubkey: sampleThirdPubkey,
+                senderName: "benthecarman",
+                content: "We got locked out",
+                displayContent: "We got locked out",
+                mentions: [],
+                timestamp: 1_709_001_040,
+                isMine: false,
+                delivery: .sent
+            ),
+            ChatMessage(
+                id: "gm6",
+                senderPubkey: sampleThirdPubkey,
+                senderName: "benthecarman",
+                content: "Nvm",
+                displayContent: "Nvm",
+                mentions: [],
+                timestamp: 1_709_001_045,
+                isMine: false,
+                delivery: .sent
+            ),
+            ChatMessage(
+                id: "gm7",
+                senderPubkey: samplePeerPubkey,
+                senderName: "Anthony",
+                content: "https://raw.githubusercontent.com/shabegom/buttons/refs/heads/main/README.md",
+                displayContent: "https://raw.githubusercontent.com/shabegom/buttons/refs/heads/main/README.md",
+                mentions: [],
+                timestamp: 1_709_001_080,
+                isMine: false,
+                delivery: .sent
+            ),
+        ]
+
+        return ChatViewState(
+            chatId: "chat-grouped",
+            isGroup: true,
+            groupName: "hackathon2",
+            members: [
+                MemberInfo(
+                    pubkey: samplePeerPubkey,
+                    npub: samplePeerNpub,
+                    name: "Anthony",
+                    pictureUrl: "https://blossom.nostr.pub/8dbc6f42ea8bf53f4af89af87eb0d9110fcaf4d263f7d2cb9f29d68f95f6f8ce"
+                ),
+                MemberInfo(
+                    pubkey: sampleThirdPubkey,
+                    npub: sampleThirdNpub,
+                    name: "benthecarman",
+                    pictureUrl: nil
+                ),
+            ],
+            isAdmin: true,
+            messages: messages,
+            canLoadOlder: true
+        )
+    }
+
     static let sampleNpub = "npub1zxu639qym0esxnn7rzrt48wycmfhdu3e5yvzwx7ja3t84zyc2r8qz8cx2y"
     static let samplePubkey = "11b9a894813efe60d39f8621ae9dc4c6d26de4732411c1cdf4bb15e88898a19c"
     static let samplePeerNpub = "npub1y2z0c7un9dwmhk4zrpw8df8p0gh0j2x54qhznwqjnp452ju4078srmwp70"
     static let samplePeerPubkey = "2284fc7b932b5dbbdaa2185c76a4e17a2ef928d4a82e29b812986b454b957f8f"
+    static let sampleThirdNpub = "npub1rtrxx9eyvag0ap3v73c4dvsqq5d2yxwe5d72qxrfpwe5svr96wuqed4p38"
+    static let sampleThirdPubkey = "1f7f5f6d64e8de7184f4ad14a2fdbef674e7dc86d51a0d65704fbfdbb6c42cb7"
     static let sampleProfile = MyProfileState(
         name: "Paul Miller",
         about: "Building Marmot over Nostr.",

--- a/rust/src/core/profile.rs
+++ b/rust/src/core/profile.rs
@@ -8,7 +8,7 @@ use crate::state::MyProfileState;
 use super::*;
 
 // TODO: Prefer user-advertised blossom servers (once we ingest and cache them from Nostr).
-const DEFAULT_BLOSSOM_SERVERS: &[&str] = &["https://blossom.nostr.pub", "https://void.cat"];
+const DEFAULT_BLOSSOM_SERVERS: &[&str] = &["https://blossom.yakihonne.com"];
 const MAX_PROFILE_IMAGE_BYTES: usize = 8 * 1024 * 1024;
 
 impl AppCore {
@@ -62,11 +62,6 @@ impl AppCore {
             self.toast("Network disabled");
             return;
         }
-        if self.my_metadata.is_none() {
-            self.refresh_my_profile(false);
-            self.toast("Profile still loading, try again in a moment");
-            return;
-        }
 
         let metadata = self.metadata_for_profile_edit(name, about);
         let (client, tx) = {
@@ -114,11 +109,6 @@ impl AppCore {
         }
         if !self.network_enabled() {
             self.toast("Network disabled");
-            return;
-        }
-        if self.my_metadata.is_none() {
-            self.refresh_my_profile(false);
-            self.toast("Profile still loading, try again in a moment");
             return;
         }
 

--- a/tools/run-ios
+++ b/tools/run-ios
@@ -296,9 +296,13 @@ fi
 
 just ios-build-sim
 
-app_path="ios/build/Debug-iphonesimulator/Pika.app"
+app_path="ios/build/Build/Products/Debug-iphonesimulator/Pika.app"
 if [ ! -d "$app_path" ]; then
-  echo "error: missing built app at $app_path" >&2
+  # Backward-compatible fallback for older local build layouts.
+  app_path="ios/build/Debug-iphonesimulator/Pika.app"
+fi
+if [ ! -d "$app_path" ]; then
+  echo "error: missing built app at ios/build/Build/Products/Debug-iphonesimulator/Pika.app" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- improve iOS chat rendering with grouped message bubbles and sender avatar gutter behavior
- add tiny in-bubble timestamps and left-align incoming message text
- improve profile sheet UX (copy buttons for npub/nsec with clearer tap behavior/feedback)
- remove Void.cat and hardcode profile image uploads to `https://blossom.yakihonne.com` with signed uploads
- include `run-ios` update for explicit simulator UDID targeting

## Testing
- cargo check -p pika_core
- ./tools/xcode-run xcodebuild -project ios/Pika.xcodeproj -scheme Pika -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO PRODUCT_BUNDLE_IDENTIFIER="${PIKA_IOS_BUNDLE_ID:-com.justinmoon.pika.dev}"
