### PR TITLE
feat(rmp-cli): add devices start command

### DIFF
--- a/crates/rmp-cli/src/cli.rs
+++ b/crates/rmp-cli/src/cli.rs
@@ -86,6 +86,45 @@ pub struct InitArgs {
 pub enum DevicesCmd {
     /// List devices/simulators/emulators.
     List,
+
+    /// Start a simulator/emulator target and wait until ready.
+    Start(DevicesStartArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct DevicesStartArgs {
+    #[arg(value_enum)]
+    pub platform: DeviceStartPlatform,
+
+    #[command(flatten)]
+    pub ios: DevicesStartIosArgs,
+
+    #[command(flatten)]
+    pub android: DevicesStartAndroidArgs,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy)]
+pub enum DeviceStartPlatform {
+    Ios,
+    Android,
+}
+
+#[derive(clap::Args, Debug, Default)]
+pub struct DevicesStartIosArgs {
+    /// iOS simulator UDID to target.
+    #[arg(long)]
+    pub udid: Option<String>,
+}
+
+#[derive(clap::Args, Debug, Default)]
+pub struct DevicesStartAndroidArgs {
+    /// Android emulator serial to target.
+    #[arg(long)]
+    pub serial: Option<String>,
+
+    /// Android AVD name to start if no emulator is running.
+    #[arg(long)]
+    pub avd: Option<String>,
 }
 
 #[derive(clap::Args, Debug)]

--- a/crates/rmp-cli/src/main.rs
+++ b/crates/rmp-cli/src/main.rs
@@ -28,6 +28,9 @@ fn main() -> ExitCode {
                 cli::Cmd::Devices {
                     cmd: cli::DevicesCmd::List,
                 } => devices::devices_list(&root, args.json, args.verbose),
+                cli::Cmd::Devices {
+                    cmd: cli::DevicesCmd::Start(s),
+                } => devices::devices_start(&root, args.json, args.verbose, s),
                 cli::Cmd::Bindings(b) => bindings::bindings(&root, args.json, args.verbose, b),
                 cli::Cmd::Run(r) => run::run(&root, args.json, args.verbose, r),
                 cli::Cmd::Init(_) => unreachable!(),

--- a/crates/rmp-cli/src/run.rs
+++ b/crates/rmp-cli/src/run.rs
@@ -174,7 +174,7 @@ fn run_ios(
     Ok(())
 }
 
-fn ensure_ios_simulator(
+pub(crate) fn ensure_ios_simulator(
     dev_dir: &Path,
     explicit_udid: Option<&str>,
     verbose: bool,
@@ -557,7 +557,7 @@ fn run_android(
     Ok(())
 }
 
-fn ensure_android_emulator(
+pub(crate) fn ensure_android_emulator(
     root: &Path,
     avd: &str,
     explicit_serial: Option<&str>,


### PR DESCRIPTION
## Summary
- add `rmp devices start` command to boot and wait for simulator/emulator readiness
- support both platforms:
  - `rmp devices start ios [--udid ...]`
  - `rmp devices start android [--serial ...] [--avd ...]`
- reuse existing run-time target boot helpers (`ensure_ios_simulator`, `ensure_android_emulator`)

## CLI
- new enum variant: `DevicesCmd::Start(DevicesStartArgs)`
- output supports human + `--json`

## Validation
- `cargo check -p rmp-cli`
