### PR TITLE
fix: remove ad-hoc key package encoding validation from pika

### DIFF
--- a/rust/src/bin/kp_debug.rs
+++ b/rust/src/bin/kp_debug.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
-use base64::Engine as _;
 use mdk_core::MDK;
 use mdk_sqlite_storage::MdkSqliteStorage;
 use nostr_sdk::prelude::*;
@@ -118,22 +117,7 @@ fn fmt_res<T, E: std::fmt::Display>(r: &std::result::Result<T, E>) -> String {
 fn normalize_peer_key_package_event_for_mdk(event: &Event) -> Event {
     let mut out = event.clone();
 
-    let content_is_hex = {
-        let s = out.content.trim();
-        !s.is_empty() && s.len().is_multiple_of(2) && s.bytes().all(|b| b.is_ascii_hexdigit())
-    };
-
-    let mut encoding_value: Option<String> = None;
-    for t in out.tags.iter() {
-        if t.kind() == TagKind::Custom("encoding".into()) {
-            if let Some(v) = t.as_slice().get(1) {
-                encoding_value = Some(v.to_string());
-            }
-        }
-    }
-
     let mut tags: Vec<Tag> = Vec::new();
-    let mut saw_encoding = false;
     for t in out.tags.iter() {
         let kind = t.kind();
         if kind == TagKind::MlsProtocolVersion {
@@ -150,26 +134,7 @@ fn normalize_peer_key_package_event_for_mdk(event: &Event) -> Event {
                 continue;
             }
         }
-        if kind == TagKind::Custom("encoding".into()) {
-            saw_encoding = true;
-            tags.push(t.clone());
-            continue;
-        }
         tags.push(t.clone());
-    }
-
-    let encoding_is_hex = encoding_value
-        .as_deref()
-        .map(|s| s.eq_ignore_ascii_case("hex"))
-        .unwrap_or(false);
-    if encoding_is_hex || (!saw_encoding && content_is_hex) {
-        if let Ok(bytes) = hex::decode(out.content.trim()) {
-            out.content = base64::engine::general_purpose::STANDARD.encode(bytes);
-            tags.retain(|t| t.kind() != TagKind::Custom("encoding".into()));
-            tags.push(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]));
-        }
-    } else if !saw_encoding {
-        tags.push(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]));
     }
 
     out.tags = tags.into_iter().collect();

--- a/rust/src/core/interop.rs
+++ b/rust/src/core/interop.rs
@@ -1,4 +1,3 @@
-use base64::Engine as _;
 use nostr_sdk::prelude::*;
 
 pub(super) fn extract_relays_from_key_package_event(event: &Event) -> Option<Vec<RelayUrl>> {
@@ -34,33 +33,19 @@ pub(super) fn extract_relays_from_key_package_relays_event(event: &Event) -> Vec
     out
 }
 
-// Best-effort compatibility for peers publishing legacy/interop keypackages:
+// Best-effort tag normalization for peers publishing legacy/interop keypackages:
 // - protocol version "1" instead of "1.0"
 // - ciphersuite "1" instead of "0x0001"
-// - missing encoding tag + hex-encoded content instead of base64
+//
+// Encoding validation (MIP-00: encoding tag MUST be "base64", hex MUST be
+// rejected) is handled by MDK's parse_key_package() — not duplicated here.
 //
 // This does NOT re-sign the event; MDK doesn't require Nostr signature verification for
 // keypackage parsing, but it does validate the credential identity matches `event.pubkey`.
 pub(super) fn normalize_peer_key_package_event_for_mdk(event: &Event) -> Event {
     let mut out = event.clone();
 
-    // Determine if content looks like hex. Some interop stacks omit the encoding tag and use hex.
-    let content_is_hex = {
-        let s = out.content.trim();
-        !s.is_empty() && s.len().is_multiple_of(2) && s.bytes().all(|b| b.is_ascii_hexdigit())
-    };
-
-    let mut encoding_value: Option<String> = None;
-    for t in out.tags.iter() {
-        if t.kind() == TagKind::Custom("encoding".into()) {
-            if let Some(v) = t.as_slice().get(1) {
-                encoding_value = Some(v.to_string());
-            }
-        }
-    }
-
     let mut tags: Vec<Tag> = Vec::new();
-    let mut saw_encoding = false;
     for t in out.tags.iter() {
         let kind = t.kind();
         if kind == TagKind::MlsProtocolVersion {
@@ -77,33 +62,7 @@ pub(super) fn normalize_peer_key_package_event_for_mdk(event: &Event) -> Event {
                 continue;
             }
         }
-        if kind == TagKind::Custom("encoding".into()) {
-            saw_encoding = true;
-            // We'll rewrite to base64 if we convert from hex below.
-            // Otherwise keep the original tag.
-            tags.push(t.clone());
-            continue;
-        }
         tags.push(t.clone());
-    }
-
-    // Convert legacy hex -> base64 and force encoding tag.
-    // Prefer explicit encoding=hex, but also accept missing encoding when content looks hex.
-    let encoding_is_hex = encoding_value
-        .as_deref()
-        .map(|s| s.eq_ignore_ascii_case("hex"))
-        .unwrap_or(false);
-    if encoding_is_hex || (!saw_encoding && content_is_hex) {
-        if let Ok(bytes) = hex::decode(out.content.trim()) {
-            out.content = base64::engine::general_purpose::STANDARD.encode(bytes);
-
-            // Replace/insert encoding tag to base64.
-            tags.retain(|t| t.kind() != TagKind::Custom("encoding".into()));
-            tags.push(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]));
-        }
-    } else if !saw_encoding {
-        // MDK requires an explicit encoding tag; default to base64 for modern clients.
-        tags.push(Tag::custom(TagKind::Custom("encoding".into()), ["base64"]));
     }
 
     out.tags = tags.into_iter().collect();
@@ -116,4 +75,97 @@ pub(super) fn referenced_key_package_event_id(rumor: &UnsignedEvent) -> Option<E
         .find(TagKind::e())
         .and_then(|t| t.content())
         .and_then(|s| EventId::from_hex(s).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a signed kind-443 event with the given tags and content.
+    fn make_kp_event(content: &str, extra_tags: Vec<Tag>) -> Event {
+        let keys = Keys::generate();
+        let mut tags = vec![
+            Tag::custom(TagKind::MlsProtocolVersion, ["1.0"]),
+            Tag::custom(TagKind::MlsCiphersuite, ["0x0001"]),
+        ];
+        tags.extend(extra_tags);
+        EventBuilder::new(Kind::MlsKeyPackage, content)
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .expect("sign")
+    }
+
+    #[test]
+    fn passes_through_valid_event_unchanged() {
+        let ev = make_kp_event(
+            "AQID",
+            vec![Tag::custom(TagKind::Custom("encoding".into()), ["base64"])],
+        );
+        let normalized = normalize_peer_key_package_event_for_mdk(&ev);
+        // Tags preserved as-is (no rewriting needed)
+        assert_eq!(ev.tags.as_slice().len(), normalized.tags.as_slice().len());
+    }
+
+    #[test]
+    fn does_not_convert_hex_content() {
+        // Hex content with hex encoding tag — normalizer must NOT convert it.
+        // MDK's parse_key_package will reject this event.
+        let ev = make_kp_event(
+            "deadbeef",
+            vec![Tag::custom(TagKind::Custom("encoding".into()), ["hex"])],
+        );
+        let normalized = normalize_peer_key_package_event_for_mdk(&ev);
+        // Content left as-is — no hex→base64 conversion
+        assert_eq!(normalized.content, "deadbeef");
+        // Encoding tag left as-is — no rewriting to base64
+        let enc = normalized
+            .tags
+            .iter()
+            .find(|t| t.kind() == TagKind::Custom("encoding".into()))
+            .and_then(|t| t.as_slice().get(1).map(|s| s.to_string()));
+        assert_eq!(enc.as_deref(), Some("hex"));
+    }
+
+    #[test]
+    fn does_not_inject_encoding_tag_when_missing() {
+        // No encoding tag at all — normalizer must NOT add one.
+        // MDK's parse_key_package will reject this event.
+        let ev = make_kp_event("deadbeef", vec![]);
+        let normalized = normalize_peer_key_package_event_for_mdk(&ev);
+        let has_encoding = normalized
+            .tags
+            .iter()
+            .any(|t| t.kind() == TagKind::Custom("encoding".into()));
+        assert!(!has_encoding, "should not inject encoding tag");
+    }
+
+    #[test]
+    fn normalizes_legacy_version_and_ciphersuite() {
+        let keys = Keys::generate();
+        let tags = vec![
+            Tag::custom(TagKind::Custom("encoding".into()), ["base64"]),
+            Tag::custom(TagKind::MlsProtocolVersion, ["1"]),
+            Tag::custom(TagKind::MlsCiphersuite, ["1"]),
+        ];
+        let ev = EventBuilder::new(Kind::MlsKeyPackage, "AQID")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .expect("sign");
+
+        let normalized = normalize_peer_key_package_event_for_mdk(&ev);
+
+        let version = normalized
+            .tags
+            .iter()
+            .find(|t| t.kind() == TagKind::MlsProtocolVersion)
+            .and_then(|t| t.as_slice().get(1).map(|s| s.to_string()));
+        assert_eq!(version.as_deref(), Some("1.0"));
+
+        let suite = normalized
+            .tags
+            .iter()
+            .find(|t| t.kind() == TagKind::MlsCiphersuite)
+            .and_then(|t| t.as_slice().get(1).map(|s| s.to_string()));
+        assert_eq!(suite.as_deref(), Some("0x0001"));
+    }
 }


### PR DESCRIPTION
## Summary

The interop normalizer (`normalize_peer_key_package_event_for_mdk`) was silently converting hex-encoded peer key packages to base64 and injecting encoding tags **before** MDK ever saw the event. This bypassed MDK's own validation, which already enforces MIP-00's requirement that encoding MUST be `base64`.

This PR removes the ad-hoc encoding validation from pika and lets MDK be the single source of truth for key package validation.

## Changes

- **Remove** hex→base64 content conversion from normalizer
- **Remove** encoding tag injection when tag is missing
- **Remove** unused `base64::Engine` import
- **Keep** version/ciphersuite tag normalization (`"1"` → `"1.0"`, `"1"` → `"0x0001"`) — still needed for legacy interop clients
- **Keep** function signature as `Event → Event` (infallible) — no change to call sites
- 4 unit tests verifying the normalizer does not convert hex or inject tags

## Context

MDK's `parse_key_package()` already:
- Requires the `["encoding", "base64"]` tag ([`key_packages.rs:266-267`](https://github.com/marmot-protocol/mdk))
- Rejects hex via `ContentEncoding::from_tag_value()` ([`util.rs:68-74`](https://github.com/marmot-protocol/mdk))
- Has security comment: `"SECURITY: No default - encoding tag must be present per MIP-00/MIP-02"` ([`util.rs:98`](https://github.com/marmot-protocol/mdk))

Key package validation should live in MDK, not be duplicated ad-hoc in each client.

Closes #111

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --lib -p pika_core -- interop::tests` — 4/4 pass
- [ ] Manual: peer with valid base64 key package — MDK accepts, group created
- [ ] Manual: peer with hex key package — MDK rejects via `parse_key_package`, toast shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)