### PR TITLE
android: implement group chat creation and group info screens

### DIFF
--- a/android/app/src/main/java/com/pika/app/ui/TestTags.kt
+++ b/android/app/src/main/java/com/pika/app/ui/TestTags.kt
@@ -18,4 +18,13 @@ object TestTags {
     const val CHAT_CALL_REJECT = "chat_call_reject"
     const val CHAT_CALL_END = "chat_call_end"
     const val CHAT_CALL_MUTE = "chat_call_mute"
+
+    const val NEWGROUP_NAME = "newgroup_name"
+    const val NEWGROUP_PEER_NPUB = "newgroup_peer_npub"
+    const val NEWGROUP_ADD_MEMBER = "newgroup_add_member"
+    const val NEWGROUP_CREATE = "newgroup_create"
+
+    const val GROUPINFO_ADD_NPUB = "groupinfo_add_npub"
+    const val GROUPINFO_ADD_BUTTON = "groupinfo_add_button"
+    const val GROUPINFO_LEAVE = "groupinfo_leave"
 }

--- a/android/app/src/main/java/com/pika/app/ui/screens/ChatListScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/ChatListScreen.kt
@@ -51,6 +51,7 @@ import com.pika.app.ui.QrCode
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.GroupAdd
 import androidx.compose.material.icons.filled.Person
 
 @Composable
@@ -81,6 +82,9 @@ fun ChatListScreen(manager: AppManager, padding: PaddingValues) {
                     }
                     IconButton(onClick = { manager.dispatch(AppAction.PushScreen(Screen.NewChat)) }) {
                         Icon(Icons.Default.Add, contentDescription = "New Chat")
+                    }
+                    IconButton(onClick = { manager.dispatch(AppAction.PushScreen(Screen.NewGroupChat)) }) {
+                        Icon(Icons.Default.GroupAdd, contentDescription = "New Group")
                     }
                     IconButton(onClick = { manager.logout() }) {
                         Icon(Icons.AutoMirrored.Filled.Logout, contentDescription = "Logout")

--- a/android/app/src/main/java/com/pika/app/ui/screens/ChatScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/ChatScreen.kt
@@ -58,6 +58,8 @@ import com.pika.app.rust.ChatMessage
 import com.pika.app.rust.MessageDeliveryState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Info
+import com.pika.app.rust.Screen
 import com.pika.app.ui.theme.PikaBlue
 import com.pika.app.ui.TestTags
 import dev.jeziellago.compose.markdowntext.MarkdownText
@@ -102,6 +104,17 @@ fun ChatScreen(manager: AppManager, chatId: String, padding: PaddingValues) {
                         },
                     ) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    if (chat.isGroup) {
+                        IconButton(
+                            onClick = {
+                                manager.dispatch(AppAction.PushScreen(Screen.GroupInfo(chat.chatId)))
+                            },
+                        ) {
+                            Icon(Icons.Default.Info, contentDescription = "Group info")
+                        }
                     }
                 },
             )

--- a/android/app/src/main/java/com/pika/app/ui/screens/GroupInfoScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/GroupInfoScreen.kt
@@ -1,33 +1,83 @@
 package com.pika.app.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.PersonRemove
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.pika.app.AppManager
 import com.pika.app.rust.AppAction
+import com.pika.app.rust.AuthState
+import com.pika.app.rust.MemberInfo
+import com.pika.app.ui.PeerKeyNormalizer
+import com.pika.app.ui.PeerKeyValidator
+import com.pika.app.ui.TestTags
+import com.pika.app.ui.theme.PikaBlue
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun GroupInfoScreen(manager: AppManager, chatId: String, padding: PaddingValues) {
-    val chat = manager.state.chatList.firstOrNull { it.chatId == chatId }
-    val title = chat?.groupName?.trim().takeIf { !it.isNullOrBlank() } ?: "Group info"
+    val chat = manager.state.currentChat
+    if (chat == null || chat.chatId != chatId) {
+        Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+            Text("Loading…")
+        }
+        return
+    }
+
+    val isAdmin = chat.isAdmin
+    val groupName = chat.groupName?.trim().takeIf { it?.isNotBlank() == true } ?: "Group"
+
+    var isEditing by remember { mutableStateOf(false) }
+    var editedName by remember { mutableStateOf(groupName) }
+    var npubInput by remember { mutableStateOf("") }
+    var showLeaveDialog by remember { mutableStateOf(false) }
+    var memberToRemove by remember { mutableStateOf<MemberInfo?>(null) }
+
+    val myPubkey = when (val a = manager.state.auth) {
+        is AuthState.LoggedIn -> a.pubkey
+        else -> null
+    }
 
     Scaffold(
         modifier = Modifier.padding(padding),
@@ -35,7 +85,7 @@ fun GroupInfoScreen(manager: AppManager, chatId: String, padding: PaddingValues)
             TopAppBar(
                 title = {
                     Text(
-                        text = title,
+                        "Group Info",
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
@@ -53,20 +103,275 @@ fun GroupInfoScreen(manager: AppManager, chatId: String, padding: PaddingValues)
             )
         },
     ) { inner ->
-        Box(modifier = Modifier.fillMaxSize().padding(inner), contentAlignment = Alignment.Center) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-                modifier = Modifier.padding(16.dp),
-            ) {
-                Text("Group details", style = MaterialTheme.typography.titleMedium)
-                if (chat == null) {
-                    Text("Missing chat in state.")
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(inner),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Group name section
+            item {
+                Text(
+                    "Group Name",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(4.dp))
+                if (isEditing) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        OutlinedTextField(
+                            value = editedName,
+                            onValueChange = { editedName = it },
+                            singleLine = true,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Button(
+                            onClick = {
+                                val trimmed = editedName.trim()
+                                if (trimmed.isNotBlank()) {
+                                    manager.dispatch(AppAction.RenameGroup(chatId, trimmed))
+                                }
+                                isEditing = false
+                            },
+                        ) {
+                            Text("Save")
+                        }
+                        TextButton(onClick = { isEditing = false }) {
+                            Text("Cancel")
+                        }
+                    }
                 } else {
-                    Text("Members: ${chat.members.size}")
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            groupName,
+                            style = MaterialTheme.typography.headlineSmall,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (isAdmin) {
+                            IconButton(onClick = {
+                                editedName = groupName
+                                isEditing = true
+                            }) {
+                                Icon(Icons.Default.Edit, contentDescription = "Edit name")
+                            }
+                        }
+                    }
                 }
+            }
+
+            // Members section
+            item {
+                HorizontalDivider()
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Members (${chat.members.size + 1})",
+                    style = MaterialTheme.typography.titleSmall,
+                )
+            }
+
+            // "You" row
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(PikaBlue.copy(alpha = 0.12f)),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            Icons.Default.Person,
+                            contentDescription = null,
+                            tint = PikaBlue,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                    Text(
+                        "You",
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Text(
+                        "Admin",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // Member rows
+            items(chat.members, key = { it.pubkey }) { member ->
+                if (member.pubkey == myPubkey) return@items
+                MemberRow(
+                    member = member,
+                    isAdmin = isAdmin,
+                    onRemove = { memberToRemove = member },
+                )
+            }
+
+            // Add member section (admin only)
+            if (isAdmin) {
+                item {
+                    HorizontalDivider()
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        "Add Member",
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    Spacer(Modifier.height(4.dp))
+
+                    val normalized = PeerKeyNormalizer.normalize(npubInput)
+                    val isValid = PeerKeyValidator.isValidPeer(normalized)
+
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        OutlinedTextField(
+                            value = npubInput,
+                            onValueChange = { npubInput = it },
+                            label = { Text("Peer npub") },
+                            singleLine = true,
+                            isError = npubInput.isNotEmpty() && !isValid,
+                            modifier = Modifier.weight(1f).testTag(TestTags.GROUPINFO_ADD_NPUB),
+                        )
+                        Button(
+                            onClick = {
+                                manager.dispatch(AppAction.AddGroupMembers(chatId, listOf(normalized)))
+                                npubInput = ""
+                            },
+                            enabled = isValid,
+                            modifier = Modifier.testTag(TestTags.GROUPINFO_ADD_BUTTON),
+                        ) {
+                            Text("Add")
+                        }
+                    }
+                }
+            }
+
+            // Leave group
+            item {
+                HorizontalDivider()
+                Spacer(Modifier.height(4.dp))
+                Button(
+                    onClick = { showLeaveDialog = true },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                    ),
+                    modifier = Modifier.fillMaxWidth().testTag(TestTags.GROUPINFO_LEAVE),
+                ) {
+                    Text("Leave Group")
+                }
+            }
+        }
+    }
+
+    // Leave confirmation dialog
+    if (showLeaveDialog) {
+        AlertDialog(
+            onDismissRequest = { showLeaveDialog = false },
+            title = { Text("Leave Group") },
+            text = { Text("Are you sure you want to leave this group?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    manager.dispatch(AppAction.LeaveGroup(chatId))
+                    showLeaveDialog = false
+                }) {
+                    Text("Leave", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLeaveDialog = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
+    // Remove member confirmation dialog
+    memberToRemove?.let { member ->
+        AlertDialog(
+            onDismissRequest = { memberToRemove = null },
+            title = { Text("Remove Member") },
+            text = { Text("Remove ${member.name ?: truncatedNpub(member.npub)} from the group?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    manager.dispatch(AppAction.RemoveGroupMembers(chatId, listOf(member.pubkey)))
+                    memberToRemove = null
+                }) {
+                    Text("Remove", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { memberToRemove = null }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun MemberRow(
+    member: MemberInfo,
+    isAdmin: Boolean,
+    onRemove: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(PikaBlue.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                (member.name ?: member.npub).take(1).uppercase(),
+                style = MaterialTheme.typography.titleSmall,
+                color = PikaBlue,
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                member.name ?: truncatedNpub(member.npub),
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (member.name != null) {
+                Text(
+                    truncatedNpub(member.npub),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+        }
+        if (isAdmin) {
+            IconButton(onClick = onRemove) {
+                Icon(
+                    Icons.Default.PersonRemove,
+                    contentDescription = "Remove member",
+                    tint = MaterialTheme.colorScheme.error,
+                )
             }
         }
     }
 }
 
+private fun truncatedNpub(npub: String): String {
+    if (npub.length <= 20) return npub
+    return npub.take(12) + "…" + npub.takeLast(4)
+}

--- a/android/app/src/main/java/com/pika/app/ui/screens/NewGroupChatScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/NewGroupChatScreen.kt
@@ -1,38 +1,108 @@
 package com.pika.app.ui.screens
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.pika.app.AppManager
 import com.pika.app.rust.AppAction
+import com.pika.app.rust.FollowListEntry
+import com.pika.app.ui.PeerKeyNormalizer
+import com.pika.app.ui.PeerKeyValidator
+import com.pika.app.ui.TestTags
+import com.pika.app.ui.theme.PikaBlue
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun NewGroupChatScreen(manager: AppManager, padding: PaddingValues) {
+    val clipboard = LocalClipboardManager.current
+    var groupName by remember { mutableStateOf("") }
+    val selectedNpubs = remember { mutableStateListOf<String>() }
+    var searchText by remember { mutableStateOf("") }
+    var npubInput by remember { mutableStateOf("") }
+    var showScanner by remember { mutableStateOf(false) }
+    var showManualEntry by remember { mutableStateOf(false) }
+
+    val isCreating = manager.state.busy.creatingChat
+    val isFetchingFollows = manager.state.busy.fetchingFollowList
+    val followList = manager.state.followList
+
+    val filteredFollows = remember(followList, searchText) {
+        if (searchText.isBlank()) followList
+        else {
+            val query = searchText.lowercase()
+            followList.filter { entry ->
+                entry.name?.lowercase()?.contains(query) == true ||
+                    entry.npub.lowercase().contains(query) ||
+                    entry.pubkey.lowercase().contains(query)
+            }
+        }
+    }
+
+    val canCreate = groupName.isNotBlank() && selectedNpubs.isNotEmpty() && !isCreating
+
+    LaunchedEffect(Unit) {
+        manager.dispatch(AppAction.RefreshFollowList)
+    }
+
     Scaffold(
         modifier = Modifier.padding(padding),
         topBar = {
             TopAppBar(
-                title = { Text("New group chat") },
+                title = { Text("New group") },
                 navigationIcon = {
                     IconButton(
                         onClick = {
                             val stack = manager.state.router.screenStack
                             manager.dispatch(AppAction.UpdateScreenStack(stack.dropLast(1)))
                         },
+                        enabled = !isCreating,
                     ) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
@@ -40,11 +110,307 @@ fun NewGroupChatScreen(manager: AppManager, padding: PaddingValues) {
             )
         },
     ) { inner ->
-        Box(modifier = Modifier.fillMaxSize().padding(inner), contentAlignment = Alignment.Center) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text("Group chat UI isn’t implemented on Android yet.")
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(inner),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Group name
+            item {
+                OutlinedTextField(
+                    value = groupName,
+                    onValueChange = { groupName = it },
+                    label = { Text("Group name") },
+                    singleLine = true,
+                    enabled = !isCreating,
+                    modifier = Modifier.fillMaxWidth().testTag(TestTags.NEWGROUP_NAME),
+                )
             }
+
+            // Selected members chips
+            if (selectedNpubs.isNotEmpty()) {
+                item {
+                    Text(
+                        "Selected (${selectedNpubs.size})",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Row(
+                        modifier = Modifier.horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        selectedNpubs.forEach { npub ->
+                            SelectedChip(
+                                npub = npub,
+                                followList = followList,
+                                enabled = !isCreating,
+                                onRemove = { selectedNpubs.remove(npub) },
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Manual entry toggle
+            item {
+                TextButton(onClick = { showManualEntry = !showManualEntry }) {
+                    Text(if (showManualEntry) "Hide manual entry" else "Add member manually")
+                }
+            }
+
+            // Manual entry
+            if (showManualEntry) {
+                item {
+                    val normalizedInput = PeerKeyNormalizer.normalize(npubInput)
+                    val isValidInput = PeerKeyValidator.isValidPeer(normalizedInput)
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        OutlinedTextField(
+                            value = npubInput,
+                            onValueChange = { npubInput = it },
+                            label = { Text("npub or hex pubkey") },
+                            singleLine = true,
+                            enabled = !isCreating,
+                            isError = npubInput.isNotEmpty() && !isValidInput,
+                            modifier = Modifier.weight(1f).testTag(TestTags.NEWGROUP_PEER_NPUB),
+                        )
+                        TextButton(
+                            onClick = { showScanner = true },
+                            enabled = !isCreating,
+                        ) {
+                            Text("QR")
+                        }
+                        TextButton(
+                            onClick = {
+                                val raw = clipboard.getText()?.text.orEmpty()
+                                npubInput = PeerKeyNormalizer.normalize(raw)
+                            },
+                            enabled = !isCreating,
+                        ) {
+                            Text("Paste")
+                        }
+                    }
+                    Spacer(Modifier.height(4.dp))
+                    Button(
+                        onClick = {
+                            if (isValidInput && normalizedInput !in selectedNpubs) {
+                                selectedNpubs.add(normalizedInput)
+                            }
+                            npubInput = ""
+                        },
+                        enabled = isValidInput && !isCreating,
+                        modifier = Modifier.testTag(TestTags.NEWGROUP_ADD_MEMBER),
+                    ) {
+                        Text("Add")
+                    }
+                }
+            }
+
+            // Follow list header
+            item {
+                HorizontalDivider()
+                Spacer(Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        "Follows",
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    if (isFetchingFollows) {
+                        Spacer(Modifier.width(8.dp))
+                        CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp)
+                    }
+                }
+                Spacer(Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = searchText,
+                    onValueChange = { searchText = it },
+                    label = { Text("Search follows") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            // Follow list content
+            if (isFetchingFollows && followList.isEmpty()) {
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                        Spacer(Modifier.width(8.dp))
+                        Text("Loading follows…")
+                    }
+                }
+            } else if (followList.isEmpty()) {
+                item {
+                    Text(
+                        "No follows found.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 8.dp),
+                    )
+                }
+            } else {
+                items(filteredFollows, key = { it.pubkey }) { entry ->
+                    val isSelected = entry.npub in selectedNpubs
+                    FollowRow(
+                        entry = entry,
+                        isSelected = isSelected,
+                        enabled = !isCreating,
+                        onClick = {
+                            if (isSelected) selectedNpubs.remove(entry.npub)
+                            else selectedNpubs.add(entry.npub)
+                        },
+                    )
+                }
+            }
+
+            // Create button
+            item {
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    onClick = {
+                        manager.dispatch(
+                            AppAction.CreateGroupChat(
+                                selectedNpubs.toList(),
+                                groupName.trim(),
+                            ),
+                        )
+                    },
+                    enabled = canCreate,
+                    modifier = Modifier.fillMaxWidth().testTag(TestTags.NEWGROUP_CREATE),
+                ) {
+                    if (isCreating) {
+                        Row {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp,
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text("Creating…")
+                        }
+                    } else {
+                        Text("Create Group")
+                    }
+                }
+            }
+        }
+    }
+
+    if (showScanner) {
+        QrScannerDialog(
+            onDismiss = { showScanner = false },
+            onScanned = { scanned ->
+                val normalized = PeerKeyNormalizer.normalize(scanned)
+                if (PeerKeyValidator.isValidPeer(normalized) && normalized !in selectedNpubs) {
+                    selectedNpubs.add(normalized)
+                } else {
+                    npubInput = scanned
+                    showManualEntry = true
+                }
+                showScanner = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun SelectedChip(
+    npub: String,
+    followList: List<FollowListEntry>,
+    enabled: Boolean,
+    onRemove: () -> Unit,
+) {
+    val displayName = followList.firstOrNull { it.npub == npub }?.name ?: truncatedNpub(npub)
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .padding(start = 10.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            displayName,
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(Modifier.width(2.dp))
+        IconButton(
+            onClick = onRemove,
+            enabled = enabled,
+            modifier = Modifier.size(20.dp),
+        ) {
+            Icon(
+                Icons.Default.Close,
+                contentDescription = "Remove",
+                modifier = Modifier.size(14.dp),
+            )
         }
     }
 }
 
+@Composable
+private fun FollowRow(
+    entry: FollowListEntry,
+    isSelected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled) { onClick() }
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(PikaBlue.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                (entry.name ?: entry.npub).take(1).uppercase(),
+                style = MaterialTheme.typography.titleSmall,
+                color = PikaBlue,
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            if (entry.name != null) {
+                Text(
+                    entry.name!!,
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Text(
+                truncatedNpub(entry.npub),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+        if (isSelected) {
+            Icon(
+                Icons.Default.Check,
+                contentDescription = "Selected",
+                tint = PikaBlue,
+            )
+        }
+    }
+}
+
+private fun truncatedNpub(npub: String): String {
+    if (npub.length <= 20) return npub
+    return npub.take(12) + "…" + npub.takeLast(4)
+}


### PR DESCRIPTION
Replace stub NewGroupChatScreen with full implementation: group name, multi-select members from follow list, manual npub entry with QR/paste, search/filter, and creation via `CreateGroupChat` action.

Replace stub GroupInfoScreen with full implementation: view/edit group name (admin), member list with remove (admin), add member by npub, leave group with confirmation dialog.

Wire up navigation: GroupAdd icon in ChatList toolbar, info icon in ChatScreen toolbar for group chats.

Tested on emulator: created a group with a pika-cli peer, verified group info screen shows members, admin controls, and all actions dispatch correctly.