### PR TITLE
fix(android): resolve 16 KB native page-size compatibility warning

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -102,10 +102,10 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material-icons-extended")
 
-    implementation("androidx.camera:camera-camera2:1.3.4")
-    implementation("androidx.camera:camera-lifecycle:1.3.4")
-    implementation("androidx.camera:camera-view:1.3.4")
-    implementation("com.google.mlkit:barcode-scanning:17.2.0")
+    implementation("androidx.camera:camera-camera2:1.4.2")
+    implementation("androidx.camera:camera-lifecycle:1.4.2")
+    implementation("androidx.camera:camera-view:1.4.2")
+    implementation("com.google.mlkit:barcode-scanning:17.3.0")
 
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     // Required for Android 16+ compatibility: Espresso 3.7.0 removes reflective
@@ -121,7 +121,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 
     // UniFFI Kotlin bindings default to JNA.
-    implementation("net.java.dev.jna:jna:5.14.0@aar")
+    implementation("net.java.dev.jna:jna:5.18.1@aar")
 
     // Markdown rendering in Compose
     implementation("com.github.jeziellago:compose-markdown:0.5.4")


### PR DESCRIPTION
## Summary
- update CameraX from 1.3.4 to 1.4.2
- update ML Kit barcode-scanning from 17.2.0 to 17.3.0
- update JNA from 5.14.0 to 5.18.1

## Why
Android warned that packaged arm64 native libraries were not 16 KB page-size compatible. This affected release packaging as well as debug.

## Verification
- `cd android && ./gradlew :app:assembleDebug :app:assembleRelease`
- `zipalign -c -P 16 4` passes for both debug/release APKs
- arm64 ELF `LOAD` segment alignment is now `0x4000` for packaged `.so` libs
