### PR TITLE
Improve marmotd binary management: auto-updates, checksums, version pinning

### DIFF
--- a/.github/workflows/marmotd-release.yml
+++ b/.github/workflows/marmotd-release.yml
@@ -37,11 +37,14 @@ jobs:
           mkdir -p dist
           cp "target/${{ matrix.target }}/release/marmotd" "dist/${{ matrix.asset_name }}"
           chmod +x "dist/${{ matrix.asset_name }}"
+          sha256sum "dist/${{ matrix.asset_name }}" > "dist/${{ matrix.asset_name }}.sha256"
 
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
-          path: dist/${{ matrix.asset_name }}
+          path: |
+            dist/${{ matrix.asset_name }}
+            dist/${{ matrix.asset_name }}.sha256
           if-no-files-found: error
 
   build-macos:
@@ -70,11 +73,14 @@ jobs:
           mkdir -p dist
           cp "target/${{ matrix.target }}/release/marmotd" "dist/${{ matrix.asset_name }}"
           chmod +x "dist/${{ matrix.asset_name }}"
+          shasum -a 256 "dist/${{ matrix.asset_name }}" > "dist/${{ matrix.asset_name }}.sha256"
 
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
-          path: dist/${{ matrix.asset_name }}
+          path: |
+            dist/${{ matrix.asset_name }}
+            dist/${{ matrix.asset_name }}.sha256
           if-no-files-found: error
 
   publish-release:

--- a/openclaw-marmot/openclaw/extensions/marmot/src/channel.ts
+++ b/openclaw-marmot/openclaw/extensions/marmot/src/channel.ts
@@ -721,6 +721,7 @@ export const marmotPlugin: ChannelPlugin<ResolvedMarmotAccount> = {
       const sidecarCmd = await resolveMarmotSidecarCommand({
         requestedCmd: requestedSidecarCmd,
         log: ctx.log,
+        pinnedVersion: resolved.config.sidecarVersion,
       });
       const relayArgs = (relays.length > 0 ? relays : ["ws://127.0.0.1:18080"]).flatMap((r) => ["--relay", r]);
       const sidecarArgs =

--- a/openclaw-marmot/openclaw/extensions/marmot/src/config-schema.ts
+++ b/openclaw-marmot/openclaw/extensions/marmot/src/config-schema.ts
@@ -13,6 +13,7 @@ export const marmotPluginConfigSchema = {
       type: "array",
       items: { type: "string" },
     },
+    sidecarVersion: { type: "string" },
     autoAcceptWelcomes: {
       type: "boolean",
       default: true,

--- a/openclaw-marmot/openclaw/extensions/marmot/src/config.ts
+++ b/openclaw-marmot/openclaw/extensions/marmot/src/config.ts
@@ -10,6 +10,7 @@ export type MarmotChannelConfig = {
   stateDir?: string;
   sidecarCmd?: string;
   sidecarArgs?: string[];
+  sidecarVersion?: string;
   autoAcceptWelcomes: boolean;
   groupPolicy: MarmotGroupPolicy;
   groupAllowFrom: string[];
@@ -37,6 +38,8 @@ export function resolveMarmotChannelConfig(raw: unknown): MarmotChannelConfig {
   const sidecarCmd =
     typeof obj.sidecarCmd === "string" && obj.sidecarCmd.trim() ? obj.sidecarCmd.trim() : undefined;
   const sidecarArgs = asStringArray(obj.sidecarArgs) ?? undefined;
+  const sidecarVersion =
+    typeof obj.sidecarVersion === "string" && obj.sidecarVersion.trim() ? obj.sidecarVersion.trim() : undefined;
 
   const autoAcceptWelcomes =
     typeof obj.autoAcceptWelcomes === "boolean" ? obj.autoAcceptWelcomes : true;
@@ -61,6 +64,7 @@ export function resolveMarmotChannelConfig(raw: unknown): MarmotChannelConfig {
     stateDir,
     sidecarCmd,
     sidecarArgs,
+    sidecarVersion,
     autoAcceptWelcomes,
     groupPolicy,
     groupAllowFrom,


### PR DESCRIPTION
Ports battle-tested binary management patterns from the maple-proxy plugin to marmotd.

## Changes

### sidecar-install.ts (major restructure)
- **24h version cache**: Caches latest version tag in `~/.openclaw/tools/marmot/.latest-version` with 24h TTL. Re-checks for updates on next gateway restart after TTL expires.
- **SHA256 checksum verification**: Downloads `.sha256` file from release and verifies binary integrity. Gracefully skips if no checksum exists (backward compatible with existing releases).
- **Old version cleanup**: Keeps at most 2 versions (current + one previous), removes older ones using proper numeric version comparison.
- **Version pinning**: New `sidecarVersion` config field (or `MARMOT_SIDECAR_VERSION` env) pins to a specific version, bypassing GitHub latest check.
- **Centralized GitHub headers**: Extracted `githubHeaders()` helper with `GITHUB_TOKEN` support.

### marmotd-release.yml (CI)
- Generates SHA256 checksums for all 4 platform builds (`sha256sum` on Linux, `shasum -a 256` on macOS)
- Uploads checksum files alongside binaries as release assets

### config.ts / config-schema.ts / channel.ts
- Added `sidecarVersion` field to config type, JSON schema, and parser
- Passes `pinnedVersion` through to `resolveMarmotSidecarCommand()`

## Notes
- Existing releases without checksums are handled gracefully (skipped with warning)
- Raw binary downloads preserved (no archives) since CI publishes single binaries — checksums provide the integrity guarantee
- `GITHUB_TOKEN` support retained since monorepo is more likely to hit GitHub API rate limits