### PR TITLE
feat: persistent WebViews with JS state injection via pika-html-state-update

### DIFF
--- a/ios/Sources/PreviewData.swift
+++ b/ios/Sources/PreviewData.swift
@@ -255,7 +255,8 @@ enum PreviewAppState {
                 delivery: .sent,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
             ChatMessage(
                 id: "m2",
@@ -269,7 +270,8 @@ enum PreviewAppState {
                 delivery: .sent,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
             ChatMessage(
                 id: "m3",
@@ -283,7 +285,8 @@ enum PreviewAppState {
                 delivery: failed ? .failed(reason: "Network timeout") : .pending,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
         ]
 
@@ -315,7 +318,8 @@ enum PreviewAppState {
                 delivery: .sent,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             )
         }
 
@@ -344,7 +348,8 @@ enum PreviewAppState {
                 delivery: .sent,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
             ChatMessage(
                 id: "gm2",
@@ -358,7 +363,8 @@ enum PreviewAppState {
                 delivery: .sent,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
             ChatMessage(
                 id: "gm3",
@@ -372,7 +378,8 @@ enum PreviewAppState {
                 delivery: .sent,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
             ChatMessage(
                 id: "gm4",
@@ -386,7 +393,8 @@ enum PreviewAppState {
                 delivery: .pending,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
             ChatMessage(
                 id: "gm5",
@@ -400,7 +408,8 @@ enum PreviewAppState {
                 delivery: .sent,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
             ChatMessage(
                 id: "gm6",
@@ -414,7 +423,8 @@ enum PreviewAppState {
                 delivery: .sent,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
             ChatMessage(
                 id: "gm7",
@@ -428,7 +438,8 @@ enum PreviewAppState {
                 delivery: .sent,
                 reactions: [],
                 pollTally: [],
-                myPollVote: nil
+                myPollVote: nil,
+                htmlState: nil
             ),
         ]
 

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -159,6 +159,7 @@ pub struct ChatMessage {
     pub reactions: Vec<ReactionSummary>,
     pub poll_tally: Vec<PollTally>,
     pub my_poll_vote: Option<String>,
+    pub html_state: Option<String>,
 }
 
 #[derive(uniffi::Record, Clone, Debug)]


### PR DESCRIPTION
Add a new `pika-html-state-update` wire format that calls `window.pikaState(body)` on live WebViews without reloading them. The existing `pika-html-update` (full HTML replacement) behavior is unchanged.

Rust core: add `html_state` field to ChatMessage, parse and process `pika-html-state-update` blocks alongside existing html-update processing. iOS: stable segment IDs based on pika-html ID so SwiftUI reuses WebViews, state injection in `updateUIView` and `didFinish` for pending state.