### PR TITLE
fix: enable Designed for iPad on Mac

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -37,6 +37,7 @@ targets:
         PRODUCT_NAME: "$(TARGET_NAME)"
         INFOPLIST_FILE: Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: YES
     dependencies:
       - framework: Frameworks/PikaCore.xcframework
         embed: false


### PR DESCRIPTION
Adds `SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: YES` to the Pika target in `project.yml` so xcodegen includes the "My Mac (Designed for iPad)" destination.