### PR TITLE
ci: post concise nostr kind-1 announcement on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,6 @@ jobs:
         env:
           AGE_SECRET_KEY: ${{ secrets.AGE_SECRET_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZAPSTORE_SIGN_WITH: ${{ secrets.ZAPSTORE_SIGN_WITH }}
         run: |
           set -euo pipefail
           set +x
@@ -211,3 +210,38 @@ jobs:
           fi
           apk_path="$(find dist -maxdepth 1 -type f -name '*.apk' | head -n 1)"
           nix develop .#default -c ./scripts/zapstore-publish "$apk_path" "https://github.com/${GITHUB_REPOSITORY}"
+
+  announce-release:
+    if: github.actor == 'justinmoon' || github.actor == 'futurepaul' || github.actor == 'AnthonyRonning' || github.actor == 'benthecarman'
+    needs: publish
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure announcement signing secret exists
+        run: |
+          set -euo pipefail
+          if [ ! -f secrets/zapstore-signing.env.age ]; then
+            echo "error: missing secrets/zapstore-signing.env.age (required for release announcement signing)"
+            exit 1
+          fi
+
+      - uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-nix-v1-${{ runner.os }}
+          path: /nix
+      - name: Fix /nix ownership
+        run: |
+          if [ -d /nix ] && [ "$(stat -c %u /nix)" != "$(id -u)" ]; then
+            sudo chown -R $(id -u):$(id -g) /nix
+          fi
+      - uses: nixbuild/nix-quick-install-action@v30
+
+      - name: Publish release announcement (kind 1)
+        env:
+          AGE_SECRET_KEY: ${{ secrets.AGE_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          set +x
+          repo_url="https://github.com/${GITHUB_REPOSITORY}"
+          nix develop .#default -c ./scripts/post-release-announcement "${GITHUB_REF_NAME}" "$repo_url"

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,6 +14,7 @@ This repo has three independent release pipelines, all tag-driven:
 |--------|------------|-------------|-----------|
 | Android APK | `v*` (e.g. `v0.2.2`) | `release.yml` | Signed APK + SHA256SUMS on GitHub Releases |
 | Zapstore publish | `v*` (e.g. `v0.2.2`) | `release.yml` (`publish-zapstore` job) | NIP-82 app/release/asset events on Zapstore relays |
+| Nostr announcement | `v*` (e.g. `v0.2.2`) | `release.yml` (`announce-release` job) | Kind-1 release announcement note |
 | marmotd (OpenClaw extension) | `marmotd-v*` (e.g. `marmotd-v0.3.2`) | `marmotd-release.yml` | Linux + macOS binaries on GitHub Releases, npm package |
 
 **Important:** All release tags must be created from the `master` branch. Tags on
@@ -88,6 +89,9 @@ gh release view v0.3.0
 - Publish helper:
   - `./scripts/zapstore-publish <apk-path> [repo-url]`
   - used by both `just zapstore-publish` and CI to centralize secret handling
+- Release announcement helper:
+  - `./scripts/post-release-announcement <tag> [repo-url] [zapstore-app-url]`
+  - publishes concise kind-1 release announcements to popular relays
 - Optional for local hardware-key decrypt:
   - `PIKA_AGE_IDENTITY_FILE` (defaults to `~/configs/yubikeys/keys.txt`)
 
@@ -116,6 +120,7 @@ Jobs:
 2. `build` - runs `just android-release`, uploads APK + `SHA256SUMS`
 3. `publish` - creates GitHub Release with uploaded assets
 4. `publish-zapstore` - publishes the built APK artifact to Zapstore relays
+5. `announce-release` - publishes a kind-1 release announcement (Zapstore + GitHub links)
 
 `publish-zapstore` is gated on `secrets/zapstore-signing.env.age` existing in
 git. It decrypts `ZAPSTORE_SIGN_WITH` via `AGE_SECRET_KEY`, uses centralized

--- a/scripts/post-release-announcement
+++ b/scripts/post-release-announcement
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set +x
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEFAULT_REPO_URL="https://github.com/sledtools/pika"
+DEFAULT_ZAPSTORE_APP_URL="https://zapstore.dev/app/com.justinmoon.pika"
+
+usage() {
+  cat <<'USAGE'
+usage: ./scripts/post-release-announcement <tag> [repo-url] [zapstore-app-url]
+
+Publishes a kind-1 Nostr release announcement for a Git tag release.
+
+Arguments:
+  tag               Release tag (e.g. v0.2.5)
+  repo-url          Optional repository URL (default: https://github.com/sledtools/pika)
+  zapstore-app-url  Optional Zapstore app URL (default: https://zapstore.dev/app/com.justinmoon.pika)
+
+Environment:
+  PIKA_ANNOUNCE_RELAYS  Space-delimited relay list override
+USAGE
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: missing command: $1" >&2
+    exit 1
+  fi
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+  usage >&2
+  exit 2
+fi
+
+need_cmd nak
+need_cmd tr
+
+tag="$1"
+repo_url="${2:-$DEFAULT_REPO_URL}"
+zapstore_app_url="${3:-$DEFAULT_ZAPSTORE_APP_URL}"
+
+if ! printf '%s\n' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "error: invalid tag format: $tag (expected vX.Y.Z)" >&2
+  exit 1
+fi
+
+sign_with="$(cd "$ROOT" && ./scripts/read-zapstore-sign-with | tr -d '\r\n')"
+if [ -z "$sign_with" ]; then
+  echo "error: decrypted Zapstore signing value is empty" >&2
+  exit 1
+fi
+
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  printf '::add-mask::%s\n' "$sign_with"
+fi
+
+content="Pika Android ${tag} is live.
+Install on Zapstore: ${zapstore_app_url}
+GitHub release: ${repo_url}/releases/tag/${tag}"
+
+if [ -n "${PIKA_ANNOUNCE_RELAYS:-}" ]; then
+  IFS=' ' read -r -a relays <<<"${PIKA_ANNOUNCE_RELAYS}"
+else
+  relays=(
+    "wss://relay.primal.net"
+    "wss://relay.damus.io"
+    "wss://relay.zapstore.dev"
+    "wss://nos.lol"
+    "wss://relay.nostr.band"
+  )
+fi
+
+if [ "${#relays[@]}" -eq 0 ]; then
+  echo "error: no relays configured for announcement" >&2
+  exit 1
+fi
+
+NOSTR_SECRET_KEY="$sign_with" nak -q event -k 1 -c "$content" "${relays[@]}"
+unset sign_with


### PR DESCRIPTION
## Summary
- add `scripts/post-release-announcement` to publish a concise kind-1 release note
- wire new `announce-release` job into `release.yml` so every `v*` release posts an announcement
- include Zapstore install URL + GitHub release URL in the note content
- remove leftover `ZAPSTORE_SIGN_WITH` workflow env wiring (age-only path remains)

## Security hardening
- no plaintext signing secret in repo or workflow vars
- announcement script decrypts via existing age flow (`read-zapstore-sign-with`)
- disables xtrace (`set +x`) while handling signer value
- masks signer in GitHub Actions logs via `::add-mask::`
- avoids passing signer on CLI flags; uses one-process `NOSTR_SECRET_KEY` env for `nak`

## Validation
- `bash -n` on updated/new scripts
- `./scripts/post-release-announcement --help`
- workflow diff reviewed for secret handling and job ordering
