### PR TITLE
feat: emoji reactions on messages

### DIFF
--- a/ios/Pika.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Pika.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "04d9e4d8045a6310349928a2f8d2e6c6fe1c41e0c952a800e312800fac9624f9",
+  "pins" : [
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "55441810c0f678c78ed7e2ebd46dde89228e02fc",
+        "version" : "2.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/Sources/ContentView.swift
+++ b/ios/Sources/ContentView.swift
@@ -131,6 +131,9 @@ private func screenView(manager: AppManager, state: AppState, screen: Screen) ->
             },
             onTapSender: { pubkey in
                 manager.dispatch(.openPeerProfile(pubkey: pubkey))
+            },
+            onReact: { messageId, emoji in
+                manager.dispatch(.reactToMessage(chatId: chatId, messageId: messageId, emoji: emoji))
             }
         )
         .sheet(isPresented: Binding(

--- a/ios/Sources/PreviewData.swift
+++ b/ios/Sources/PreviewData.swift
@@ -253,6 +253,7 @@ enum PreviewAppState {
                 timestamp: 1_709_000_001,
                 isMine: true,
                 delivery: .sent,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),
@@ -266,6 +267,7 @@ enum PreviewAppState {
                 timestamp: 1_709_000_050,
                 isMine: false,
                 delivery: .sent,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),
@@ -279,6 +281,7 @@ enum PreviewAppState {
                 timestamp: 1_709_000_100,
                 isMine: true,
                 delivery: failed ? .failed(reason: "Network timeout") : .pending,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),
@@ -310,6 +313,7 @@ enum PreviewAppState {
                 timestamp: Int64(1_709_000_200 + idx),
                 isMine: idx.isMultiple(of: 2),
                 delivery: .sent,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             )
@@ -338,6 +342,7 @@ enum PreviewAppState {
                 timestamp: 1_709_001_000,
                 isMine: false,
                 delivery: .sent,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),
@@ -351,6 +356,7 @@ enum PreviewAppState {
                 timestamp: 1_709_001_005,
                 isMine: false,
                 delivery: .sent,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),
@@ -364,6 +370,7 @@ enum PreviewAppState {
                 timestamp: 1_709_001_020,
                 isMine: true,
                 delivery: .sent,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),
@@ -377,6 +384,7 @@ enum PreviewAppState {
                 timestamp: 1_709_001_030,
                 isMine: true,
                 delivery: .pending,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),
@@ -390,6 +398,7 @@ enum PreviewAppState {
                 timestamp: 1_709_001_040,
                 isMine: false,
                 delivery: .sent,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),
@@ -403,6 +412,7 @@ enum PreviewAppState {
                 timestamp: 1_709_001_045,
                 isMine: false,
                 delivery: .sent,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),
@@ -416,6 +426,7 @@ enum PreviewAppState {
                 timestamp: 1_709_001_080,
                 isMine: false,
                 delivery: .sent,
+                reactions: [],
                 pollTally: [],
                 myPollVote: nil
             ),

--- a/rust/src/actions.rs
+++ b/rust/src/actions.rs
@@ -75,6 +75,11 @@ pub enum AppAction {
     ArchiveChat {
         chat_id: String,
     },
+    ReactToMessage {
+        chat_id: String,
+        message_id: String,
+        emoji: String,
+    },
 
     // UI
     ClearToast,
@@ -131,6 +136,7 @@ impl AppAction {
 
             // Chat management
             AppAction::ArchiveChat { .. } => "ArchiveChat",
+            AppAction::ReactToMessage { .. } => "ReactToMessage",
 
             // UI
             AppAction::ClearToast => "ClearToast",

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -156,8 +156,16 @@ pub struct ChatMessage {
     pub timestamp: i64,
     pub is_mine: bool,
     pub delivery: MessageDeliveryState,
+    pub reactions: Vec<ReactionSummary>,
     pub poll_tally: Vec<PollTally>,
     pub my_poll_vote: Option<String>,
+}
+
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct ReactionSummary {
+    pub emoji: String,
+    pub count: u32,
+    pub reacted_by_me: bool,
 }
 
 #[derive(uniffi::Record, Clone, Debug)]


### PR DESCRIPTION
## Summary

Adds emoji reactions to messages, Signal-style.

### Rust
- `ReactToMessage` action sends `kind 7` rumor (NIP-25) through existing MLS `create_message` pipeline
- Reactions reference target message via `e` tag, content is the emoji
- `refresh_current_chat` separates kind 7 from regular messages, aggregates into `ReactionSummary` (emoji, count, reacted_by_me) on each `ChatMessage`
- Fire-and-forget publishing (same as regular messages)

### iOS
- Long-press message shows floating emoji bar (frosted glass capsule) with 6 quick emojis + "+" button
- "+" opens full emoji picker sheet with categories and search
- Reaction chips overlay bottom corner of bubble (bottom-left for outgoing, bottom-right for incoming)
- Solid dark pill background with system-background border stroke
- Tapping a chip sends another reaction of that emoji
- Haptic feedback on long press

Closes #76