### PR TITLE
ci: build x86_64 linux on ubuntu-22.04 for broader glibc compat

### DIFF
--- a/.github/workflows/marmotd-release.yml
+++ b/.github/workflows/marmotd-release.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             asset_name: marmotd-x86_64-linux
-            runner: ubuntu-24.04
+            runner: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
             asset_name: marmotd-aarch64-linux
             runner: ubuntu-24.04-arm


### PR DESCRIPTION
The prebuilt x86_64 linux binary currently requires GLIBC 2.38+ (from ubuntu-24.04), which means it doesn't run on Ubuntu 22.04 or other distros with older glibc.

Building on ubuntu-22.04 (GLIBC 2.35) produces a binary that works on 22.04+ and any distro with glibc >= 2.35, with no downsides.

Only changes x86_64 — leaves aarch64 on ubuntu-24.04-arm as-is.