### PR TITLE
fix(openclaw-marmot): use sledtools/pika as default sidecar repo

### DIFF
--- a/openclaw-marmot/openclaw/extensions/marmot/src/sidecar-install.ts
+++ b/openclaw-marmot/openclaw/extensions/marmot/src/sidecar-install.ts
@@ -23,7 +23,7 @@ type GitHubRelease = {
 };
 
 // marmotd is built and released from this monorepo.
-const DEFAULT_REPO = "justinmoon/pika";
+const DEFAULT_REPO = "sledtools/pika";
 const DEFAULT_BINARY_NAME = "marmotd";
 
 function hasPathSeparator(input: string): boolean {


### PR DESCRIPTION
The `DEFAULT_REPO` for marmotd sidecar binary downloads in `sidecar-install.ts` was set to `justinmoon/pika` instead of the canonical `sledtools/pika`.

This works today because both repos have the same releases, but will break if releases stop being mirrored to the personal repo.

One-line fix: `justinmoon/pika` → `sledtools/pika`

The `MARMOT_SIDECAR_REPO` env var override still works as a fallback.

Fixes #86