### PR TITLE
fix: secure nsec login input on iOS and Android

### DIFF
--- a/android/app/src/androidTest/java/com/pika/app/PikaUiTest.kt
+++ b/android/app/src/androidTest/java/com/pika/app/PikaUiTest.kt
@@ -4,6 +4,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -13,6 +14,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pika.app.ui.TestTags
@@ -32,6 +35,17 @@ class PikaUiTest {
         //
         // If external tools (agent-device/uiautomator) are running concurrently, they can still
         // interfere; run UI tests in isolation.
+    }
+
+    @Test
+    fun loginNsecField_isPasswordSemantics() {
+        hardResetForeground()
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        runOnMain { AppManager.getInstance(ctx).logout() }
+
+        compose.onNodeWithTag(TestTags.LOGIN_NSEC)
+            .assertExists()
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.Password))
     }
 
     @Test

--- a/android/app/src/main/java/com/pika/app/ui/screens/LoginScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/LoginScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -20,6 +21,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.pika.app.AppManager
 import com.pika.app.rust.AppAction
@@ -69,6 +72,12 @@ fun LoginScreen(manager: AppManager, padding: PaddingValues) {
             singleLine = true,
             enabled = !anyBusy,
             label = { Text("nsec") },
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions =
+                KeyboardOptions(
+                    autoCorrect = false,
+                    keyboardType = KeyboardType.Password,
+                ),
             modifier = Modifier.fillMaxWidth().testTag(TestTags.LOGIN_NSEC),
         )
 

--- a/ios/Sources/Views/LoginView.swift
+++ b/ios/Sources/Views/LoginView.swift
@@ -62,7 +62,7 @@ struct LoginView: View {
                 }
                 .padding(.vertical, 4)
 
-                TextField("Enter your nsec", text: $nsecInput)
+                SecureField("Enter your nsec", text: $nsecInput)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .textFieldStyle(.roundedBorder)

--- a/ios/UITests/CallE2ETests.swift
+++ b/ios/UITests/CallE2ETests.swift
@@ -112,7 +112,7 @@ final class CallE2ETests: XCTestCase {
         app.launch()
 
         // --- Login with test nsec ---
-        let loginNsec = app.textFields.matching(identifier: "login_nsec_input").firstMatch
+        let loginNsec = app.secureTextFields.matching(identifier: "login_nsec_input").firstMatch
         let loginSubmit = app.buttons.matching(identifier: "login_submit").firstMatch
 
         if loginNsec.waitForExistence(timeout: 5) {

--- a/ios/UITests/PikaUITests.swift
+++ b/ios/UITests/PikaUITests.swift
@@ -330,7 +330,7 @@ final class PikaUITests: XCTestCase {
         let createAccount = app.buttons.matching(identifier: "login_create_account").firstMatch
         if createAccount.waitForExistence(timeout: 5) {
             if !testNsec.isEmpty {
-                let loginNsec = app.textFields.matching(identifier: "login_nsec_input").firstMatch
+                let loginNsec = app.secureTextFields.matching(identifier: "login_nsec_input").firstMatch
                 let loginSubmit = app.buttons.matching(identifier: "login_submit").firstMatch
                 XCTAssertTrue(loginNsec.waitForExistence(timeout: 5))
                 XCTAssertTrue(loginSubmit.waitForExistence(timeout: 5))


### PR DESCRIPTION
## Summary
- replace iOS login nsec entry with `SecureField`
- mask Android login nsec entry with password transformation + password keyboard
- tighten iOS UI test selectors to `secureTextFields`
- add Android UI regression test asserting password semantics on login nsec field
- desktop already had secure nsec input (`.secure(true)`), no desktop code change

Closes #123

## Verification
- `just nightly`
- `./tools/xcode-run xcodebuild -project ios/Pika.xcodeproj -scheme Pika -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build build-for-testing ARCHS=arm64 ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO PIKA_APP_BUNDLE_ID=org.pikachat.pika.dev`
- `cd android && ./gradlew :app:compileDebugKotlin :app:assembleDebug`
