### PR TITLE
feat: archive chats to hide from chat list

### DIFF
--- a/ios/Sources/ContentView.swift
+++ b/ios/Sources/ContentView.swift
@@ -95,6 +95,7 @@ private func screenView(manager: AppManager, state: AppState, screen: Screen) ->
             state: chatListState(from: state),
             onLogout: { manager.logout() },
             onOpenChat: { manager.dispatch(.openChat(chatId: $0)) },
+            onArchiveChat: { manager.dispatch(.archiveChat(chatId: $0)) },
             onNewChat: { manager.dispatch(.pushScreen(screen: .newChat)) },
             onNewGroupChat: { manager.dispatch(.pushScreen(screen: .newGroupChat)) },
             onRefreshProfile: { manager.refreshMyProfile() },

--- a/ios/Sources/Views/ChatListView.swift
+++ b/ios/Sources/Views/ChatListView.swift
@@ -5,6 +5,7 @@ struct ChatListView: View {
     let state: ChatListViewState
     let onLogout: @MainActor () -> Void
     let onOpenChat: @MainActor (String) -> Void
+    let onArchiveChat: @MainActor (String) -> Void
     let onNewChat: @MainActor () -> Void
     let onNewGroupChat: @MainActor () -> Void
     let onRefreshProfile: @MainActor () -> Void
@@ -59,6 +60,14 @@ struct ChatListView: View {
                 }
             }
             .buttonStyle(.plain)
+            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                Button(role: .destructive) {
+                    onArchiveChat(chat.chatId)
+                } label: {
+                    Label("Archive", systemImage: "archivebox")
+                }
+                .tint(.orange)
+            }
         }
         .navigationTitle("Chats")
         .toolbar {
@@ -156,6 +165,7 @@ struct ChatListView: View {
             ),
             onLogout: {},
             onOpenChat: { _ in },
+            onArchiveChat: { _ in },
             onNewChat: {},
             onNewGroupChat: {},
             onRefreshProfile: {},
@@ -176,6 +186,7 @@ struct ChatListView: View {
             ),
             onLogout: {},
             onOpenChat: { _ in },
+            onArchiveChat: { _ in },
             onNewChat: {},
             onNewGroupChat: {},
             onRefreshProfile: {},
@@ -196,6 +207,7 @@ struct ChatListView: View {
             ),
             onLogout: {},
             onOpenChat: { _ in },
+            onArchiveChat: { _ in },
             onNewChat: {},
             onNewGroupChat: {},
             onRefreshProfile: {},

--- a/rust/src/actions.rs
+++ b/rust/src/actions.rs
@@ -71,6 +71,11 @@ pub enum AppAction {
         name: String,
     },
 
+    // Chat management
+    ArchiveChat {
+        chat_id: String,
+    },
+
     // UI
     ClearToast,
 
@@ -123,6 +128,9 @@ impl AppAction {
             AppAction::RemoveGroupMembers { .. } => "RemoveGroupMembers",
             AppAction::LeaveGroup { .. } => "LeaveGroup",
             AppAction::RenameGroup { .. } => "RenameGroup",
+
+            // Chat management
+            AppAction::ArchiveChat { .. } => "ArchiveChat",
 
             // UI
             AppAction::ClearToast => "ClearToast",

--- a/rust/src/core/session.rs
+++ b/rust/src/core/session.rs
@@ -58,6 +58,7 @@ impl AppCore {
             self.start_notifications_loop();
         }
 
+        self.load_archived_chats();
         self.refresh_all_from_storage();
         self.refresh_my_profile(false);
         self.refresh_follow_list();

--- a/rust/src/core/storage.rs
+++ b/rust/src/core/storage.rs
@@ -37,6 +37,10 @@ impl AppCore {
         for g in groups {
             let chat_id = hex::encode(g.nostr_group_id);
 
+            if self.archived_chats.contains(&chat_id) {
+                continue;
+            }
+
             // Get all members except self.
             let all_members: BTreeSet<PublicKey> =
                 sess.mdk.get_members(&g.mls_group_id).unwrap_or_default();


### PR DESCRIPTION
Swipe left on any chat row to archive it. The chat disappears from the list but all data stays intact in MDK -- no deletion, no MDK API needed.

Archived chat IDs are persisted to `archived_chats.json` in the data dir so they survive app restarts. To "reset" a broken 1:1 MLS session, archive the old chat and start a fresh one with the same person.

Partial workaround for #60 (full delete blocked on MDK exposing a `delete_group()` API, tracked in #68).