### PR TITLE
fix(ios): build/deploy issues blocking new developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ android/local.properties
 ios/.build/
 ios/build/
 ios/build-device/
+ios/build-appstore/
 ios/Frameworks/
 ios/**/xcuserdata/
 ios/Bindings/*.swift
@@ -28,6 +29,7 @@ ios/Bindings/*.modulemap
 ios/NSEBindings/*.swift
 ios/NSEBindings/*.h
 ios/NSEBindings/*.modulemap
+ios/.build-number
 
 # Misc
 .android-avd/

--- a/ios/NotificationService/Info.plist
+++ b/ios/NotificationService/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>Pika Notifications</string>
 	<key>PikaAppGroup</key>
 	<string>$(PIKA_APP_GROUP)</string>
 	<key>PikaKeychainGroup</key>

--- a/ios/NotificationService/NotificationService.entitlements
+++ b/ios/NotificationService/NotificationService.entitlements
@@ -6,12 +6,11 @@
 	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.$(PIKA_APP_BUNDLE_ID)</string>
+		<string>$(PIKA_APP_GROUP)</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(PIKA_APP_BUNDLE_ID).shared</string>
 	</array>
-
 </dict>
 </plist>

--- a/ios/Pika.entitlements
+++ b/ios/Pika.entitlements
@@ -8,7 +8,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+		<string>$(PIKA_APP_GROUP)</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/ios/Sources/AppManager.swift
+++ b/ios/Sources/AppManager.swift
@@ -54,8 +54,15 @@ final class AppManager: AppReconciler {
         let fm = FileManager.default
         let appGroup = Bundle.main.infoDictionary?["PikaAppGroup"] as? String ?? "group.com.justinmoon.pika"
         let keychainGroup = Bundle.main.infoDictionary?["PikaKeychainGroup"] as? String ?? ""
-        let dataDirUrl = fm.containerURL(forSecurityApplicationGroupIdentifier: appGroup)!
-            .appendingPathComponent("Library/Application Support")
+        let dataDirUrl: URL
+        if let groupContainer = fm.containerURL(forSecurityApplicationGroupIdentifier: appGroup) {
+            dataDirUrl = groupContainer.appendingPathComponent("Library/Application Support")
+        } else {
+            // Fallback for simulator builds where CODE_SIGNING_ALLOWED=NO
+            // means entitlements aren't embedded and the app group container
+            // is unavailable. NSE won't work but the app itself runs fine.
+            dataDirUrl = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        }
         let dataDir = dataDirUrl.path
         let nsecStore = KeychainNsecStore(keychainGroup: keychainGroup)
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,6 +1,6 @@
 name: Pika
 options:
-  bundleIdPrefix: com.justinmoon
+  bundleIdPrefix: org.pikachat
   deploymentTarget:
     iOS: "17.0"
   createIntermediateGroups: true
@@ -9,12 +9,12 @@ settings:
   base:
     # PIKA_APP_BUNDLE_ID is the "root" bundle id; targets derive from it.
     # Override on the xcodebuild command line (run-ios does this automatically).
-    PIKA_APP_BUNDLE_ID: com.justinmoon.pika
+    PIKA_APP_BUNDLE_ID: org.pikachat.pika
     PRODUCT_BUNDLE_IDENTIFIER: $(PIKA_APP_BUNDLE_ID)
     # PIKA_APP_GROUP: derived from bundle ID. Override via xcodebuild if needed.
     PIKA_APP_GROUP: "group.$(PIKA_APP_BUNDLE_ID)"
     CODE_SIGN_STYLE: Automatic
-    MARKETING_VERSION: 0.1.0
+    MARKETING_VERSION: 1.0
     CURRENT_PROJECT_VERSION: 1
     SWIFT_VERSION: 5.0
 
@@ -45,6 +45,16 @@ targets:
         embed: false
       - package: MarkdownUI
       - target: PikaNotificationService
+    postBuildScripts:
+      - name: "Stamp build number"
+        script: |
+          if [ -f "${PROJECT_DIR}/.build-number" ]; then
+            BUILD_NUMBER=$(cat "${PROJECT_DIR}/.build-number")
+          else
+            BUILD_NUMBER=$(date +"%Y%m%d%H%M")
+          fi
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"
+        basedOnDependencyAnalysis: false
 
   PikaNotificationService:
     type: app-extension
@@ -57,6 +67,7 @@ targets:
           - "*.modulemap"
     settings:
       base:
+        PRODUCT_NAME: PikaNotificationService
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_FILE: NotificationService/Info.plist
         CODE_SIGN_ENTITLEMENTS: NotificationService/NotificationService.entitlements
@@ -64,6 +75,16 @@ targets:
     dependencies:
       - framework: Frameworks/PikaNSE.xcframework
         embed: false
+    postBuildScripts:
+      - name: "Stamp build number"
+        script: |
+          if [ -f "${PROJECT_DIR}/.build-number" ]; then
+            BUILD_NUMBER=$(cat "${PROJECT_DIR}/.build-number")
+          else
+            BUILD_NUMBER=$(date +"%Y%m%d%H%M")
+          fi
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"
+        basedOnDependencyAnalysis: false
 
   PikaTests:
     type: bundle.unit-test
@@ -126,6 +147,9 @@ targets:
 schemes:
   Pika:
     build:
+      preActions:
+        - script: 'date +"%Y%m%d%H%M" > "${PROJECT_DIR}/.build-number"'
+          settingsTarget: Pika
       targets:
         Pika: all
     test:

--- a/justfile
+++ b/justfile
@@ -530,6 +530,17 @@ ios-xcframework: ios-gen-swift ios-rust
 ios-xcodeproj:
   cd ios && rm -rf Pika.xcodeproj && xcodegen generate
 
+# Prepare for App Store: build both xcframework slices and regenerate project.
+# After running, open Xcode, select your dev team, and Product > Archive.
+ios-appstore: ios-xcframework ios-xcodeproj
+  @echo ""
+  @echo "Ready for App Store build."
+  @echo "  1. Open Xcode:  open ios/Pika.xcodeproj"
+  @echo "  2. Select your development team in Signing & Capabilities"
+  @echo "  3. Product > Archive"
+  @echo ""
+  open ios/Pika.xcodeproj
+
 # Build iOS app for simulator.
 ios-build-sim: ios-xcframework ios-xcodeproj
   SIM_ARCH="${PIKA_IOS_SIM_ARCH:-$( [ "$(uname -m)" = "x86_64" ] && echo x86_64 || echo arm64 )}"; \


### PR DESCRIPTION
## Context

After pulling master I couldn't build or deploy the app at all. This documents the full gauntlet I ran through and the fixes needed.

## What this PR fixes

### 1. Simulator crash on launch (`EXC_BREAKPOINT` at AppManager.swift:57)

`containerURL(forSecurityApplicationGroupIdentifier:)` returns `nil` on simulator because `ios-build-sim` uses `CODE_SIGNING_ALLOWED=NO`, which means entitlements aren't embedded in the binary. The force-unwrap `!` crashes immediately.

**Fix:** Fall back to `applicationSupportDirectory` when the app group container is unavailable.

### 2. Xcode GUI: "Multiple commands produce .appex"

The NSE target doesn't have an explicit `PRODUCT_NAME` in project.yml. xcodegen leaves it unset, confusing Xcode's build system about the `.appex` output path.

**Fix:** Add `PRODUCT_NAME: PikaNotificationService` to the NSE target in project.yml.

### 3. App Store upload: "Missing Info.plist value CFBundleDisplayName"

App Store validation rejects the upload because the NSE's Info.plist is missing `CFBundleDisplayName`.

**Fix:** Add `CFBundleDisplayName` to `NotificationService/Info.plist`.

### 4. Bundle ID reset to `com.justinmoon` after every xcodegen run

`project.yml` hardcoded `bundleIdPrefix: com.justinmoon` and `PIKA_APP_BUNDLE_ID: com.justinmoon.pika`. Every `xcodegen generate` (which happens on every `just run-ios`) wiped any manual `org.pikachat.pika` set in Xcode.

**Fix:** Changed project.yml defaults to `org.pikachat.pika`. Dev scripts (`just run-ios`) already override to `com.justinmoon.pika.dev` via `PIKA_IOS_BUNDLE_ID` env var, so dev builds are unaffected.

### 5. Entitlements inconsistency between app and NSE

`Pika.entitlements` used `group.$(PRODUCT_BUNDLE_IDENTIFIER)` while `NotificationService.entitlements` hardcoded `group.org.pikachat.pika`. These could diverge depending on the build configuration.

**Fix:** Both entitlements now use `$(PIKA_APP_GROUP)`, which derives from the same `PIKA_APP_BUNDLE_ID` build setting.

### 6. CFBundleVersion mismatch between app and extension

Static `CURRENT_PROJECT_VERSION: 1` in project.yml meant manually bumping the build number was easy to forget, and app/extension versions could drift.

**Fix:** Added a scheme pre-action + postBuildScripts that stamp `CFBundleVersion` with a timestamp (`YYYYMMDDHHmm`) at build time. Both targets read from the same generated `.build-number` file, guaranteeing they match. `MARKETING_VERSION` updated to `1.0`.

### 7. No easy App Store build workflow

`just run-ios` rebuilds xcframeworks with only the simulator slice (for speed), then `xcodegen generate` wipes manual Xcode settings. Opening Xcode afterward for a device/archive build fails with "no library for this platform".

**Fix:** Added `just ios-appstore` recipe that builds both xcframework slices (device + sim), regenerates the project, and opens Xcode — ready for Archive.

### 8. `ios/build-appstore/` not gitignored

**Fix:** Added to `.gitignore`.

## Test plan

- [x] Simulator build via `just run-ios` — launches without crash
- [x] `just ios-appstore` builds both xcframework slices and opens Xcode
- [x] App Store archive — build number auto-stamps from timestamp
- [x] App and extension CFBundleVersion match

🤖 Generated with [Claude Code](https://claude.com/claude-code)