### PR TITLE
android: add Avatar composable with Coil image loading

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -141,4 +141,7 @@ dependencies {
 
     // Markdown rendering in Compose
     implementation("com.github.jeziellago:compose-markdown:0.5.4")
+
+    // Async image loading
+    implementation("io.coil-kt:coil-compose:2.7.0")
 }

--- a/android/app/src/main/java/com/pika/app/ui/Avatar.kt
+++ b/android/app/src/main/java/com/pika/app/ui/Avatar.kt
@@ -1,0 +1,57 @@
+package com.pika.app.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.SubcomposeAsyncImage
+import com.pika.app.ui.theme.PikaBlue
+
+@Composable
+fun Avatar(
+    name: String?,
+    npub: String,
+    pictureUrl: String?,
+    size: Dp = 44.dp,
+) {
+    if (!pictureUrl.isNullOrBlank()) {
+        val placeholder: @Composable () -> Unit = { InitialsCircle(name, npub, size) }
+        SubcomposeAsyncImage(
+            model = pictureUrl,
+            contentDescription = name ?: npub,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.size(size).clip(CircleShape),
+            loading = { placeholder() },
+            error = { placeholder() },
+        )
+    } else {
+        InitialsCircle(name = name, npub = npub, size = size)
+    }
+}
+
+@Composable
+private fun InitialsCircle(name: String?, npub: String, size: Dp) {
+    val initial = (name ?: npub).take(1).uppercase()
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(PikaBlue.copy(alpha = 0.12f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            initial,
+            fontSize = (size.value * 0.4f).sp,
+            color = PikaBlue,
+        )
+    }
+}

--- a/android/app/src/main/java/com/pika/app/ui/screens/ChatListScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/ChatListScreen.kt
@@ -1,6 +1,5 @@
 package com.pika.app.ui.screens
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
@@ -46,7 +44,7 @@ import com.pika.app.rust.AppAction
 import com.pika.app.rust.AuthState
 import com.pika.app.rust.ChatSummary
 import com.pika.app.rust.Screen
-import com.pika.app.ui.theme.PikaBlue
+import com.pika.app.ui.Avatar
 import com.pika.app.ui.QrCode
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
@@ -142,6 +140,10 @@ fun ChatListScreen(manager: AppManager, padding: PaddingValues) {
 @Composable
 private fun ChatRow(chat: ChatSummary, selfPubkey: String?, onClick: () -> Unit) {
     val title = chatTitle(chat, selfPubkey)
+    val peer = if (!chat.isGroup) {
+        chat.members.firstOrNull { selfPubkey == null || it.pubkey != selfPubkey }
+            ?: chat.members.firstOrNull()
+    } else null
     Row(
         modifier =
             Modifier
@@ -158,20 +160,11 @@ private fun ChatRow(chat: ChatSummary, selfPubkey: String?, onClick: () -> Unit)
                 }
             },
         ) {
-            Box(
-                modifier =
-                    Modifier
-                        .size(44.dp)
-                        .clip(CircleShape)
-                        .background(PikaBlue.copy(alpha = 0.12f)),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    title.take(1).uppercase(),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = PikaBlue,
-                )
-            }
+            Avatar(
+                name = peer?.name ?: chat.groupName,
+                npub = peer?.npub ?: chat.chatId,
+                pictureUrl = peer?.pictureUrl,
+            )
         }
 
         Column(modifier = Modifier.weight(1f)) {

--- a/android/app/src/main/java/com/pika/app/ui/screens/GroupInfoScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/GroupInfoScreen.kt
@@ -1,6 +1,5 @@
 package com.pika.app.ui.screens
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,15 +10,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonRemove
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -41,7 +37,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -49,10 +44,10 @@ import com.pika.app.AppManager
 import com.pika.app.rust.AppAction
 import com.pika.app.rust.AuthState
 import com.pika.app.rust.MemberInfo
+import com.pika.app.ui.Avatar
 import com.pika.app.ui.PeerKeyNormalizer
 import com.pika.app.ui.PeerKeyValidator
 import com.pika.app.ui.TestTags
-import com.pika.app.ui.theme.PikaBlue
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -74,10 +69,11 @@ fun GroupInfoScreen(manager: AppManager, chatId: String, padding: PaddingValues)
     var showLeaveDialog by remember { mutableStateOf(false) }
     var memberToRemove by remember { mutableStateOf<MemberInfo?>(null) }
 
-    val myPubkey = when (val a = manager.state.auth) {
-        is AuthState.LoggedIn -> a.pubkey
-        else -> null
+    val (myPubkey, myNpub) = when (val a = manager.state.auth) {
+        is AuthState.LoggedIn -> a.pubkey to a.npub
+        else -> null to null
     }
+    val myProfile = manager.state.myProfile
 
     Scaffold(
         modifier = Modifier.padding(padding),
@@ -180,20 +176,12 @@ fun GroupInfoScreen(manager: AppManager, chatId: String, padding: PaddingValues)
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(CircleShape)
-                            .background(PikaBlue.copy(alpha = 0.12f)),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Icon(
-                            Icons.Default.Person,
-                            contentDescription = null,
-                            tint = PikaBlue,
-                            modifier = Modifier.size(20.dp),
-                        )
-                    }
+                    Avatar(
+                        name = myProfile.name.takeIf { it.isNotBlank() },
+                        npub = myNpub ?: "",
+                        pictureUrl = myProfile.pictureUrl,
+                        size = 40.dp,
+                    )
                     Text(
                         "You",
                         style = MaterialTheme.typography.bodyLarge,
@@ -330,19 +318,12 @@ private fun MemberRow(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(CircleShape)
-                .background(PikaBlue.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                (member.name ?: member.npub).take(1).uppercase(),
-                style = MaterialTheme.typography.titleSmall,
-                color = PikaBlue,
-            )
-        }
+        Avatar(
+            name = member.name,
+            npub = member.npub,
+            pictureUrl = member.pictureUrl,
+            size = 40.dp,
+        )
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 member.name ?: truncatedNpub(member.npub),

--- a/android/app/src/main/java/com/pika/app/ui/screens/NewGroupChatScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/NewGroupChatScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -53,6 +52,7 @@ import androidx.compose.ui.unit.dp
 import com.pika.app.AppManager
 import com.pika.app.rust.AppAction
 import com.pika.app.rust.FollowListEntry
+import com.pika.app.ui.Avatar
 import com.pika.app.ui.PeerKeyNormalizer
 import com.pika.app.ui.PeerKeyValidator
 import com.pika.app.ui.TestTags
@@ -371,19 +371,12 @@ private fun FollowRow(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(CircleShape)
-                .background(PikaBlue.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                (entry.name ?: entry.npub).take(1).uppercase(),
-                style = MaterialTheme.typography.titleSmall,
-                color = PikaBlue,
-            )
-        }
+        Avatar(
+            name = entry.name,
+            npub = entry.npub,
+            pictureUrl = entry.pictureUrl,
+            size = 40.dp,
+        )
         Column(modifier = Modifier.weight(1f)) {
             if (entry.name != null) {
                 Text(


### PR DESCRIPTION
Add reusable `Avatar` composable that loads profile pictures via Coil's `SubcomposeAsyncImage` with initials circle fallback for loading/error states.

Replace manual initials-only circles in ChatListScreen, GroupInfoScreen, and NewGroupChatScreen with the new component. When a peer has a `pictureUrl` set, their profile picture will now be displayed; otherwise falls back to the existing initials circle.

Adds `io.coil-kt:coil-compose:2.7.0` dependency.