### PR TITLE
fix(auth): harden nostr-connect callback flow and iOS scheme binding

### DIFF
--- a/android/app/src/main/java/com/pika/app/AmberIntentBridge.kt
+++ b/android/app/src/main/java/com/pika/app/AmberIntentBridge.kt
@@ -40,10 +40,16 @@ object AmberIntentBridge {
         // Bring Pika back to the foreground — Amber may leave its own activity
         // on top of our task stack even after finishing the result handshake.
         activityRef.get()?.get()?.let { activity ->
-            val bringBack = activity.packageManager.getLaunchIntentForPackage(activity.packageName)
-            if (bringBack != null) {
-                bringBack.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-                activity.startActivity(bringBack)
+            if (!activity.hasWindowFocus()) {
+                val bringBack = activity.packageManager.getLaunchIntentForPackage(activity.packageName)
+                if (bringBack != null) {
+                    bringBack.addFlags(
+                        Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or
+                            Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                            Intent.FLAG_ACTIVITY_CLEAR_TOP,
+                    )
+                    activity.startActivity(bringBack)
+                }
             }
         }
         future.complete(

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -29,9 +29,7 @@
 			<string>com.justinmoon.pika</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>pika</string>
-				<string>pika-dev</string>
-				<string>pika-test</string>
+				<string>$(PIKA_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/Pika.xcodeproj/project.pbxproj
+++ b/ios/Pika.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PIKA_URL_SCHEME = "pika-dev";
 				PRODUCT_BUNDLE_IDENTIFIER = com.justinmoon.pika.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -609,6 +610,7 @@
 				MARKETING_VERSION = 0.1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				PIKA_URL_SCHEME = pika;
 				PRODUCT_BUNDLE_IDENTIFIER = com.justinmoon.pika;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/ios/Sources/AppManager.swift
+++ b/ios/Sources/AppManager.swift
@@ -358,7 +358,11 @@ final class AppManager: AppReconciler {
     private func isExpectedNostrConnectCallback(_ url: URL) -> Bool {
         guard url.host?.lowercased() == "nostrconnect-return" else { return false }
         guard let scheme = url.scheme?.lowercased() else { return false }
-        return scheme == "pika" || scheme == "pika-dev" || scheme == "pika-test"
+        let expectedScheme =
+            IOSExternalSignerBridge
+                .callbackScheme(forBundleIdentifier: Bundle.main.bundleIdentifier)
+                .lowercased()
+        return scheme == expectedScheme
     }
 }
 

--- a/ios/Sources/IOSExternalSignerBridge.swift
+++ b/ios/Sources/IOSExternalSignerBridge.swift
@@ -3,11 +3,11 @@ import UIKit
 
 final class IOSExternalSignerBridge: ExternalSignerBridge, @unchecked Sendable {
     private var nostrConnectCallbackUrl: String {
-        let scheme = Self.callbackScheme(bundleIdentifier: Bundle.main.bundleIdentifier)
+        let scheme = Self.callbackScheme(forBundleIdentifier: Bundle.main.bundleIdentifier)
         return "\(scheme)://nostrconnect-return"
     }
 
-    private static func callbackScheme(bundleIdentifier: String?) -> String {
+    static func callbackScheme(forBundleIdentifier bundleIdentifier: String?) -> String {
         guard let bundleIdentifier else { return "pika" }
         if bundleIdentifier.hasSuffix(".dev") { return "pika-dev" }
         if bundleIdentifier.hasSuffix(".pikatest") { return "pika-test" }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -10,12 +10,14 @@ settings:
     # Note: device builds still need a valid DEVELOPMENT_TEAM; we keep that out of git and
     # pass it via env from tools/run-ios.
     PRODUCT_BUNDLE_IDENTIFIER: com.justinmoon.pika
+    PIKA_URL_SCHEME: pika
     MARKETING_VERSION: 0.1.0
     CURRENT_PROJECT_VERSION: 1
     SWIFT_VERSION: 5.0
   configs:
     Debug:
       PRODUCT_BUNDLE_IDENTIFIER: com.justinmoon.pika.dev
+      PIKA_URL_SCHEME: pika-dev
 
 packages:
   MarkdownUI:

--- a/justfile
+++ b/justfile
@@ -473,7 +473,7 @@ ios-xcodeproj:
 # Build iOS app for simulator.
 ios-build-sim: ios-xcframework ios-xcodeproj
   SIM_ARCH="${PIKA_IOS_SIM_ARCH:-$( [ "$(uname -m)" = "x86_64" ] && echo x86_64 || echo arm64 )}"; \
-  ./tools/xcode-run xcodebuild -project ios/Pika.xcodeproj -scheme Pika -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build build ARCHS="$SIM_ARCH" ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO PRODUCT_BUNDLE_IDENTIFIER="${PIKA_IOS_BUNDLE_ID:-com.justinmoon.pika.dev}"
+  ./tools/xcode-run xcodebuild -project ios/Pika.xcodeproj -scheme Pika -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build build ARCHS="$SIM_ARCH" ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO PRODUCT_BUNDLE_IDENTIFIER="${PIKA_IOS_BUNDLE_ID:-com.justinmoon.pika.dev}" PIKA_URL_SCHEME="${PIKA_IOS_URL_SCHEME:-pika-dev}"
 
 # Run iOS UI tests on simulator (skips E2E deployed-bot test).
 ios-ui-test: ios-xcframework ios-xcodeproj

--- a/tools/run-ios
+++ b/tools/run-ios
@@ -36,6 +36,7 @@ fi
 
 IOS_BUNDLE_ID="${PIKA_IOS_BUNDLE_ID:-com.justinmoon.pika.dev}"
 IOS_TEAM_ID="${PIKA_IOS_DEVELOPMENT_TEAM:-}"
+IOS_URL_SCHEME="${PIKA_IOS_URL_SCHEME:-}"
 MODE="sim"
 CONSOLE="${PIKA_IOS_CONSOLE:-0}"
 RELEASE=0
@@ -50,6 +51,7 @@ usage: ./tools/run-ios [--sim|--device] [--release] [--console] [--udid <udid>] 
 
 Env:
   PIKA_IOS_BUNDLE_ID        (default: $IOS_BUNDLE_ID)
+  PIKA_IOS_URL_SCHEME       (default: derived from bundle id: pika|pika-dev|pika-test)
   PIKA_IOS_DEVELOPMENT_TEAM (required for --device; put it in .env to avoid typing)
   PIKA_IOS_DEVICE_UDID      (optional, for --device)
   PIKA_IOS_SIM_UDID         (optional, for --sim)
@@ -59,6 +61,19 @@ Env:
   PIKA_NO_RELAY_OVERRIDE=1  disable dev-friendly relay defaults
   PIKA_IOS_DEVICE_ALLOW_LOCAL_OVERRIDES=1  allow localhost relay/MoQ overrides on physical devices
 EOF
+}
+
+callback_scheme_for_bundle_id() {
+  local bundle_id="$1"
+  if [[ "$bundle_id" == *.dev ]]; then
+    echo "pika-dev"
+    return 0
+  fi
+  if [[ "$bundle_id" == *.pikatest ]]; then
+    echo "pika-test"
+    return 0
+  fi
+  echo "pika"
 }
 
 list_connected_iphones() {
@@ -118,6 +133,9 @@ if [ "$RELEASE" = "1" ]; then
   export PIKA_RUST_PROFILE="release"
 else
   export PIKA_RUST_PROFILE="${PIKA_RUST_PROFILE:-debug}"
+fi
+if [ -z "${IOS_URL_SCHEME:-}" ]; then
+  IOS_URL_SCHEME="$(callback_scheme_for_bundle_id "$IOS_BUNDLE_ID")"
 fi
 echo "rust profile: $PIKA_RUST_PROFILE"
 
@@ -244,6 +262,7 @@ if [ "$MODE" = "device" ]; then
   # Build signed device .app (must unset LD/CC/CXX inside Nix shells).
   signing_settings=()
   signing_settings+=("PRODUCT_BUNDLE_IDENTIFIER=$IOS_BUNDLE_ID")
+  signing_settings+=("PIKA_URL_SCHEME=$IOS_URL_SCHEME")
   signing_settings+=("DEVELOPMENT_TEAM=$IOS_TEAM_ID")
   signing_settings+=("CODE_SIGN_STYLE=Automatic")
 
@@ -381,6 +400,7 @@ if [ -z "${PIKA_IOS_RUST_TARGETS:-}" ]; then
     export PIKA_IOS_RUST_TARGETS="aarch64-apple-ios-sim"
   fi
 fi
+export PIKA_IOS_URL_SCHEME="$IOS_URL_SCHEME"
 
 just ios-build-sim
 


### PR DESCRIPTION
## Summary
- require an observed app callback before pending nostr-connect login can complete via internal continuation paths
- persist callback-seen state across restart for pending login snapshots
- bind iOS URL handling to a single scheme per build via `PIKA_URL_SCHEME` and align runtime callback filtering
- reduce Android Amber foreground churn by only relaunching Pika when not focused

## Validation
- cargo test --manifest-path rust/Cargo.toml --test app_flows
- just android-assemble
- just ios-build-sim
