### PR TITLE
ci: enable strict Swift/Kotlin lint checks (intentional initial failures)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*.{kt,kts}]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+max_line_length = 140
+ktlint_code_style = ktlint_official
+ktlint_function_naming_ignore_when_annotated_with = Composable
+ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than = unset
+ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than = unset
+ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than = 5
+ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -44,6 +44,16 @@ jobs:
 
       - run: nix develop .#default -c just pre-merge-pika
 
+  check-ios:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'pre-merge')
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: nixbuild/nix-quick-install-action@v30
+
+      - run: nix develop .#default -c just pre-merge-ios
+
   check-marmotd:
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'pre-merge')
     runs-on: blacksmith-16vcpu-ubuntu-2404
@@ -104,12 +114,16 @@ jobs:
 
   pre-merge:
     if: always() && (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'pre-merge'))
-    needs: [check-pika, check-marmotd, check-rmp]
+    needs: [check-pika, check-ios, check-marmotd, check-rmp]
     runs-on: ubuntu-latest
     steps:
       - run: |
           if [[ "${{ needs.check-pika.result }}" != "success" ]]; then
             echo "check-pika failed"
+            exit 1
+          fi
+          if [[ "${{ needs.check-ios.result }}" != "success" ]]; then
+            echo "check-ios failed"
             exit 1
           fi
           if [[ "${{ needs.check-marmotd.result }}" != "success" ]]; then

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,44 @@
+included:
+  - ios/Sources
+  - ios/Tests
+  - ios/UITests
+
+excluded:
+  - ios/Bindings
+  - ios/.build
+  - ios/build
+  - ios/Frameworks
+
+line_length:
+  warning: 140
+  error: 180
+
+file_length:
+  warning: 1200
+  error: 1800
+
+function_body_length:
+  warning: 120
+  error: 180
+
+type_body_length:
+  warning: 500
+  error: 800
+
+identifier_name:
+  min_length:
+    warning: 2
+  excluded:
+    - id
+    - x
+    - y
+    - z
+
+opt_in_rules:
+  - empty_count
+  - explicit_init
+  - first_where
+  - redundant_nil_coalescing
+  - sorted_imports
+  - toggle_bool
+  - vertical_whitespace_closing_braces

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ cargo run -p pika-cli -- --relay ws://127.0.0.1:7777 groups
 just fmt          # Format Rust code
 just clippy       # Lint
 just test         # Run pika_core tests
+just kotlin-lint  # Lint Kotlin (excludes generated UniFFI bindings)
+just android-lint # Run Android lint (excludes generated UniFFI bindings)
+just swift-lint   # Lint Swift (macOS only)
 just qa           # Full QA: fmt + clippy + test + platform builds
 just pre-merge    # CI entrypoint for the whole repo
 ```

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -70,6 +70,11 @@ android {
         jvmTarget = "17"
     }
 
+    lint {
+        lintConfig = file("lint.xml")
+        abortOnError = true
+    }
+
     packaging {
         resources.excludes.addAll(
             listOf(

--- a/android/app/lint.xml
+++ b/android/app/lint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <!-- UniFFI output is generated from Rust and not manually maintained. -->
+    <issue id="all">
+        <ignore regexp=".*/src/main/java/com/pika/app/rust/.*" />
+    </issue>
+</lint>

--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,9 @@
             androidSdk
             pkgs.jdk17_headless
             pkgs.just
+            pkgs.ktlint
+            pkgs.detekt
+            pkgs.swiftformat
             pkgs.nodejs_22
             pkgs.python3
             pkgs.curl
@@ -156,6 +159,7 @@
             zsp
             rmp
           ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.swiftlint
             pkgs.xcodegen
           ];
 


### PR DESCRIPTION
## Summary\nEnable Swift/Kotlin/Android linting and checking in CI and local Available recipes:
    android-assemble                                  # Build Android debug APK.
    android-install                                   # Build and install Android debug APK on connected device.
    android-lint                                      # Run Android lint.
    android-local-properties                          # Write android/local.properties with SDK path.
    android-manual-qa                                 # Show Android manual QA instructions.
    android-release                                   # Build signed Android release APK (arm64-v8a) and copy to dist/.
    android-rust                                      # Note: this clears `android/app/src/main/jniLibs` so output matches the requested ABI set.
    android-ui-e2e                                    # Android E2E: public relays + deployed bot (nondeterministic). Requires emulator.
    android-ui-e2e-local                              # Android E2E: local Nostr relay + local Rust bot. Requires emulator.
    android-ui-test                                   # Run Android instrumentation tests (requires running emulator/device).
    cli-build                                         # Build pika-cli (debug).
    cli-identity STATE_DIR=".pika-cli" RELAY="ws://127.0.0.1:7777" # Show (or create) an identity in the given state dir.
    cli-release                                       # Build pika-cli (release).
    cli-smoke RELAY="ws://127.0.0.1:7777"             # Requires a Nostr relay running at RELAY (e.g. `strfry` or `nostr-rs-relay`).
    clippy *ARGS                                      # Lint with clippy.
    default                                           # List available recipes.
    device                                            # Optional: device automation (npx). Not required for building.
    doctor-ios                                        # Check iOS dev environment (Xcode, simulators, runtimes).
    e2e-local-marmotd                                 # Builds marmotd from the workspace crate (`crates/marmotd`) so no external repos are required.
    e2e-local-relay                                   # Deterministic E2E: local Nostr relay + local Rust bot (iOS + Android).
    e2e-public                                        # Rust-level E2E smoke test against public relays (nondeterministic).
    e2e-public-relays                                 # E2E against public relays + deployed bot (nondeterministic).
    e2e-real-moq                                      # E2E call test over the real MOQ relay (nondeterministic; requires QUIC egress).
    fmt                                               # Check formatting (cargo fmt).
    gen-kotlin                                        # Generate Kotlin bindings via UniFFI.
    info                                              # Print developer-facing usage notes (targets, env vars, common flows).
    interop-rust-baseline                             # Interop baseline: local Rust bot. Requires ~/code/marmot-interop-lab-rust.
    interop-rust-manual                               # Interactive interop test (manual send/receive with local bot).
    ios-build-sim                                     # Build iOS app for simulator.
    ios-gen-swift                                     # Generate Swift bindings via UniFFI.
    ios-manual-qa                                     # Show iOS manual QA instructions.
    ios-rust                                          # Keep `PIKA_IOS_RUST_TARGETS` aligned with destination (device vs simulator) to avoid link errors.
    ios-ui-e2e                                        # iOS E2E: public relays + deployed bot (nondeterministic). Requires PIKA_UI_E2E=1.
    ios-ui-e2e-local                                  # iOS E2E: local Nostr relay + local Rust bot.
    ios-ui-test                                       # Run iOS UI tests on simulator (skips E2E deployed-bot test).
    ios-xcframework                                   # Build PikaCore.xcframework (device + simulator slices).
    ios-xcodeproj                                     # Generate Xcode project via xcodegen.
    kotlin-lint                                       # Lint Kotlin sources (excluding generated UniFFI bindings).
    nightly                                           # Nightly root task.
    nightly-marmotd                                   # Nightly lane: build marmotd + run the marmotd E2E suite (local Nostr relay + local MoQ relay).
    nightly-pika-e2e                                  # Nightly E2E (Rust): run all `#[ignore]` tests (intended for long/flaky network suites).
    openclaw-marmot-scenarios                         # openclaw-marmot scenario suite (local Nostr relay + marmotd scenarios).
    pre-merge                                         # Single CI entrypoint for the whole repo.
    pre-merge-ios                                     # CI-safe pre-merge for iOS native lint + simulator build.
    pre-merge-marmotd                                 # CI-safe pre-merge for the openclaw-marmot (marmotd) lane.
    pre-merge-pika                                    # CI-safe pre-merge for the Pika app lane.
    pre-merge-rmp                                     # CI-safe pre-merge for the RMP tooling lane.
    qa                                                # Full QA: fmt, clippy, test, android build, iOS sim build.
    release VERSION                                   # Create + push version tag (vX.Y.Z) after validating VERSION and clean tree.
    rmp *ARGS                                         # Run the new Rust `rmp` CLI.
    rmp-init-run PLATFORM="android" NAME="rmp-e2e" ORG="com.example" # End-to-end launch check for a freshly initialized project.
    rmp-init-smoke NAME="rmp-smoke" ORG="com.example" # Smoke test `rmp init` output locally (scaffold + doctor + core check).
    rmp-init-smoke-ci ORG="com.example"               # Linux-safe CI checks for `rmp init` output.
    rmp-nightly-linux NAME="rmp-nightly-linux" ORG="com.example" AVD="rmp_ci_api35" # Nightly Linux lane: scaffold + Android emulator run.
    rmp-nightly-macos NAME="rmp-nightly-macos" ORG="com.example" # Nightly macOS lane: scaffold + iOS simulator run.
    run-android *ARGS                                 # Build, install, and launch Android app on emulator/device.
    run-ios *ARGS                                     # Build, install, and launch iOS app on simulator/device.
    rust-build-host                                   # Build Rust core for the host platform.
    swift-lint                                        # Lint Swift sources (macOS only).
    test *ARGS                                        # Run pika_core tests.
    zapstore-check APK                                # Check Zapstore publish inputs for a local APK without publishing events.
    zapstore-encrypt-signing                          # Encrypt Zapstore signing value to `secrets/zapstore-signing.env.age`.
    zapstore-publish APK                              # Publish a local APK artifact to Zapstore. workflows, with generated UniFFI code excluded from lint scopes.\n\n## Intentional current state\nThis PR is expected to fail lint/checks right now.\nWe are intentionally not fixing existing violations in this PR; cleanup will happen in a future update.