### PR TITLE
fix(marmot): read groupPolicy/groups from live config in isGroupAllowed

### DIFF
--- a/openclaw-marmot/openclaw/extensions/marmot/src/config-schema.ts
+++ b/openclaw-marmot/openclaw/extensions/marmot/src/config-schema.ts
@@ -33,6 +33,9 @@ export const marmotPluginConfigSchema = {
         additionalProperties: false,
         properties: {
           name: { type: "string" },
+          requireMention: { type: "boolean" },
+          users: { type: "array", items: { type: "string" } },
+          systemPrompt: { type: "string" },
         },
       },
     },


### PR DESCRIPTION
Fixes #177.

## Problem

`isGroupAllowed` was capturing `allowedGroups` once at startup:

```ts
const allowedGroups = resolved.config.groups ?? {};  // captured at startAccount
```

If there was any issue with config loading at that moment (timing race, unexpected config structure, etc.), `allowedGroups` would be empty. Since `groupPolicy` defaults to `"allowlist"`, every group would be silently dropped with "group not allowed" — even groups explicitly listed in config.

## Fix

`isGroupAllowed` now reads from `runtime.config.loadConfig()` on every call, consistent with how `resolveGroupConfig` (and all other per-group config functions) work:

```ts
const isGroupAllowed = (nostrGroupId: string): boolean => {
  const liveCfg = runtime.config.loadConfig();
  const livePolicy = liveCfg?.channels?.marmot?.groupPolicy ?? "allowlist";
  if (livePolicy === "open") return true;
  const gid = String(nostrGroupId).trim().toLowerCase();
  const liveGroups = liveCfg?.channels?.marmot?.groups ?? {};
  return Object.keys(liveGroups).some((k) => String(k).trim().toLowerCase() === gid);
};
```

Benefits:
- No startup capture — always fresh
- Key normalization (lowercase + trim) is now explicit and consistent with incoming group IDs
- Config changes take effect without restart

## Bonus: config schema fix

Updated `config-schema.ts` group entry schema to include `requireMention`, `users`, and `systemPrompt` (added in #171 but the schema was never updated). Without this, schema validation could silently strip those fields.