### PR TITLE
feat: updatable pika-html WebViews via application-level IDs

### DIFF
--- a/android/app/src/main/java/com/pika/app/ui/screens/ChatScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/ChatScreen.kt
@@ -168,8 +168,11 @@ private fun parseMessageSegments(content: String): List<MessageSegment> {
                     segments.add(MessageSegment.Markdown("```$blockType\n$blockBody\n```"))
                 }
             }
-            "html", "html-update" -> {
+            "html" -> {
                 segments.add(MessageSegment.PikaHtml(blockBody))
+            }
+            "html-update", "prompt-response" -> {
+                // Consumed by Rust core; silently drop if one slips through.
             }
             else -> {
                 segments.add(MessageSegment.Markdown("```$blockType\n$blockBody\n```"))

--- a/ios/Sources/Views/ChatView.swift
+++ b/ios/Sources/Views/ChatView.swift
@@ -347,8 +347,10 @@ private func parseMessageSegments(_ content: String) -> [MessageSegment] {
                let prompt = try? JSONDecoder().decode(PikaPrompt.self, from: data) {
                 segments.append(.pikaPrompt(prompt))
             }
-        case "html", "html-update":
+        case "html":
             segments.append(.pikaHtml(blockBody))
+        case "html-update", "prompt-response":
+            break // Consumed by Rust core; silently drop if one slips through.
         default:
             segments.append(.markdown("```\(blockType)\n\(blockBody)\n```"))
         }


### PR DESCRIPTION
Adds pika-html-update wire format so the bot can update an existing WebView in-place instead of sending a new message. The Rust core merges updates into originals and strips update messages before the UI sees them, following the same pattern as pika-prompt-response/poll tallies.