### PR TITLE
Simplify release workflows: tag-only, no commit to master

### DIFF
--- a/.github/workflows/marmotd-release.yml
+++ b/.github/workflows/marmotd-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release (e.g. 0.5.1)"
+        description: "Version to release (e.g. 0.5.1) — must already be bumped on master"
         required: true
         type: string
 
@@ -31,7 +31,7 @@ jobs:
               ;;
           esac
 
-  bump-and-tag:
+  tag-release:
     if: github.event_name == 'workflow_dispatch'
     needs: authorize
     runs-on: ubuntu-latest
@@ -41,62 +41,46 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: master
-          fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Validate version input
-        run: |
-          set -euo pipefail
-          version="${{ inputs.version }}"
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "error: version must be x.y.z (got: $version)"
-            exit 1
-          fi
-          tag="marmotd-v${version}"
-          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
-            echo "error: tag already exists: $tag"
-            exit 1
-          fi
-
-      - name: Bump versions
-        run: |
-          set -euo pipefail
-          version="${{ inputs.version }}"
-
-          # Bump Cargo.toml
-          sed -i "s/^version = \".*\"/version = \"${version}\"/" crates/marmotd/Cargo.toml
-
-          # Bump package.json
-          cd openclaw-marmot/openclaw/extensions/marmot
-          npm version "$version" --no-git-tag-version --allow-same-version
-          cd "$GITHUB_WORKSPACE"
-
-          # Update Cargo.lock
-          cargo check -p marmotd --quiet
-
-      - name: Commit, tag, and push
+      - name: Validate and tag
         id: tag
         run: |
           set -euo pipefail
           version="${{ inputs.version }}"
           tag="marmotd-v${version}"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add crates/marmotd/Cargo.toml openclaw-marmot/openclaw/extensions/marmot/package.json Cargo.lock
-          git commit -m "release: marmotd v${version}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "error: version must be x.y.z (got: $version)"
+            exit 1
+          fi
+
+          # Verify the version is already bumped in source files
+          cargo_version=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/marmotd/Cargo.toml)
+          if [ "$cargo_version" != "$version" ]; then
+            echo "error: Cargo.toml version is $cargo_version but expected $version"
+            echo "hint: bump versions first via PR, then run this workflow"
+            exit 1
+          fi
+
+          pkg_version=$(node -p "require('./openclaw-marmot/openclaw/extensions/marmot/package.json').version")
+          if [ "$pkg_version" != "$version" ]; then
+            echo "error: package.json version is $pkg_version but expected $version"
+            echo "hint: bump versions first via PR, then run this workflow"
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "error: tag already exists: $tag"
+            exit 1
+          fi
+
           git tag "$tag"
-          git push origin master "$tag"
+          git push origin "$tag"
 
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
   resolve-tag:
-    needs: [authorize, bump-and-tag]
+    needs: [authorize, tag-release]
     if: always() && needs.authorize.result == 'success'
     runs-on: ubuntu-latest
     outputs:
@@ -106,7 +90,7 @@ jobs:
         id: resolve
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ needs.bump-and-tag.outputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ needs.tag-release.outputs.tag }}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release (e.g. 0.2.9)"
+        description: "Version to release (e.g. 0.2.9) — must already be bumped on master"
         required: true
         type: string
 
@@ -32,57 +32,49 @@ jobs:
           esac
       - run: echo "release approved"
 
-  bump-and-tag:
+  tag-release:
     if: github.event_name == 'workflow_dispatch'
     needs: approve-release
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
-      version: ${{ steps.tag.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: master
-          fetch-depth: 0
 
-      - name: Validate version input
-        run: |
-          set -euo pipefail
-          version="${{ inputs.version }}"
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "error: version must be x.y.z (got: $version)"
-            exit 1
-          fi
-          tag="pika/v${version}"
-          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
-            echo "error: tag already exists: $tag"
-            exit 1
-          fi
-
-      - name: Bump VERSION file
-        run: |
-          set -euo pipefail
-          echo -n "${{ inputs.version }}" > VERSION
-
-      - name: Commit, tag, and push
+      - name: Validate and tag
         id: tag
         run: |
           set -euo pipefail
           version="${{ inputs.version }}"
           tag="pika/v${version}"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add VERSION
-          git commit -m "release: pika v${version}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "error: version must be x.y.z (got: $version)"
+            exit 1
+          fi
+
+          # Verify the VERSION file already has the right version
+          current_version="$(./scripts/version-read --name)"
+          if [ "$current_version" != "$version" ]; then
+            echo "error: VERSION file says $current_version but expected $version"
+            echo "hint: bump VERSION first via PR, then run this workflow"
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "error: tag already exists: $tag"
+            exit 1
+          fi
+
           git tag "$tag"
-          git push origin master "$tag"
+          git push origin "$tag"
 
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
 
   resolve-tag:
-    needs: [approve-release, bump-and-tag]
+    needs: [approve-release, tag-release]
     if: always() && needs.approve-release.result == 'success'
     runs-on: ubuntu-latest
     outputs:
@@ -92,7 +84,7 @@ jobs:
         id: resolve
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ needs.bump-and-tag.outputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ needs.tag-release.outputs.tag }}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Problem

The previous workflow_dispatch tried to push version bump commits directly to master, which is blocked by branch protection rules.

## Fix

Removed the `bump-and-tag` jobs. Workflows now only create and push tags (which aren't blocked by branch protection). Version bumps are done separately via PR before triggering the release.

## Release flow

### marmotd + plugin
1. Bump versions via PR (use `./scripts/bump-marmotd.sh 0.5.1` locally, or manually edit `Cargo.toml` + `package.json`)
2. Merge PR to master
3. Go to Actions > `marmotd release` > Run workflow > enter version
4. Workflow **validates** that `Cargo.toml` and `package.json` already have the right version, then tags, builds, and publishes

### pika app
1. Bump `VERSION` file via PR
2. Merge PR to master
3. Go to Actions > `release` > Run workflow > enter version
4. Workflow **validates** that `VERSION` matches, then tags, builds, and publishes

If the version doesn't match, the workflow fails immediately with a clear error message and hint.

Tag-triggered releases (`git tag && push`) still work as a fallback.