### PR TITLE
release: marmotd v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "marmotd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/crates/marmotd/Cargo.toml
+++ b/crates/marmotd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marmotd"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 [dependencies]

--- a/openclaw-marmot/openclaw/extensions/marmot/package.json
+++ b/openclaw-marmot/openclaw/extensions/marmot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justinmoon/marmot",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "OpenClaw Marmot channel plugin (Rust sidecar)",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Bumps marmotd and the openclaw marmot plugin from 0.4.0 to 0.5.0.

After merging, the admin should tag and push:
```
git tag marmotd-v0.5.0
git push origin marmotd-v0.5.0
```

The tag push triggers the release CI which will:
1. Build binaries for all 4 platforms (linux x64/arm64, macOS x64/arm64)
2. Generate SHA256 checksums for each binary
3. Publish the GitHub Release with binaries + checksums
4. Publish the updated plugin to npm (`@justinmoon/marmot@0.5.0`)