### PR TITLE
Add --version flag to marmotd

### DIFF
--- a/crates/marmotd/src/main.rs
+++ b/crates/marmotd/src/main.rs
@@ -19,6 +19,7 @@ mod daemon;
 
 #[derive(Debug, Parser)]
 #[command(name = "marmotd")]
+#[command(version)]
 #[command(about = "Marmot interop lab harness (Rust track)")]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
Adds `#[command(version)]` to the marmotd clap CLI struct so `marmotd --version` prints the version from Cargo.toml (currently `0.4.0`).