### PR TITLE
Add workflow_dispatch release triggers for marmotd and pika

### DIFF
--- a/.github/workflows/marmotd-release.yml
+++ b/.github/workflows/marmotd-release.yml
@@ -4,12 +4,115 @@ on:
   push:
     tags:
       - "marmotd-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.5.1)"
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    steps:
+      - name: Enforce allowed release actors
+        run: |
+          set -euo pipefail
+          case "${GITHUB_ACTOR}" in
+            justinmoon|futurepaul|benthecarman|AnthonyRonning) ;;
+            *)
+              echo "error: actor '${GITHUB_ACTOR}' is not allowed to run release workflow"
+              exit 1
+              ;;
+          esac
+
+  bump-and-tag:
+    if: github.event_name == 'workflow_dispatch'
+    needs: authorize
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Validate version input
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "error: version must be x.y.z (got: $version)"
+            exit 1
+          fi
+          tag="marmotd-v${version}"
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "error: tag already exists: $tag"
+            exit 1
+          fi
+
+      - name: Bump versions
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+
+          # Bump Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"${version}\"/" crates/marmotd/Cargo.toml
+
+          # Bump package.json
+          cd openclaw-marmot/openclaw/extensions/marmot
+          npm version "$version" --no-git-tag-version --allow-same-version
+          cd "$GITHUB_WORKSPACE"
+
+          # Update Cargo.lock
+          cargo check -p marmotd --quiet
+
+      - name: Commit, tag, and push
+        id: tag
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          tag="marmotd-v${version}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add crates/marmotd/Cargo.toml openclaw-marmot/openclaw/extensions/marmot/package.json Cargo.lock
+          git commit -m "release: marmotd v${version}"
+          git tag "$tag"
+          git push origin master "$tag"
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  resolve-tag:
+    needs: [authorize, bump-and-tag]
+    if: always() && needs.authorize.result == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Resolve tag
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ needs.bump-and-tag.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
   build-linux:
+    needs: resolve-tag
     strategy:
       fail-fast: false
       matrix:
@@ -23,6 +126,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -48,6 +153,7 @@ jobs:
           if-no-files-found: error
 
   build-macos:
+    needs: resolve-tag
     strategy:
       fail-fast: false
       matrix:
@@ -59,6 +165,8 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -85,6 +193,7 @@ jobs:
 
   publish-release:
     needs:
+      - resolve-tag
       - build-linux
       - build-macos
     runs-on: ubuntu-latest
@@ -98,13 +207,18 @@ jobs:
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.resolve-tag.outputs.tag }}
           files: dist/*
 
   publish-npm:
-    needs: publish-release
+    needs:
+      - resolve-tag
+      - publish-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "pika/v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.2.9)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -27,11 +32,78 @@ jobs:
           esac
       - run: echo "release approved"
 
-  check:
+  bump-and-tag:
+    if: github.event_name == 'workflow_dispatch'
     needs: approve-release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Validate version input
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "error: version must be x.y.z (got: $version)"
+            exit 1
+          fi
+          tag="pika/v${version}"
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "error: tag already exists: $tag"
+            exit 1
+          fi
+
+      - name: Bump VERSION file
+        run: |
+          set -euo pipefail
+          echo -n "${{ inputs.version }}" > VERSION
+
+      - name: Commit, tag, and push
+        id: tag
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          tag="pika/v${version}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add VERSION
+          git commit -m "release: pika v${version}"
+          git tag "$tag"
+          git push origin master "$tag"
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  resolve-tag:
+    needs: [approve-release, bump-and-tag]
+    if: always() && needs.approve-release.result == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Resolve tag
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ needs.bump-and-tag.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  check:
+    needs: resolve-tag
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - uses: useblacksmith/stickydisk@v1
         with:
@@ -56,23 +128,22 @@ jobs:
       - name: Validate tag matches VERSION
         run: |
           set -euo pipefail
-          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
-            echo "error: release workflow must run on a tag ref"
-            exit 1
-          fi
           expected_tag="pika/v$(./scripts/version-read --name)"
-          if [ "${GITHUB_REF_NAME}" != "$expected_tag" ]; then
-            echo "error: tag/version mismatch: ref=${GITHUB_REF_NAME}, expected=${expected_tag}"
+          tag="${{ needs.resolve-tag.outputs.tag }}"
+          if [ "$tag" != "$expected_tag" ]; then
+            echo "error: tag/version mismatch: tag=${tag}, expected=${expected_tag}"
             exit 1
           fi
 
       - run: nix develop .#default -c just pre-merge-pika
 
   build-android:
-    needs: check
+    needs: [resolve-tag, check]
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - uses: useblacksmith/stickydisk@v1
         with:
@@ -93,15 +164,6 @@ jobs:
         with:
           key: ${{ github.repository }}-cargo-target-v1-${{ runner.os }}
           path: target
-
-      - name: Validate tag matches VERSION
-        run: |
-          set -euo pipefail
-          expected_tag="pika/v$(./scripts/version-read --name)"
-          if [ "${GITHUB_REF_NAME}" != "$expected_tag" ]; then
-            echo "error: tag/version mismatch: ref=${GITHUB_REF_NAME}, expected=${expected_tag}"
-            exit 1
-          fi
 
       - name: Build signed release APK
         env:
@@ -115,25 +177,18 @@ jobs:
           if-no-files-found: error
 
   build-macos:
-    needs: check
+    needs: [resolve-tag, check]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - uses: Swatinem/rust-cache@v2
-
-      - name: Validate tag matches VERSION
-        run: |
-          set -euo pipefail
-          expected_tag="pika/v$(./scripts/version-read --name)"
-          if [ "${GITHUB_REF_NAME}" != "$expected_tag" ]; then
-            echo "error: tag/version mismatch: ref=${GITHUB_REF_NAME}, expected=${expected_tag}"
-            exit 1
-          fi
 
       - name: Build macOS universal DMG
         run: ./scripts/build-macos-release
@@ -145,10 +200,12 @@ jobs:
           if-no-files-found: error
 
   publish:
-    needs: [build-android, build-macos]
+    needs: [resolve-tag, build-android, build-macos]
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -160,23 +217,14 @@ jobs:
           name: release-macos
           path: dist
 
-      - name: Validate tag matches VERSION
-        run: |
-          set -euo pipefail
-          expected_tag="pika/v$(./scripts/version-read --name)"
-          if [ "${GITHUB_REF_NAME}" != "$expected_tag" ]; then
-            echo "error: tag/version mismatch: ref=${GITHUB_REF_NAME}, expected=${expected_tag}"
-            exit 1
-          fi
-
       - name: Generate checksums
         run: sha256sum dist/*.apk dist/*.dmg > dist/SHA256SUMS
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Pika ${{ github.ref_name }}
+          tag_name: ${{ needs.resolve-tag.outputs.tag }}
+          name: Pika ${{ needs.resolve-tag.outputs.tag }}
           generate_release_notes: true
           overwrite_files: true
           files: |
@@ -185,10 +233,12 @@ jobs:
             dist/SHA256SUMS
 
   publish-zapstore:
-    needs: [build-android, publish]
+    needs: [resolve-tag, build-android, publish]
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - name: Check Zapstore signing secret
         id: zapstore_secret
@@ -221,16 +271,6 @@ jobs:
           name: release-android
           path: dist
 
-      - name: Validate tag matches VERSION
-        if: steps.zapstore_secret.outputs.present == 'true'
-        run: |
-          set -euo pipefail
-          expected_tag="pika/v$(./scripts/version-read --name)"
-          if [ "${GITHUB_REF_NAME}" != "$expected_tag" ]; then
-            echo "error: tag/version mismatch: ref=${GITHUB_REF_NAME}, expected=${expected_tag}"
-            exit 1
-          fi
-
       - name: Publish to Zapstore
         if: steps.zapstore_secret.outputs.present == 'true'
         env:
@@ -249,10 +289,12 @@ jobs:
           nix develop .#default -c ./scripts/zapstore-publish "$apk_path" "https://github.com/${GITHUB_REPOSITORY}"
 
   announce-release:
-    needs: publish
+    needs: [resolve-tag, publish]
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - name: Ensure announcement signing secret exists
         run: |
@@ -279,5 +321,6 @@ jobs:
         run: |
           set -euo pipefail
           set +x
+          tag="${{ needs.resolve-tag.outputs.tag }}"
           repo_url="https://github.com/${GITHUB_REPOSITORY}"
-          nix develop .#default -c ./scripts/post-release-announcement "${GITHUB_REF_NAME}" "$repo_url"
+          nix develop .#default -c ./scripts/post-release-announcement "$tag" "$repo_url"


### PR DESCRIPTION
## Summary

Both release workflows now support releasing directly from the GitHub Actions UI. No local scripts, no manual tagging.

## How to release

### marmotd + plugin
1. Go to Actions > `marmotd release` > `Run workflow`
2. Enter version (e.g. `0.5.1`)
3. The workflow bumps `Cargo.toml`, `package.json`, updates `Cargo.lock`, commits, tags `marmotd-v0.5.1`, builds all 4 platform binaries with SHA256 checksums, publishes GitHub Release, and publishes to npm

### pika app
1. Go to Actions > `release` > `Run workflow`
2. Enter version (e.g. `0.2.9`)
3. The workflow bumps `VERSION`, commits, tags `pika/v0.2.9`, runs pre-merge checks, builds Android APK + macOS DMG, publishes GitHub Release, publishes to Zapstore, and posts Nostr announcement

## Safety

- **Actor gating**: only justinmoon, futurepaul, benthecarman, AnthonyRonning can trigger
- **Environment approval**: `release` environment gate still required
- **Version validation**: rejects malformed versions and duplicate tags
- **Tag-triggered fallback**: existing `git tag && git push` flow still works for both workflows
- **All builds check out the exact tag**: ensures build artifacts match the tagged commit

## Changes

- `marmotd-release.yml`: added `workflow_dispatch` trigger with `authorize` + `bump-and-tag` + `resolve-tag` jobs; build/publish jobs now use resolved tag for checkout
- `release.yml`: same pattern; removed redundant per-job tag validation (now centralized in `check` job); all jobs check out via `resolve-tag` output