### PR TITLE
ios: implement phase 4a callkit baseline

### DIFF
--- a/docs/calling-ux.md
+++ b/docs/calling-ux.md
@@ -4,7 +4,7 @@ read_when:
   - refactoring iOS chat/call surfaces
   - implementing call UI state transitions
   - integrating CallKit and audio-session routing behavior
-status: phase_0_3_complete
+status: phase_0_4a_complete_phase_4bcd_planned
 ---
 
 # Calling UX Plan
@@ -16,6 +16,7 @@ status: phase_0_3_complete
 3. Replace the current inline "debug-like" call strip with a deliberate full-screen call experience.
 4. Avoid overcomplicating chat history now; defer call timeline logging to a later phase.
 5. Remove current iOS warnings and deprecated API usage as part of the cleanup.
+6. Integrate CallKit without breaking Rust-owned call state transitions.
 
 ## Non-Goals (For Initial Phases)
 
@@ -23,15 +24,36 @@ status: phase_0_3_complete
 2. CallKit parity on Android.
 3. Multi-party or video calling UX.
 
-## Current Pain Points
+## Historical Pain Points (Phases 0-3)
 
-1. Call controls are embedded inline in `ChatView`, which feels unfinished.
-2. "Call ended: ..." sticks in chat context and competes with message content.
-3. The call affordance is not in the expected top-right phone location.
-4. iOS warnings are accumulating:
+1. Inline call controls in `ChatView` looked unfinished.
+2. Call state/status UI cluttered chat context.
+3. Call affordance placement did not match expected top-right phone action.
+4. iOS warning debt:
    - `AVAudioSession.CategoryOptions.allowBluetooth` deprecation
    - `AVAudioSession.recordPermission` and `requestRecordPermission` deprecations
-   - Main-actor isolation warnings around `manager.dispatch` in `ContentView`
+   - main-actor isolation warnings around `manager.dispatch` in `ContentView`
+
+## Current Status (2026-02-17)
+
+1. Phase 0 is complete:
+   - iOS deprecations/warnings shown earlier are addressed.
+   - Audio category option is now `.allowBluetoothHFP`.
+   - Mic permission checks use `AVAudioApplication`.
+2. Phase 1 is complete:
+   - Call entry moved to chat top-right.
+   - Dedicated full-screen in-app call screen is shipped.
+3. Phase 2 is complete:
+   - Return-to-call pill is present in chat and no longer blocks input.
+4. Phase 3 is complete:
+   - Call timeline events are inline with messages and sorted in timeline order.
+5. Phase 4A baseline is complete:
+   - iOS has a global CallKit coordinator (`CXProvider` + `CXCallController`) with Rust `call_id` to CallKit `UUID` mapping.
+   - Outgoing/incoming/end actions are synchronized between in-app UI, CallKit actions, and Rust state transitions.
+6. Remaining major gaps:
+   - Phase 4B mute/hold parity is not implemented yet.
+   - Phase 4C audio-session ownership handoff to CallKit is not implemented yet.
+   - Phase 4D PushKit/background incoming is not implemented yet.
 
 ## Product Direction
 
@@ -39,6 +61,31 @@ status: phase_0_3_complete
 2. The rest of the app remains navigable; user can return to the call screen quickly.
 3. Chat thread remains message-focused for now (no immediate call event spam).
 4. Build a clean path to CallKit + proper Apple audio processing/routing.
+
+## Architecture Constraints (Current)
+
+1. Rust remains source of truth (`docs/state.md`): native must not invent business transitions.
+2. Current Rust call action surface:
+   - `startCall(chatId)`
+   - `acceptCall(chatId)`
+   - `rejectCall(chatId)`
+   - `endCall`
+   - `toggleMute`
+3. Current Rust `CallStatus` values:
+   - `offering`, `ringing`, `connecting`, `active`, `ended(reason)`
+4. Current runtime behavior:
+   - `startCall` moves to `offering`.
+   - `acceptCall` moves to `connecting`.
+   - runtime connected/stats move to `active` and set `started_at`.
+   - end/reject moves to `ended(reason)` (not immediately `nil`).
+
+## CallKit Integration Principles (New)
+
+1. Use one global `CXProvider` and one global `CXCallController`.
+2. Keep a deterministic map between Rust `call_id` and CallKit `UUID`.
+3. Treat CallKit as a control plane and system UI surface; Rust still owns domain state.
+4. Make all cross-plane actions idempotent (duplicate callbacks and racey ordering are normal).
+5. Fulfill/fail every CallKit action promptly; never leave actions pending.
 
 ## Phase 0: Foundation + Warning Cleanup
 
@@ -140,32 +187,161 @@ status: phase_0_3_complete
 
 ## Phase 4: CallKit + Advanced Audio Routing
 
+### Phase 4A: CallKit Control Plane (Foreground-First)
+
+#### Scope
+
+1. Add `CallKitCoordinator` in iOS layer (`CXProvider` + `CXCallController` + UUID map).
+2. Outgoing flow:
+   - Request `CXStartCallAction`.
+   - In provider `perform start`, dispatch Rust `startCall(chatId)`.
+   - On Rust state transitions, report:
+     - `reportOutgoingCall(... startedConnectingAt:)` when `connecting`
+     - `reportOutgoingCall(... connectedAt:)` when `active`
+3. Incoming flow (while app is running):
+   - When Rust enters `ringing`, call `reportNewIncomingCall`.
+   - In provider `perform answer`, dispatch Rust `acceptCall(chatId)`.
+   - In provider `perform end` while ringing, dispatch Rust `rejectCall(chatId)`.
+4. End flow:
+   - On Rust `ended(reason)`, report CallKit end reason once and retire mapping.
+
+#### Exit Criteria
+
+1. System incoming/outgoing call UI appears and is interactive.
+2. Answer/reject/end from CallKit drives Rust correctly.
+3. In-app call UI and CallKit stay synchronized without duplicate calls.
+
+### Phase 4B: Action Parity (Mute/Hold Semantics)
+
+#### Scope
+
+1. Add deterministic mute action support for CallKit `CXSetMutedCallAction`.
+2. Recommended Rust API addition:
+   - `setMute(isMuted: Bool)` to avoid races inherent in `toggleMute`.
+3. Hold support:
+   - If runtime cannot hold media yet, explicitly fail `CXSetHeldCallAction` (do not fake hold).
+
+#### Exit Criteria
+
+1. AirPods/system mute actions stay in sync with Rust `is_muted`.
+2. No mute flip-flop from repeated toggle races.
+
+### Phase 4C: Audio Session Ownership Handoff
+
+#### Scope
+
+1. Keep voice config (`.playAndRecord`, `.voiceChat`, `.allowBluetoothHFP`) but hand activation lifecycle to CallKit delegate callbacks:
+   - `provider(_:didActivate:)`
+   - `provider(_:didDeactivate:)`
+2. Update `CallAudioSessionCoordinator` so it can run in:
+   - non-CallKit mode (current behavior)
+   - CallKit-driven mode (activation delegated to CallKit)
+3. Add observers/handling for:
+   - interruptions
+   - route changes
+   - foreground/background transitions
+4. Add route diagnostics and explicit route selection plumbing for speaker/receiver/Bluetooth where needed.
+
+#### Exit Criteria
+
+1. No one-way-audio regressions across route switches.
+2. Audio activation/deactivation order is deterministic in logs.
+3. Switching between outputs/inputs remains user-controllable.
+
+### Phase 4D: PushKit + Background Incoming (If Product Requires It)
+
+#### Scope
+
+1. Register VoIP push token via `PKPushRegistry` and backend plumbing.
+2. On VoIP push receive, report incoming call to CallKit immediately, then reconcile with Rust call state.
+3. Add pending-invite cache for startup/background race windows.
+4. Enforce strict dedupe by `call_id` + UUID mapping to avoid duplicate reports.
+
+#### Exit Criteria
+
+1. Incoming calls ring when app is backgrounded/terminated.
+2. No PushKit contract violations due to delayed/missing CallKit reporting.
+
+## Phase 5: Apple Audio Pipeline Migration (Stub)
+
 ### Scope
 
-1. Integrate CallKit (`CXProvider`, `CXCallController`) for system call UX.
-2. Improve audio route behavior and interruptions handling.
-3. Preserve ability to switch input/output devices while using voice-optimized processing.
-
-### Audio/Platform Notes
-
-1. Continue using `.playAndRecord` + `.voiceChat`.
-2. Prefer HFP route support for bidirectional call audio (`.allowBluetoothHFP`).
-3. Validate route switching UX (speaker, receiver, Bluetooth) against real devices.
-4. Handle interruptions, route changes, and foreground/background transitions cleanly.
+1. Replace iOS call capture/playback backend from Rust `cpal` to Apple-native voice pipeline.
+2. Keep Rust as owner of call signaling/state/crypto/media transport; migrate only iOS audio I/O path.
+3. Add an explicit iOS audio bridge contract for 20ms PCM frames (48 kHz mono) between Swift audio engine and Rust media loop.
+4. Use Apple voice-processing path (`AVAudioSession` voice-call config + voice-processing-enabled I/O) so echo cancellation/noise handling come from Apple stack.
+5. Preserve user route control (receiver/speaker/wired/Bluetooth HFP) and ensure route changes do not break duplex audio.
+6. Remove iOS dependence on `cpal` for production call quality.
 
 ### Exit Criteria
 
-1. Incoming/outgoing call lifecycle is reflected in system UI.
-2. Audio routing is consistent and debuggable.
-3. Existing in-app call controls remain coherent with CallKit state.
+1. On iOS, active calls use Apple-native capture/playback path end-to-end (not `cpal`).
+2. Voice-processing behavior is measurably improved in real-device tests (echo, background noise, duplex stability).
+3. Route switching and interruptions are stable with no one-way audio regressions.
+4. Rust call-state behavior and in-app/CallKit UX remain unchanged by audio backend swap.
+5. `cpal` path remains only as non-iOS fallback/testing backend.
+
+## CallKit <-> Rust Mapping
+
+1. Rust `offering`:
+   - CallKit call exists, outgoing transaction active.
+2. Rust `connecting`:
+   - call `reportOutgoingCall(... startedConnectingAt:)`.
+3. Rust `active`:
+   - call `reportOutgoingCall(... connectedAt:)`.
+4. Rust `ringing`:
+   - call `reportNewIncomingCall`.
+5. Rust `ended(reason)`:
+   - map reason to `CXCallEndedReason` and call `reportCall(... endedAt:reason:)`.
+
+## Risks and Mitigations
+
+1. Duplicate end reporting:
+   - mitigate with per-call one-shot "endedReported" guard.
+2. Call action races (in-app vs system buttons):
+   - route all actions through one coordinator and compare against latest Rust snapshot before dispatch.
+3. UUID mismatches:
+   - deterministic UUID strategy with persistence for active call.
+4. Mute race from `toggleMute`:
+   - add `setMute` action in Phase 4B.
+5. Audio activation conflicts:
+   - single owner policy: either CallKit owns activation or app does, never both at once.
+
+## Validation Matrix (Phase 4)
+
+1. Outgoing call start from in-app button, then end from CallKit UI.
+2. Incoming call answer from CallKit UI, then end from in-app UI.
+3. Incoming call reject from CallKit UI.
+4. Mute/unmute from in-app and system route/mute controls.
+5. Route switches during active call:
+   - receiver <-> speaker
+   - wired headset connect/disconnect
+   - Bluetooth HFP connect/disconnect
+6. Interruptions:
+   - another cellular/FaceTime call
+   - Siri interruption
+7. App lifecycle:
+   - foreground to background to foreground while active call is live
+8. Multi-device behavior sanity checks on real devices.
+
+## Primary References Used For This Plan
+
+1. Apple docs: `CXProvider` and `CXCallAction` API surface.
+2. WWDC20 Session 10111 (`Advances in App Background Execution`) CallKit/PushKit flow guidance.
+3. WWDC23 Session 10235 (`Tune voice processing for audio input and output`) voice-processing/audio-session guidance.
+4. WWDC23 Session 10233 (`Enhance your app's audio experience with AirPods`) mute-control and `AVAudioApplication` behavior.
 
 ## Recommended Execution Order
 
 1. Phase 0 first (safe refactor + warning cleanup).
 2. Phase 1 second (visible UX win).
 3. Phase 2 third (continuity polish).
-4. Phase 3 optional (defer if velocity matters).
-5. Phase 4 when platform integration is prioritized.
+4. Phase 3 fourth (now complete).
+5. Phase 4A next (CallKit control plane).
+6. Phase 4C after 4A (audio-session ownership handoff).
+7. Phase 4B next (mute/hold action parity).
+8. Phase 4D last, gated on background incoming requirements/backend readiness.
+9. Phase 5 after Phase 4 is stable (Apple-native iOS audio pipeline migration).
 
 ## QA Checklist (Per Phase)
 

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -26,6 +26,11 @@
 	<string>Scan QR codes to start new chats.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Voice calls require microphone access.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>voip</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/Sources/ContentView.swift
+++ b/ios/Sources/ContentView.swift
@@ -142,20 +142,20 @@ struct ContentView: View {
                 peerName: callPeerDisplayName(for: call, in: state),
                 onAcceptCall: {
                     manager.dispatch(.openChat(chatId: call.chatId))
-                    manager.dispatch(.acceptCall(chatId: call.chatId))
+                    manager.acceptCall(chatId: call.chatId)
                 },
                 onRejectCall: {
-                    manager.dispatch(.rejectCall(chatId: call.chatId))
+                    manager.rejectCall(chatId: call.chatId)
                 },
                 onEndCall: {
-                    manager.dispatch(.endCall)
+                    manager.endCall()
                 },
                 onToggleMute: {
                     manager.dispatch(.toggleMute)
                 },
                 onStartAgain: {
                     manager.dispatch(.openChat(chatId: call.chatId))
-                    manager.dispatch(.startCall(chatId: call.chatId))
+                    manager.startCall(chatId: call.chatId)
                 },
                 onDismiss: {
                     isCallScreenPresented = false
@@ -218,7 +218,7 @@ private func screenView(
             activeCall: state.activeCall,
             callEvents: manager.callTimelineEventsByChatId[chatId] ?? [],
             onSendMessage: { manager.dispatch(.sendMessage(chatId: chatId, content: $0)) },
-            onStartCall: { manager.dispatch(.startCall(chatId: chatId)) },
+            onStartCall: { manager.startCall(chatId: chatId) },
             onOpenCallScreen: {
                 onOpenCallScreen()
             },


### PR DESCRIPTION
## Summary
- add a global iOS `CallKitCoordinator` (`CXProvider` + `CXCallController`) and wire it through `AppManager`
- route in-app call actions (`start/accept/reject/end`) through CallKit transactions first, with Rust dispatch fallback on failure
- synchronize Rust `activeCall` transitions with CallKit reporting for outgoing/incoming/connect/end lifecycle
- add deterministic Rust `call_id` <-> CallKit `UUID` mapping, including fallback UUID derivation
- add `UIBackgroundModes` (`audio`, `voip`) in iOS app plist for call behavior groundwork
- update calling UX docs status: Phase 4A complete baseline, Phase 4B/C/D remaining

## Validation
- `xcodebuild -project ios/Pika.xcodeproj -scheme Pika -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project ios/Pika.xcodeproj -scheme Pika -configuration Debug -destination 'platform=iOS Simulator,name=Pika iPhone 15' ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS=x86_64 build`
- manual device run via `./tools/pika-run ios run --device --udid <udid> --console`
  - observed `requestStartCall transaction accepted`
  - observed `provider perform start`
  - observed `CXCallObserver` tracking active outgoing call
  - confirmed system CallKit UI/indicators appear on device

## Follow-ups (out of scope)
- Phase 4B: mute/hold parity (`CXSetMutedCallAction`, explicit hold failure until runtime supports hold)
- Phase 4C: hand audio-session activation/deactivation ownership to CallKit delegate callbacks
- Phase 4D: PushKit + background incoming flow
