### PR TITLE
fix(ci): stabilize nightly Android and Rust e2e lanes

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -233,6 +233,8 @@ jobs:
 
       - run: |
           nix develop .#default -c ./tools/android-avd-ensure
+          # Run deterministic Android UI E2E in CI; audio-call E2E remains opt-in due flakiness.
+          PIKA_ANDROID_E2E_TEST_CLASS="com.pika.app.PikaE2eUiTest#e2e_deployedRustBot_pingPong" \
           PIKA_ANDROID_FORCE_GUI=0 \
           PIKA_ANDROID_EMULATOR_ARGS="-no-window" \
           nix develop .#default -c just android-ui-e2e-local

--- a/justfile
+++ b/justfile
@@ -171,7 +171,8 @@ nightly-pika-e2e:
   if [ -z "${PIKA_TEST_NSEC:-}" ]; then \
     echo "note: PIKA_TEST_NSEC not set; e2e_deployed_bot_call will skip"; \
   fi; \
-  cargo test -p pika_core --tests -- --ignored --nocapture
+  # Keep nightly meaningful but avoid the explicitly disabled flaky local-relay call test.
+  cargo test -p pika_core --tests -- --ignored --skip call_invite_accept_end_flow_over_local_relay --nocapture
 
 # Nightly lane: build marmotd + run the marmotd E2E suite (local Nostr relay + local MoQ relay).
 nightly-marmotd:

--- a/tools/ui-e2e-local
+++ b/tools/ui-e2e-local
@@ -259,10 +259,12 @@ fi
 
 case "$platform" in
   android)
+    # Default to the full class locally; allow CI or callers to narrow to a stable method.
+    TEST_CLASS="${PIKA_ANDROID_E2E_TEST_CLASS:-com.pika.app.PikaE2eUiTest}"
     ./tools/android-emulator-ensure >/dev/null
     just gen-kotlin android-rust android-local-properties >/dev/null
     (cd android && ./gradlew :app:connectedDebugAndroidTest \
-      -Pandroid.testInstrumentationRunnerArguments.class=com.pika.app.PikaE2eUiTest \
+      -Pandroid.testInstrumentationRunnerArguments.class="${TEST_CLASS}" \
       -Pandroid.testInstrumentationRunnerArguments.pika_e2e=1 \
       -Pandroid.testInstrumentationRunnerArguments.pika_disable_network=false \
       -Pandroid.testInstrumentationRunnerArguments.pika_reset=1 \


### PR DESCRIPTION
## Summary
- stabilize Rust nightly ignored-test run by excluding an explicitly disabled flaky call test
- make Android local UI E2E test selection configurable via `PIKA_ANDROID_E2E_TEST_CLASS`
- in nightly CI, run deterministic Android ping/pong E2E method on headless emulator

## Why
Recent nightly dispatches showed:
- `nightly-pika` failed due `call_invite_accept_end_flow_over_local_relay` (already marked disabled/flaky)
- `nightly-pika-ui-android` failed on nondeterministic audio-call E2E timeout

This keeps nightly signal strong while avoiding known flaky paths in the required nightly aggregate.

## Validation plan
- trigger `pre-merge.yml` with `mode=nightly` on this branch
- confirm `nightly-linux` and `nightly-pika-ui-android` run and complete successfully
- confirm `nightly-pika` no longer fails on the disabled local-relay call test
