### PR TITLE
feat: migrate call timeline events to Rust-owned state

### DIFF
--- a/android/app/src/main/java/com/pika/app/AppManager.kt
+++ b/android/app/src/main/java/com/pika/app/AppManager.kt
@@ -44,6 +44,7 @@ class AppManager private constructor(context: Context) : AppReconciler {
             followList = emptyList(),
             peerProfile = null,
             activeCall = null,
+            callTimeline = emptyList(),
             toast = null,
         ),
     )

--- a/android/app/src/main/java/com/pika/app/rust/pika_core.kt
+++ b/android/app/src/main/java/com/pika/app/rust/pika_core.kt
@@ -1481,6 +1481,8 @@ data class AppState (
     , 
     var `activeCall`: CallState?
     , 
+    var `callTimeline`: List<CallTimelineEvent>
+    , 
     var `toast`: kotlin.String?
     
 ){
@@ -1508,6 +1510,7 @@ public object FfiConverterTypeAppState: FfiConverterRustBuffer<AppState> {
             FfiConverterSequenceTypeFollowListEntry.read(buf),
             FfiConverterOptionalTypePeerProfileState.read(buf),
             FfiConverterOptionalTypeCallState.read(buf),
+            FfiConverterSequenceTypeCallTimelineEvent.read(buf),
             FfiConverterOptionalString.read(buf),
         )
     }
@@ -1523,6 +1526,7 @@ public object FfiConverterTypeAppState: FfiConverterRustBuffer<AppState> {
             FfiConverterSequenceTypeFollowListEntry.allocationSize(value.`followList`) +
             FfiConverterOptionalTypePeerProfileState.allocationSize(value.`peerProfile`) +
             FfiConverterOptionalTypeCallState.allocationSize(value.`activeCall`) +
+            FfiConverterSequenceTypeCallTimelineEvent.allocationSize(value.`callTimeline`) +
             FfiConverterOptionalString.allocationSize(value.`toast`)
     )
 
@@ -1537,6 +1541,7 @@ public object FfiConverterTypeAppState: FfiConverterRustBuffer<AppState> {
             FfiConverterSequenceTypeFollowListEntry.write(value.`followList`, buf)
             FfiConverterOptionalTypePeerProfileState.write(value.`peerProfile`, buf)
             FfiConverterOptionalTypeCallState.write(value.`activeCall`, buf)
+            FfiConverterSequenceTypeCallTimelineEvent.write(value.`callTimeline`, buf)
             FfiConverterOptionalString.write(value.`toast`, buf)
     }
 }
@@ -1709,6 +1714,54 @@ public object FfiConverterTypeCallState: FfiConverterRustBuffer<CallState> {
             FfiConverterOptionalLong.write(value.`startedAt`, buf)
             FfiConverterBoolean.write(value.`isMuted`, buf)
             FfiConverterOptionalTypeCallDebugStats.write(value.`debug`, buf)
+    }
+}
+
+
+
+data class CallTimelineEvent (
+    var `id`: kotlin.String
+    , 
+    var `chatId`: kotlin.String
+    , 
+    var `text`: kotlin.String
+    , 
+    var `timestamp`: kotlin.Long
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeCallTimelineEvent: FfiConverterRustBuffer<CallTimelineEvent> {
+    override fun read(buf: ByteBuffer): CallTimelineEvent {
+        return CallTimelineEvent(
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterLong.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: CallTimelineEvent) = (
+            FfiConverterString.allocationSize(value.`id`) +
+            FfiConverterString.allocationSize(value.`chatId`) +
+            FfiConverterString.allocationSize(value.`text`) +
+            FfiConverterLong.allocationSize(value.`timestamp`)
+    )
+
+    override fun write(value: CallTimelineEvent, buf: ByteBuffer) {
+            FfiConverterString.write(value.`id`, buf)
+            FfiConverterString.write(value.`chatId`, buf)
+            FfiConverterString.write(value.`text`, buf)
+            FfiConverterLong.write(value.`timestamp`, buf)
     }
 }
 
@@ -3911,6 +3964,34 @@ public object FfiConverterSequenceString: FfiConverterRustBuffer<List<kotlin.Str
         buf.putInt(value.size)
         value.iterator().forEach {
             FfiConverterString.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterSequenceTypeCallTimelineEvent: FfiConverterRustBuffer<List<CallTimelineEvent>> {
+    override fun read(buf: ByteBuffer): List<CallTimelineEvent> {
+        val len = buf.getInt()
+        return List<CallTimelineEvent>(len) {
+            FfiConverterTypeCallTimelineEvent.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<CallTimelineEvent>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeCallTimelineEvent.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<CallTimelineEvent>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeCallTimelineEvent.write(it, buf)
         }
     }
 }

--- a/ios/Sources/ContentView.swift
+++ b/ios/Sources/ContentView.swift
@@ -216,7 +216,7 @@ private func screenView(
             chatId: chatId,
             state: chatScreenState(from: state),
             activeCall: state.activeCall,
-            callEvents: manager.callTimelineEventsByChatId[chatId] ?? [],
+            callEvents: state.callTimeline.filter { $0.chatId == chatId },
             onSendMessage: { manager.dispatch(.sendMessage(chatId: chatId, content: $0)) },
             onStartCall: { manager.dispatch(.startCall(chatId: chatId)) },
             onOpenCallScreen: {

--- a/ios/Sources/PreviewData.swift
+++ b/ios/Sources/PreviewData.swift
@@ -214,6 +214,7 @@ enum PreviewAppState {
         currentChat: ChatViewState? = nil,
         followList: [FollowListEntry] = [],
         activeCall: CallState? = nil,
+        callTimeline: [CallTimelineEvent] = [],
         toast: String? = nil
     ) -> AppState {
         AppState(
@@ -227,6 +228,7 @@ enum PreviewAppState {
             followList: followList,
             peerProfile: nil,
             activeCall: activeCall,
+            callTimeline: callTimeline,
             toast: toast
         )
     }

--- a/ios/Sources/Views/Call/CallPresentationModel.swift
+++ b/ios/Sources/Views/Call/CallPresentationModel.swift
@@ -83,22 +83,4 @@ func formattedCallDebugStats(_ debug: CallDebugStats) -> String {
     "tx \(debug.txFrames)  rx \(debug.rxFrames)  drop \(debug.rxDropped)"
 }
 
-func callEndedTimelineText(reason: String, previousStatus: CallStatus?, startedAt: Int64?) -> String {
-    if case .ringing = previousStatus, reason == "busy" {
-        return "Missed call"
-    }
 
-    if reason == "declined" {
-        return "Call declined"
-    }
-
-    var base = "Call ended"
-    if reason != "user_hangup" {
-        base += ": \(callReasonText(reason))"
-    }
-
-    if let duration = callDurationText(startedAt: startedAt), duration != "00:00" {
-        base += " (\(duration))"
-    }
-    return base
-}

--- a/ios/Sources/Views/Call/CallTimelineEvent.swift
+++ b/ios/Sources/Views/Call/CallTimelineEvent.swift
@@ -1,17 +1,11 @@
 import Foundation
 import SwiftUI
 
-struct CallTimelineEvent: Identifiable, Equatable, Hashable {
-    let id: String
-    let chatId: String
-    let text: String
-    let timestamp: Date
+extension CallTimelineEvent: Identifiable {}
 
-    init(id: String, chatId: String, text: String, timestamp: Date = .now) {
-        self.id = id
-        self.chatId = chatId
-        self.text = text
-        self.timestamp = timestamp
+extension CallTimelineEvent {
+    var date: Date {
+        Date(timeIntervalSince1970: TimeInterval(timestamp))
     }
 }
 

--- a/ios/Sources/Views/ChatView.swift
+++ b/ios/Sources/Views/ChatView.swift
@@ -366,7 +366,7 @@ struct ChatView: View {
             case .message(_, let message):
                 return Date(timeIntervalSince1970: TimeInterval(message.timestamp))
             case .callEvent(_, let event):
-                return event.timestamp
+                return event.date
             }
         }
 

--- a/ios/Tests/AppManagerTests.swift
+++ b/ios/Tests/AppManagerTests.swift
@@ -12,6 +12,9 @@ final class AppManagerTests: XCTestCase {
             chatList: [],
             currentChat: nil,
             followList: [],
+            peerProfile: nil,
+            activeCall: nil,
+            callTimeline: [],
             toast: toast
         )
     }

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -1,4 +1,12 @@
 #[derive(uniffi::Record, Clone, Debug)]
+pub struct CallTimelineEvent {
+    pub id: String,
+    pub chat_id: String,
+    pub text: String,
+    pub timestamp: i64,
+}
+
+#[derive(uniffi::Record, Clone, Debug)]
 pub struct AppState {
     pub rev: u64,
     pub router: Router,
@@ -10,6 +18,7 @@ pub struct AppState {
     pub follow_list: Vec<FollowListEntry>,
     pub peer_profile: Option<PeerProfileState>,
     pub active_call: Option<CallState>,
+    pub call_timeline: Vec<CallTimelineEvent>,
     pub toast: Option<String>,
 }
 
@@ -29,6 +38,7 @@ impl AppState {
             follow_list: vec![],
             peer_profile: None,
             active_call: None,
+            call_timeline: vec![],
             toast: None,
         }
     }


### PR DESCRIPTION
## Summary

Moves call timeline event tracking from Swift `AppManager` into Rust `AppCore`, aligning with the architecture principle that all business-logic state lives in Rust.

## Changes

**Rust** (`state.rs`, `core/mod.rs`, `core/call_control.rs`)
- Added `CallTimelineEvent` record (`id`, `chat_id`, `text`, `timestamp`) to `AppState.call_timeline`
- `AppCore` records "Call started" / "Call ended" events by observing call state transitions
- Deduplication via `call_timeline_logged_keys` with a cap of ~200 entries
- `call_timeline_ended_text()` handles missed calls, declined calls, and duration formatting
- Timeline and keys cleared on logout

**iOS** (`AppManager.swift`, `ContentView.swift`, `ChatView.swift`, `CallTimelineEvent.swift`, `CallPresentationModel.swift`)
- Removed `callTimelineEventsByChatId`, `loggedCallTimelineKeys`, `recordCallTimelineTransition`, `appendCallTimelineEventIfNeeded`, `callEndedTimelineText` from Swift
- `ContentView` now filters `state.callTimeline` by `chatId`
- `CallTimelineEvent.swift` extends the UniFFI-generated type with `Identifiable` and a `date` computed property

**Android** (`AppManager.kt`)
- Added `callTimeline = emptyList()` to default `AppState` construction

## Validation
- `cargo test -p pika_core` — all pass
- `just clippy` — clean
- `just fmt` — clean
- `just ios-build-sim` — builds successfully
- `just android-assemble` — builds successfully
- iOS unit tests (AppManagerTests) — 4/4 pass