### PR TITLE
iOS: polish long-press message context overlay

### DIFF
--- a/ios/Bindings/pika_core.swift
+++ b/ios/Bindings/pika_core.swift
@@ -841,10 +841,11 @@ public struct ChatMessage: Equatable, Hashable {
     public var reactions: [ReactionSummary]
     public var pollTally: [PollTally]
     public var myPollVote: String?
+    public var htmlState: String?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(id: String, senderPubkey: String, senderName: String?, content: String, displayContent: String, mentions: [Mention], timestamp: Int64, isMine: Bool, delivery: MessageDeliveryState, reactions: [ReactionSummary], pollTally: [PollTally], myPollVote: String?) {
+    public init(id: String, senderPubkey: String, senderName: String?, content: String, displayContent: String, mentions: [Mention], timestamp: Int64, isMine: Bool, delivery: MessageDeliveryState, reactions: [ReactionSummary], pollTally: [PollTally], myPollVote: String?, htmlState: String?) {
         self.id = id
         self.senderPubkey = senderPubkey
         self.senderName = senderName
@@ -857,6 +858,7 @@ public struct ChatMessage: Equatable, Hashable {
         self.reactions = reactions
         self.pollTally = pollTally
         self.myPollVote = myPollVote
+        self.htmlState = htmlState
     }
 
     
@@ -886,7 +888,8 @@ public struct FfiConverterTypeChatMessage: FfiConverterRustBuffer {
                 delivery: FfiConverterTypeMessageDeliveryState.read(from: &buf), 
                 reactions: FfiConverterSequenceTypeReactionSummary.read(from: &buf), 
                 pollTally: FfiConverterSequenceTypePollTally.read(from: &buf), 
-                myPollVote: FfiConverterOptionString.read(from: &buf)
+                myPollVote: FfiConverterOptionString.read(from: &buf), 
+                htmlState: FfiConverterOptionString.read(from: &buf)
         )
     }
 
@@ -903,6 +906,7 @@ public struct FfiConverterTypeChatMessage: FfiConverterRustBuffer {
         FfiConverterSequenceTypeReactionSummary.write(value.reactions, into: &buf)
         FfiConverterSequenceTypePollTally.write(value.pollTally, into: &buf)
         FfiConverterOptionString.write(value.myPollVote, into: &buf)
+        FfiConverterOptionString.write(value.htmlState, into: &buf)
     }
 }
 

--- a/ios/Sources/TestIds.swift
+++ b/ios/Sources/TestIds.swift
@@ -36,6 +36,9 @@ enum TestIds {
     static let chatMessageInput = "chat_message_input"
     static let chatSend = "chat_send"
     static let chatGroupInfo = "chat_group_info"
+    static let chatReactionBar = "chat_reaction_bar"
+    static let chatActionCard = "chat_action_card"
+    static let chatActionCopy = "chat_action_copy"
 
     // Group info
     static let groupInfoAddNpub = "groupinfo_add_npub"


### PR DESCRIPTION
## Summary
- replace per-bubble long-press reactions with a focused overlay flow that blurs the full chat UI and isolates the selected message
- keep a lightweight action card with only `Copy` (with TODO marker for future Reply/Forward/Info actions)
- remove debug-info action UI and wire outside-tap dismissal
- tune focused message presentation:
  - stronger background blur while overlay is active
  - no translucent incoming note background in the focused card
  - short notes use natural height, long notes cap and scroll
- add UI-test hooks and a UI test that validates long-press, action visibility, and outside-tap dismissal

## Files
- `ios/Sources/Views/ChatView.swift`
- `ios/Sources/TestIds.swift`
- `ios/UITests/PikaUITests.swift`
- `ios/Bindings/pika_core.swift` (generated binding update for `ChatMessage.htmlState`)

## Validation
- `just ios-build-sim`
