### PR TITLE
fix(core): disable NIP-70 protected keypackage publish

### DIFF
--- a/rust/src/core/session.rs
+++ b/rust/src/core/session.rs
@@ -268,8 +268,9 @@ impl AppCore {
                         } else {
                             errors.join("; ")
                         };
-                        let any_retryable =
-                            errors.iter().any(|e| e.contains("auth") || e.contains("AUTH"));
+                        let any_retryable = errors
+                            .iter()
+                            .any(|e| e.contains("auth") || e.contains("AUTH"));
                         let maybe_not_connected = errors.iter().any(|e| {
                             e.contains("no relays")
                                 || e.contains("not ready")


### PR DESCRIPTION
## Summary
- strip `TagKind::Protected` from keypackage events before publish in `pika_core`
- keep split key-package relay plumbing intact (`key_package_relay_urls` behavior unchanged)
- keep retry logic focused on auth-related relay failures

## Validation
- `just nightly` (local)
