### PR TITLE
feat: peer profile view with follow/unfollow

### DIFF
--- a/ios/Sources/ContentView.swift
+++ b/ios/Sources/ContentView.swift
@@ -127,8 +127,24 @@ private func screenView(manager: AppManager, state: AppState, screen: Screen) ->
             onSendMessage: { manager.dispatch(.sendMessage(chatId: chatId, content: $0)) },
             onGroupInfo: {
                 manager.dispatch(.pushScreen(screen: .groupInfo(chatId: chatId)))
+            },
+            onTapSender: { pubkey in
+                manager.dispatch(.openPeerProfile(pubkey: pubkey))
             }
         )
+        .sheet(isPresented: Binding(
+            get: { state.peerProfile != nil },
+            set: { if !$0 { manager.dispatch(.closePeerProfile) } }
+        )) {
+            if let profile = state.peerProfile {
+                PeerProfileSheet(
+                    profile: profile,
+                    onFollow: { manager.dispatch(.followUser(pubkey: profile.pubkey)) },
+                    onUnfollow: { manager.dispatch(.unfollowUser(pubkey: profile.pubkey)) },
+                    onClose: { manager.dispatch(.closePeerProfile) }
+                )
+            }
+        }
     case .groupInfo(let chatId):
         GroupInfoView(
             state: groupInfoState(from: state),
@@ -143,8 +159,24 @@ private func screenView(manager: AppManager, state: AppState, screen: Screen) ->
             },
             onRenameGroup: { name in
                 manager.dispatch(.renameGroup(chatId: chatId, name: name))
+            },
+            onTapMember: { pubkey in
+                manager.dispatch(.openPeerProfile(pubkey: pubkey))
             }
         )
+        .sheet(isPresented: Binding(
+            get: { state.peerProfile != nil },
+            set: { if !$0 { manager.dispatch(.closePeerProfile) } }
+        )) {
+            if let profile = state.peerProfile {
+                PeerProfileSheet(
+                    profile: profile,
+                    onFollow: { manager.dispatch(.followUser(pubkey: profile.pubkey)) },
+                    onUnfollow: { manager.dispatch(.unfollowUser(pubkey: profile.pubkey)) },
+                    onClose: { manager.dispatch(.closePeerProfile) }
+                )
+            }
+        }
     }
 }
 

--- a/ios/Sources/PreviewData.swift
+++ b/ios/Sources/PreviewData.swift
@@ -224,6 +224,7 @@ enum PreviewAppState {
             chatList: chatList,
             currentChat: currentChat,
             followList: followList,
+            peerProfile: nil,
             toast: toast
         )
     }

--- a/ios/Sources/Views/GroupInfoView.swift
+++ b/ios/Sources/Views/GroupInfoView.swift
@@ -7,6 +7,7 @@ struct GroupInfoView: View {
     let onRemoveMember: @MainActor (String) -> Void
     let onLeaveGroup: @MainActor () -> Void
     let onRenameGroup: @MainActor (String) -> Void
+    let onTapMember: (@MainActor (String) -> Void)?
     @State private var npubInput = ""
     @State private var showScanner = false
     @State private var isEditing = false
@@ -58,26 +59,31 @@ struct GroupInfoView: View {
                     }
 
                     ForEach(chat.members, id: \.pubkey) { member in
-                        HStack(spacing: 8) {
-                            AvatarView(
-                                name: member.name,
-                                npub: member.npub,
-                                pictureUrl: member.pictureUrl,
-                                size: 28
-                            )
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text(member.name ?? truncated(member.npub))
-                                    .font(.body)
-                                    .lineLimit(1)
-                                if member.name != nil {
-                                    Text(truncated(member.npub))
-                                        .font(.caption2)
-                                        .foregroundStyle(.tertiary)
+                        Button {
+                            onTapMember?(member.pubkey)
+                        } label: {
+                            HStack(spacing: 8) {
+                                AvatarView(
+                                    name: member.name,
+                                    npub: member.npub,
+                                    pictureUrl: member.pictureUrl,
+                                    size: 28
+                                )
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(member.name ?? truncated(member.npub))
+                                        .font(.body)
                                         .lineLimit(1)
+                                    if member.name != nil {
+                                        Text(truncated(member.npub))
+                                            .font(.caption2)
+                                            .foregroundStyle(.tertiary)
+                                            .lineLimit(1)
+                                    }
                                 }
+                                Spacer()
                             }
-                            Spacer()
                         }
+                        .buttonStyle(.plain)
                         .swipeActions(edge: .trailing) {
                             if chat.isAdmin {
                                 Button(role: .destructive) {
@@ -150,7 +156,8 @@ struct GroupInfoView: View {
             onAddMembers: { _ in },
             onRemoveMember: { _ in },
             onLeaveGroup: {},
-            onRenameGroup: { _ in }
+            onRenameGroup: { _ in },
+            onTapMember: nil
         )
     }
 }

--- a/ios/Sources/Views/PeerProfileSheet.swift
+++ b/ios/Sources/Views/PeerProfileSheet.swift
@@ -1,0 +1,164 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+import UIKit
+
+struct PeerProfileSheet: View {
+    let profile: PeerProfileState
+    let onFollow: @MainActor () -> Void
+    let onUnfollow: @MainActor () -> Void
+    let onClose: @MainActor () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var didCopyNpub = false
+    @State private var copyResetTask: Task<Void, Never>?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                avatarSection
+                nameSection
+                npubSection
+                qrSection
+                followSection
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Profile")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Close") {
+                        onClose()
+                        dismiss()
+                    }
+                }
+            }
+            .onDisappear {
+                copyResetTask?.cancel()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var avatarSection: some View {
+        Section {
+            VStack(spacing: 8) {
+                AvatarView(
+                    name: profile.name,
+                    npub: profile.npub,
+                    pictureUrl: profile.pictureUrl,
+                    size: 96
+                )
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 6)
+        }
+    }
+
+    @ViewBuilder
+    private var nameSection: some View {
+        if profile.name != nil || profile.about != nil {
+            Section("Profile") {
+                if let name = profile.name {
+                    HStack {
+                        Text("Name")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(name)
+                    }
+                }
+                if let about = profile.about {
+                    Text(about)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var npubSection: some View {
+        Section {
+            HStack(alignment: .center, spacing: 12) {
+                Text(profile.npub)
+                    .font(.system(.footnote, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer()
+
+                HStack(spacing: 8) {
+                    if didCopyNpub {
+                        Text("Copied")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.green)
+                    }
+                    Button {
+                        UIPasteboard.general.string = profile.npub
+                        didCopyNpub = true
+                        copyResetTask?.cancel()
+                        copyResetTask = Task { @MainActor in
+                            try? await Task.sleep(nanoseconds: 1_200_000_000)
+                            didCopyNpub = false
+                        }
+                    } label: {
+                        Image(systemName: didCopyNpub ? "checkmark.circle.fill" : "doc.on.doc")
+                            .font(.body.weight(.semibold))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+                .animation(.easeInOut(duration: 0.15), value: didCopyNpub)
+            }
+        } header: {
+            Text("Public Key")
+        }
+    }
+
+    @ViewBuilder
+    private var qrSection: some View {
+        Section("QR Code") {
+            if let img = qrImage(from: profile.npub) {
+                HStack {
+                    Spacer()
+                    Image(uiImage: img)
+                        .interpolation(.none)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 220, height: 220)
+                        .background(.white)
+                        .clipShape(.rect(cornerRadius: 12))
+                    Spacer()
+                }
+            } else {
+                Text("Could not generate QR code.")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var followSection: some View {
+        Section {
+            if profile.isFollowed {
+                Button("Unfollow", role: .destructive) {
+                    onUnfollow()
+                }
+            } else {
+                Button("Follow") {
+                    onFollow()
+                }
+            }
+        }
+    }
+
+    private func qrImage(from text: String) -> UIImage? {
+        let data = Data(text.utf8)
+        let filter = CIFilter.qrCodeGenerator()
+        filter.setValue(data, forKey: "inputMessage")
+        guard var output = filter.outputImage else { return nil }
+        output = output.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+        let ctx = CIContext()
+        guard let cg = ctx.createCGImage(output, from: output.extent) else { return nil }
+        return UIImage(cgImage: cg)
+    }
+}

--- a/rust/src/actions.rs
+++ b/rust/src/actions.rs
@@ -77,8 +77,20 @@ pub enum AppAction {
     // Lifecycle
     Foregrounded,
 
+    // Peer profile
+    OpenPeerProfile {
+        pubkey: String,
+    },
+    ClosePeerProfile,
+
     // Follow list
     RefreshFollowList,
+    FollowUser {
+        pubkey: String,
+    },
+    UnfollowUser {
+        pubkey: String,
+    },
 }
 
 impl AppAction {
@@ -118,8 +130,14 @@ impl AppAction {
             // Lifecycle
             AppAction::Foregrounded => "Foregrounded",
 
+            // Peer profile
+            AppAction::OpenPeerProfile { .. } => "OpenPeerProfile",
+            AppAction::ClosePeerProfile => "ClosePeerProfile",
+
             // Follow list
             AppAction::RefreshFollowList => "RefreshFollowList",
+            AppAction::FollowUser { .. } => "FollowUser",
+            AppAction::UnfollowUser { .. } => "UnfollowUser",
         }
     }
 }

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -8,6 +8,7 @@ pub struct AppState {
     pub chat_list: Vec<ChatSummary>,
     pub current_chat: Option<ChatViewState>,
     pub follow_list: Vec<FollowListEntry>,
+    pub peer_profile: Option<PeerProfileState>,
     pub toast: Option<String>,
 }
 
@@ -25,6 +26,7 @@ impl AppState {
             chat_list: vec![],
             current_chat: None,
             follow_list: vec![],
+            peer_profile: None,
             toast: None,
         }
     }
@@ -94,6 +96,16 @@ pub struct MemberInfo {
     pub npub: String,
     pub name: Option<String>,
     pub picture_url: Option<String>,
+}
+
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct PeerProfileState {
+    pub pubkey: String,
+    pub npub: String,
+    pub name: Option<String>,
+    pub about: Option<String>,
+    pub picture_url: Option<String>,
+    pub is_followed: bool,
 }
 
 #[derive(uniffi::Record, Clone, Debug)]

--- a/rust/src/updates.rs
+++ b/rust/src/updates.rs
@@ -110,4 +110,18 @@ pub enum InternalEvent {
     FollowListFetched {
         entries: Vec<(String, Option<String>, Option<String>)>, // (hex_pubkey, name, picture_url)
     },
+
+    // Peer profile fetch result
+    PeerProfileFetched {
+        pubkey: String,
+        name: Option<String>,
+        about: Option<String>,
+        picture_url: Option<String>,
+    },
+
+    // Contact list modification result
+    ContactListModifyFailed {
+        pubkey: String,
+        revert_to: bool, // revert is_followed to this value
+    },
 }


### PR DESCRIPTION
## What

Tap any user's avatar or name to view their profile and follow/unfollow them.

### Tappable locations
- **Chat view**: sender avatar + name (group chats)
- **1:1 chat nav bar**: avatar + name centered in toolbar
- **Group info**: member list rows

Existing functional taps (chat list rows, follow list in new chat/group creation) are not overridden.

### Profile sheet shows
- Avatar, name, about
- npub with copy button
- QR code
- Follow / Unfollow button

### Safety
Contact list modification (kind 3) always fetches the **latest** version from relays before adding/removing a `p` tag. If the fetch or publish fails, the UI reverts the optimistic update and shows an error toast. This prevents accidentally wiping the user's follow list with stale data.

The follow list is also refreshed when opening a peer profile to ensure the follow status is accurate even right after app restart.