### PR TITLE
Add hidden developer mode with full local wipe tool

### DIFF
--- a/ios/Sources/ContentView.swift
+++ b/ios/Sources/ContentView.swift
@@ -196,6 +196,9 @@ private func screenView(
             onUploadProfilePhoto: { data, mimeType in
                 manager.uploadMyProfileImage(data: data, mimeType: mimeType)
             },
+            isDeveloperModeEnabledProvider: { manager.isDeveloperModeEnabled },
+            onEnableDeveloperMode: { manager.enableDeveloperMode() },
+            onWipeLocalData: { manager.wipeLocalDataForDeveloperTools() },
             nsecProvider: { manager.getNsec() }
         )
     case .newChat:

--- a/ios/Sources/Views/ChatListView.swift
+++ b/ios/Sources/Views/ChatListView.swift
@@ -11,6 +11,9 @@ struct ChatListView: View {
     let onRefreshProfile: @MainActor () -> Void
     let onSaveProfile: @MainActor (_ name: String, _ about: String) -> Void
     let onUploadProfilePhoto: @MainActor (_ data: Data, _ mimeType: String) -> Void
+    let isDeveloperModeEnabledProvider: @MainActor () -> Bool
+    let onEnableDeveloperMode: @MainActor () -> Void
+    let onWipeLocalData: @MainActor () -> Void
     let nsecProvider: @MainActor () -> String?
     @State private var showMyNpub = false
 
@@ -93,7 +96,10 @@ struct ChatListView: View {
                             onRefreshProfile: onRefreshProfile,
                             onSaveProfile: onSaveProfile,
                             onUploadPhoto: onUploadProfilePhoto,
-                            onLogout: onLogout
+                            onLogout: onLogout,
+                            isDeveloperModeEnabledProvider: isDeveloperModeEnabledProvider,
+                            onEnableDeveloperMode: onEnableDeveloperMode,
+                            onWipeLocalData: onWipeLocalData
                         )
                     }
                 }
@@ -171,6 +177,9 @@ struct ChatListView: View {
             onRefreshProfile: {},
             onSaveProfile: { _, _ in },
             onUploadProfilePhoto: { _, _ in },
+            isDeveloperModeEnabledProvider: { false },
+            onEnableDeveloperMode: {},
+            onWipeLocalData: {},
             nsecProvider: { nil }
         )
     }
@@ -192,6 +201,9 @@ struct ChatListView: View {
             onRefreshProfile: {},
             onSaveProfile: { _, _ in },
             onUploadProfilePhoto: { _, _ in },
+            isDeveloperModeEnabledProvider: { false },
+            onEnableDeveloperMode: {},
+            onWipeLocalData: {},
             nsecProvider: { nil }
         )
     }
@@ -213,6 +225,9 @@ struct ChatListView: View {
             onRefreshProfile: {},
             onSaveProfile: { _, _ in },
             onUploadProfilePhoto: { _, _ in },
+            isDeveloperModeEnabledProvider: { false },
+            onEnableDeveloperMode: {},
+            onWipeLocalData: {},
             nsecProvider: { nil }
         )
     }

--- a/rust/src/actions.rs
+++ b/rust/src/actions.rs
@@ -11,6 +11,7 @@ pub enum AppAction {
         nsec: String,
     },
     Logout,
+    WipeLocalData,
     RefreshMyProfile,
     SaveMyProfile {
         name: String,
@@ -132,6 +133,7 @@ impl AppAction {
             AppAction::Login { .. } => "Login",
             AppAction::RestoreSession { .. } => "RestoreSession",
             AppAction::Logout => "Logout",
+            AppAction::WipeLocalData => "WipeLocalData",
             AppAction::RefreshMyProfile => "RefreshMyProfile",
             AppAction::SaveMyProfile { .. } => "SaveMyProfile",
             AppAction::UploadMyProfileImage { .. } => "UploadMyProfileImage",


### PR DESCRIPTION
## Summary
- add hidden developer mode unlock via 7 taps on build number (iOS + Android)
- add developer-only UI action to wipe all local app data with destructive confirmation
- add new Rust `AppAction::WipeLocalData` flow that fully clears local storage, resets in-memory config, and preserves iOS migration sentinel
- keep this available in release builds for now (no debug gating)

## Verification
- cargo test -p pika_core --test app_flows
- ./gradlew :app:compileDebugKotlin
- xcodebuild -project ios/Pika.xcodeproj -scheme Pika -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO PIKA_APP_BUNDLE_ID=org.pikachat.pika.dev