### PR TITLE
Add multi-device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ End-to-end encrypted messaging for iOS and Android, built on [MLS](https://messa
 |---|:---:|:---:|:---:|
 | 1:1 encrypted messaging | ✅ | ✅ | ✅ |
 | Group chats (MLS) | ✅ | ✅ | ✅ |
+| Multi-device support | ✅ | ✅ | ✅ |
 | Voice calls (1:1) | ✅ | ✅ | ✅ |
 | Video calls (1:1) | ✅ | | ✅ |
 | Push notifications | ✅ | | |

--- a/android/app/src/main/java/com/pika/app/AppManager.kt
+++ b/android/app/src/main/java/com/pika/app/AppManager.kt
@@ -57,6 +57,9 @@ class AppManager private constructor(context: Context) : AppReconciler {
             peerProfile = null,
             activeCall = null,
             callTimeline = emptyList(),
+            myDevices = emptyList(),
+            pendingDevices = emptyList(),
+            autoAddDevices = true,
             toast = null,
         ),
     )

--- a/android/app/src/main/java/com/pika/app/rust/pika_core.kt
+++ b/android/app/src/main/java/com/pika/app/rust/pika_core.kt
@@ -616,6 +616,9 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 internal interface UniffiCallbackInterfaceAppReconcilerMethod0 : com.sun.jna.Callback {
     fun callback(`uniffiHandle`: Long,`update`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,)
 }
+internal interface UniffiCallbackInterfaceVideoFrameReceiverMethod0 : com.sun.jna.Callback {
+    fun callback(`uniffiHandle`: Long,`callId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,)
+}
 internal interface UniffiCallbackInterfaceExternalSignerBridgeMethod0 : com.sun.jna.Callback {
     fun callback(`uniffiHandle`: Long,`url`: RustBuffer.ByValue,`uniffiOutReturn`: RustBuffer,uniffiCallStatus: UniffiRustCallStatus,)
 }
@@ -653,6 +656,25 @@ internal open class UniffiVTableCallbackInterfaceAppReconciler(
         `uniffiFree` = other.`uniffiFree`
         `uniffiClone` = other.`uniffiClone`
         `reconcile` = other.`reconcile`
+    }
+
+}
+@Structure.FieldOrder("uniffiFree", "uniffiClone", "onVideoFrame")
+internal open class UniffiVTableCallbackInterfaceVideoFrameReceiver(
+    @JvmField internal var `uniffiFree`: UniffiCallbackInterfaceFree? = null,
+    @JvmField internal var `uniffiClone`: UniffiCallbackInterfaceClone? = null,
+    @JvmField internal var `onVideoFrame`: UniffiCallbackInterfaceVideoFrameReceiverMethod0? = null,
+) : Structure() {
+    class UniffiByValue(
+        `uniffiFree`: UniffiCallbackInterfaceFree? = null,
+        `uniffiClone`: UniffiCallbackInterfaceClone? = null,
+        `onVideoFrame`: UniffiCallbackInterfaceVideoFrameReceiverMethod0? = null,
+    ): UniffiVTableCallbackInterfaceVideoFrameReceiver(`uniffiFree`,`uniffiClone`,`onVideoFrame`,), Structure.ByValue
+
+   internal fun uniffiSetValue(other: UniffiVTableCallbackInterfaceVideoFrameReceiver) {
+        `uniffiFree` = other.`uniffiFree`
+        `uniffiClone` = other.`uniffiClone`
+        `onVideoFrame` = other.`onVideoFrame`
     }
 
 }
@@ -720,13 +742,19 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_pika_core_checksum_method_ffiapp_listen_for_updates(
     ): Short
+    external fun uniffi_pika_core_checksum_method_ffiapp_send_video_frame(
+    ): Short
     external fun uniffi_pika_core_checksum_method_ffiapp_set_external_signer_bridge(
+    ): Short
+    external fun uniffi_pika_core_checksum_method_ffiapp_set_video_frame_receiver(
     ): Short
     external fun uniffi_pika_core_checksum_method_ffiapp_state(
     ): Short
     external fun uniffi_pika_core_checksum_constructor_ffiapp_new(
     ): Short
     external fun uniffi_pika_core_checksum_method_appreconciler_reconcile(
+    ): Short
+    external fun uniffi_pika_core_checksum_method_videoframereceiver_on_video_frame(
     ): Short
     external fun uniffi_pika_core_checksum_method_externalsignerbridge_open_url(
     ): Short
@@ -760,6 +788,7 @@ internal object UniffiLib {
         Native.register(UniffiLib::class.java, findLibraryName(componentName = "pika_core"))
         uniffiCallbackInterfaceAppReconciler.register(this)
         uniffiCallbackInterfaceExternalSignerBridge.register(this)
+        uniffiCallbackInterfaceVideoFrameReceiver.register(this)
         
     }
     external fun uniffi_pika_core_fn_clone_ffiapp(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -772,11 +801,17 @@ internal object UniffiLib {
     ): Unit
     external fun uniffi_pika_core_fn_method_ffiapp_listen_for_updates(`ptr`: Long,`reconciler`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
+    external fun uniffi_pika_core_fn_method_ffiapp_send_video_frame(`ptr`: Long,`payload`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
     external fun uniffi_pika_core_fn_method_ffiapp_set_external_signer_bridge(`ptr`: Long,`bridge`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    external fun uniffi_pika_core_fn_method_ffiapp_set_video_frame_receiver(`ptr`: Long,`receiver`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     external fun uniffi_pika_core_fn_method_ffiapp_state(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_pika_core_fn_init_callback_vtable_appreconciler(`vtable`: UniffiVTableCallbackInterfaceAppReconciler,
+    ): Unit
+    external fun uniffi_pika_core_fn_init_callback_vtable_videoframereceiver(`vtable`: UniffiVTableCallbackInterfaceVideoFrameReceiver,
     ): Unit
     external fun uniffi_pika_core_fn_init_callback_vtable_externalsignerbridge(`vtable`: UniffiVTableCallbackInterfaceExternalSignerBridge,
     ): Unit
@@ -905,7 +940,13 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_pika_core_checksum_method_ffiapp_listen_for_updates() != 54024.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_pika_core_checksum_method_ffiapp_send_video_frame() != 39589.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_pika_core_checksum_method_ffiapp_set_external_signer_bridge() != 60161.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_pika_core_checksum_method_ffiapp_set_video_frame_receiver() != 45698.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_pika_core_checksum_method_ffiapp_state() != 64637.toShort()) {
@@ -915,6 +956,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_pika_core_checksum_method_appreconciler_reconcile() != 10811.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_pika_core_checksum_method_videoframereceiver_on_video_frame() != 12741.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_pika_core_checksum_method_externalsignerbridge_open_url() != 29331.toShort()) {
@@ -1298,6 +1342,25 @@ public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
     }
 }
 
+/**
+ * @suppress
+ */
+public object FfiConverterByteArray: FfiConverterRustBuffer<ByteArray> {
+    override fun read(buf: ByteBuffer): ByteArray {
+        val len = buf.getInt()
+        val byteArr = ByteArray(len)
+        buf.get(byteArr)
+        return byteArr
+    }
+    override fun allocationSize(value: ByteArray): ULong {
+        return 4UL + value.size.toULong()
+    }
+    override fun write(value: ByteArray, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        buf.put(value)
+    }
+}
+
 
 // This template implements a class for working with a Rust struct via a handle
 // to the live Rust struct on the other side of the FFI.
@@ -1400,7 +1463,11 @@ public interface FfiAppInterface {
     
     fun `listenForUpdates`(`reconciler`: AppReconciler)
     
+    fun `sendVideoFrame`(`payload`: kotlin.ByteArray)
+    
     fun `setExternalSignerBridge`(`bridge`: ExternalSignerBridge)
+    
+    fun `setVideoFrameReceiver`(`receiver`: VideoFrameReceiver)
     
     fun `state`(): AppState
     
@@ -1535,6 +1602,18 @@ open class FfiApp: Disposable, AutoCloseable, FfiAppInterface
     
     
 
+    override fun `sendVideoFrame`(`payload`: kotlin.ByteArray)
+        = 
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_pika_core_fn_method_ffiapp_send_video_frame(
+        it,
+        FfiConverterByteArray.lower(`payload`),_status)
+}
+    }
+    
+    
+
     override fun `setExternalSignerBridge`(`bridge`: ExternalSignerBridge)
         = 
     callWithHandle {
@@ -1542,6 +1621,18 @@ open class FfiApp: Disposable, AutoCloseable, FfiAppInterface
     UniffiLib.uniffi_pika_core_fn_method_ffiapp_set_external_signer_bridge(
         it,
         FfiConverterTypeExternalSignerBridge.lower(`bridge`),_status)
+}
+    }
+    
+    
+
+    override fun `setVideoFrameReceiver`(`receiver`: VideoFrameReceiver)
+        = 
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_pika_core_fn_method_ffiapp_set_video_frame_receiver(
+        it,
+        FfiConverterTypeVideoFrameReceiver.lower(`receiver`),_status)
 }
     }
     
@@ -1623,6 +1714,12 @@ data class AppState (
     , 
     var `callTimeline`: List<CallTimelineEvent>
     , 
+    var `myDevices`: List<DeviceInfo>
+    , 
+    var `pendingDevices`: List<DeviceInfo>
+    , 
+    var `autoAddDevices`: kotlin.Boolean
+    , 
     var `toast`: kotlin.String?
     
 ){
@@ -1651,6 +1748,9 @@ public object FfiConverterTypeAppState: FfiConverterRustBuffer<AppState> {
             FfiConverterOptionalTypePeerProfileState.read(buf),
             FfiConverterOptionalTypeCallState.read(buf),
             FfiConverterSequenceTypeCallTimelineEvent.read(buf),
+            FfiConverterSequenceTypeDeviceInfo.read(buf),
+            FfiConverterSequenceTypeDeviceInfo.read(buf),
+            FfiConverterBoolean.read(buf),
             FfiConverterOptionalString.read(buf),
         )
     }
@@ -1667,6 +1767,9 @@ public object FfiConverterTypeAppState: FfiConverterRustBuffer<AppState> {
             FfiConverterOptionalTypePeerProfileState.allocationSize(value.`peerProfile`) +
             FfiConverterOptionalTypeCallState.allocationSize(value.`activeCall`) +
             FfiConverterSequenceTypeCallTimelineEvent.allocationSize(value.`callTimeline`) +
+            FfiConverterSequenceTypeDeviceInfo.allocationSize(value.`myDevices`) +
+            FfiConverterSequenceTypeDeviceInfo.allocationSize(value.`pendingDevices`) +
+            FfiConverterBoolean.allocationSize(value.`autoAddDevices`) +
             FfiConverterOptionalString.allocationSize(value.`toast`)
     )
 
@@ -1682,6 +1785,9 @@ public object FfiConverterTypeAppState: FfiConverterRustBuffer<AppState> {
             FfiConverterOptionalTypePeerProfileState.write(value.`peerProfile`, buf)
             FfiConverterOptionalTypeCallState.write(value.`activeCall`, buf)
             FfiConverterSequenceTypeCallTimelineEvent.write(value.`callTimeline`, buf)
+            FfiConverterSequenceTypeDeviceInfo.write(value.`myDevices`, buf)
+            FfiConverterSequenceTypeDeviceInfo.write(value.`pendingDevices`, buf)
+            FfiConverterBoolean.write(value.`autoAddDevices`, buf)
             FfiConverterOptionalString.write(value.`toast`, buf)
     }
 }
@@ -1753,6 +1859,12 @@ data class CallDebugStats (
     var `jitterBufferMs`: kotlin.UInt
     , 
     var `lastRttMs`: kotlin.UInt?
+    , 
+    var `videoTx`: kotlin.ULong
+    , 
+    var `videoRx`: kotlin.ULong
+    , 
+    var `videoRxDecryptFail`: kotlin.ULong
     
 ){
     
@@ -1774,6 +1886,9 @@ public object FfiConverterTypeCallDebugStats: FfiConverterRustBuffer<CallDebugSt
             FfiConverterULong.read(buf),
             FfiConverterUInt.read(buf),
             FfiConverterOptionalUInt.read(buf),
+            FfiConverterULong.read(buf),
+            FfiConverterULong.read(buf),
+            FfiConverterULong.read(buf),
         )
     }
 
@@ -1782,7 +1897,10 @@ public object FfiConverterTypeCallDebugStats: FfiConverterRustBuffer<CallDebugSt
             FfiConverterULong.allocationSize(value.`rxFrames`) +
             FfiConverterULong.allocationSize(value.`rxDropped`) +
             FfiConverterUInt.allocationSize(value.`jitterBufferMs`) +
-            FfiConverterOptionalUInt.allocationSize(value.`lastRttMs`)
+            FfiConverterOptionalUInt.allocationSize(value.`lastRttMs`) +
+            FfiConverterULong.allocationSize(value.`videoTx`) +
+            FfiConverterULong.allocationSize(value.`videoRx`) +
+            FfiConverterULong.allocationSize(value.`videoRxDecryptFail`)
     )
 
     override fun write(value: CallDebugStats, buf: ByteBuffer) {
@@ -1791,6 +1909,9 @@ public object FfiConverterTypeCallDebugStats: FfiConverterRustBuffer<CallDebugSt
             FfiConverterULong.write(value.`rxDropped`, buf)
             FfiConverterUInt.write(value.`jitterBufferMs`, buf)
             FfiConverterOptionalUInt.write(value.`lastRttMs`, buf)
+            FfiConverterULong.write(value.`videoTx`, buf)
+            FfiConverterULong.write(value.`videoRx`, buf)
+            FfiConverterULong.write(value.`videoRxDecryptFail`, buf)
     }
 }
 
@@ -1814,6 +1935,10 @@ data class CallState (
     var `startedAt`: kotlin.Long?
     , 
     var `isMuted`: kotlin.Boolean
+    , 
+    var `isVideoCall`: kotlin.Boolean
+    , 
+    var `isCameraEnabled`: kotlin.Boolean
     , 
     var `debug`: CallDebugStats?
     
@@ -1841,6 +1966,8 @@ public object FfiConverterTypeCallState: FfiConverterRustBuffer<CallState> {
             FfiConverterBoolean.read(buf),
             FfiConverterOptionalLong.read(buf),
             FfiConverterBoolean.read(buf),
+            FfiConverterBoolean.read(buf),
+            FfiConverterBoolean.read(buf),
             FfiConverterOptionalTypeCallDebugStats.read(buf),
         )
     }
@@ -1855,6 +1982,8 @@ public object FfiConverterTypeCallState: FfiConverterRustBuffer<CallState> {
             FfiConverterBoolean.allocationSize(value.`shouldEnableProximityLock`) +
             FfiConverterOptionalLong.allocationSize(value.`startedAt`) +
             FfiConverterBoolean.allocationSize(value.`isMuted`) +
+            FfiConverterBoolean.allocationSize(value.`isVideoCall`) +
+            FfiConverterBoolean.allocationSize(value.`isCameraEnabled`) +
             FfiConverterOptionalTypeCallDebugStats.allocationSize(value.`debug`)
     )
 
@@ -1868,6 +1997,8 @@ public object FfiConverterTypeCallState: FfiConverterRustBuffer<CallState> {
             FfiConverterBoolean.write(value.`shouldEnableProximityLock`, buf)
             FfiConverterOptionalLong.write(value.`startedAt`, buf)
             FfiConverterBoolean.write(value.`isMuted`, buf)
+            FfiConverterBoolean.write(value.`isVideoCall`, buf)
+            FfiConverterBoolean.write(value.`isCameraEnabled`, buf)
             FfiConverterOptionalTypeCallDebugStats.write(value.`debug`, buf)
     }
 }
@@ -2146,6 +2277,79 @@ public object FfiConverterTypeChatViewState: FfiConverterRustBuffer<ChatViewStat
             FfiConverterSequenceTypeChatMessage.write(value.`messages`, buf)
             FfiConverterBoolean.write(value.`canLoadOlder`, buf)
             FfiConverterSequenceTypeTypingMember.write(value.`typingMembers`, buf)
+    }
+}
+
+
+
+/**
+ * Info about one of the user's own devices (derived from key packages on relays).
+ */
+data class DeviceInfo (
+    /**
+     * Hex event ID of the key package event.
+     */
+    var `keyPackageEventId`: kotlin.String
+    , 
+    /**
+     * JSON of the full key package event (for use with AddMyDevice).
+     */
+    var `keyPackageEventJson`: kotlin.String
+    , 
+    /**
+     * Stable short identifier for display (e.g. "a3f8b2c1").
+     * For the current device: derived from local device ID.
+     * For other devices: derived from key package content hash.
+     */
+    var `fingerprint`: kotlin.String
+    , 
+    /**
+     * Timestamp the key package was published (created_at).
+     */
+    var `publishedAt`: kotlin.Long
+    , 
+    /**
+     * Whether this is the current device's key package.
+     */
+    var `isCurrentDevice`: kotlin.Boolean
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeDeviceInfo: FfiConverterRustBuffer<DeviceInfo> {
+    override fun read(buf: ByteBuffer): DeviceInfo {
+        return DeviceInfo(
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterLong.read(buf),
+            FfiConverterBoolean.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: DeviceInfo) = (
+            FfiConverterString.allocationSize(value.`keyPackageEventId`) +
+            FfiConverterString.allocationSize(value.`keyPackageEventJson`) +
+            FfiConverterString.allocationSize(value.`fingerprint`) +
+            FfiConverterLong.allocationSize(value.`publishedAt`) +
+            FfiConverterBoolean.allocationSize(value.`isCurrentDevice`)
+    )
+
+    override fun write(value: DeviceInfo, buf: ByteBuffer) {
+            FfiConverterString.write(value.`keyPackageEventId`, buf)
+            FfiConverterString.write(value.`keyPackageEventJson`, buf)
+            FfiConverterString.write(value.`fingerprint`, buf)
+            FfiConverterLong.write(value.`publishedAt`, buf)
+            FfiConverterBoolean.write(value.`isCurrentDevice`, buf)
     }
 }
 
@@ -2839,6 +3043,15 @@ sealed class AppAction {
         companion object
     }
     
+    data class StartVideoCall(
+        val `chatId`: kotlin.String) : AppAction()
+        
+    {
+        
+
+        companion object
+    }
+    
     data class AcceptCall(
         val `chatId`: kotlin.String) : AppAction()
         
@@ -2861,6 +3074,9 @@ sealed class AppAction {
     
     
     object ToggleMute : AppAction()
+    
+    
+    object ToggleCamera : AppAction()
     
     
     data class CreateGroupChat(
@@ -2911,6 +3127,51 @@ sealed class AppAction {
 
         companion object
     }
+    
+    data class AddMyDevice(
+        val `keyPackageEventJson`: kotlin.String) : AppAction()
+        
+    {
+        
+
+        companion object
+    }
+    
+    object FetchMyDevices : AppAction()
+    
+    
+    data class SetAutoAddDevices(
+        val `enabled`: kotlin.Boolean) : AppAction()
+        
+    {
+        
+
+        companion object
+    }
+    
+    data class AcceptPendingDevice(
+        val `fingerprint`: kotlin.String) : AppAction()
+        
+    {
+        
+
+        companion object
+    }
+    
+    data class RejectPendingDevice(
+        val `fingerprint`: kotlin.String) : AppAction()
+        
+    {
+        
+
+        companion object
+    }
+    
+    object AcceptAllPendingDevices : AppAction()
+    
+    
+    object RejectAllPendingDevices : AppAction()
+    
     
     data class ArchiveChat(
         val `chatId`: kotlin.String) : AppAction()
@@ -3085,63 +3346,82 @@ public object FfiConverterTypeAppAction : FfiConverterRustBuffer<AppAction>{
             22 -> AppAction.StartCall(
                 FfiConverterString.read(buf),
                 )
-            23 -> AppAction.AcceptCall(
+            23 -> AppAction.StartVideoCall(
                 FfiConverterString.read(buf),
                 )
-            24 -> AppAction.RejectCall(
+            24 -> AppAction.AcceptCall(
                 FfiConverterString.read(buf),
                 )
-            25 -> AppAction.EndCall
-            26 -> AppAction.ToggleMute
-            27 -> AppAction.CreateGroupChat(
+            25 -> AppAction.RejectCall(
+                FfiConverterString.read(buf),
+                )
+            26 -> AppAction.EndCall
+            27 -> AppAction.ToggleMute
+            28 -> AppAction.ToggleCamera
+            29 -> AppAction.CreateGroupChat(
                 FfiConverterSequenceString.read(buf),
                 FfiConverterString.read(buf),
                 )
-            28 -> AppAction.AddGroupMembers(
+            30 -> AppAction.AddGroupMembers(
                 FfiConverterString.read(buf),
                 FfiConverterSequenceString.read(buf),
                 )
-            29 -> AppAction.RemoveGroupMembers(
+            31 -> AppAction.RemoveGroupMembers(
                 FfiConverterString.read(buf),
                 FfiConverterSequenceString.read(buf),
                 )
-            30 -> AppAction.LeaveGroup(
+            32 -> AppAction.LeaveGroup(
                 FfiConverterString.read(buf),
                 )
-            31 -> AppAction.RenameGroup(
-                FfiConverterString.read(buf),
-                FfiConverterString.read(buf),
-                )
-            32 -> AppAction.ArchiveChat(
-                FfiConverterString.read(buf),
-                )
-            33 -> AppAction.ReactToMessage(
-                FfiConverterString.read(buf),
+            33 -> AppAction.RenameGroup(
                 FfiConverterString.read(buf),
                 FfiConverterString.read(buf),
                 )
-            34 -> AppAction.TypingStarted(
+            34 -> AppAction.AddMyDevice(
                 FfiConverterString.read(buf),
                 )
-            35 -> AppAction.ClearToast
-            36 -> AppAction.Foregrounded
-            37 -> AppAction.NostrConnectCallback(
+            35 -> AppAction.FetchMyDevices
+            36 -> AppAction.SetAutoAddDevices(
+                FfiConverterBoolean.read(buf),
+                )
+            37 -> AppAction.AcceptPendingDevice(
                 FfiConverterString.read(buf),
                 )
-            38 -> AppAction.ReloadConfig
-            39 -> AppAction.OpenPeerProfile(
+            38 -> AppAction.RejectPendingDevice(
                 FfiConverterString.read(buf),
                 )
-            40 -> AppAction.ClosePeerProfile
-            41 -> AppAction.SetPushToken(
+            39 -> AppAction.AcceptAllPendingDevices
+            40 -> AppAction.RejectAllPendingDevices
+            41 -> AppAction.ArchiveChat(
                 FfiConverterString.read(buf),
                 )
-            42 -> AppAction.ReregisterPush
-            43 -> AppAction.RefreshFollowList
-            44 -> AppAction.FollowUser(
+            42 -> AppAction.ReactToMessage(
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
                 FfiConverterString.read(buf),
                 )
-            45 -> AppAction.UnfollowUser(
+            43 -> AppAction.TypingStarted(
+                FfiConverterString.read(buf),
+                )
+            44 -> AppAction.ClearToast
+            45 -> AppAction.Foregrounded
+            46 -> AppAction.NostrConnectCallback(
+                FfiConverterString.read(buf),
+                )
+            47 -> AppAction.ReloadConfig
+            48 -> AppAction.OpenPeerProfile(
+                FfiConverterString.read(buf),
+                )
+            49 -> AppAction.ClosePeerProfile
+            50 -> AppAction.SetPushToken(
+                FfiConverterString.read(buf),
+                )
+            51 -> AppAction.ReregisterPush
+            52 -> AppAction.RefreshFollowList
+            53 -> AppAction.FollowUser(
+                FfiConverterString.read(buf),
+                )
+            54 -> AppAction.UnfollowUser(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -3308,6 +3588,13 @@ public object FfiConverterTypeAppAction : FfiConverterRustBuffer<AppAction>{
                 + FfiConverterString.allocationSize(value.`chatId`)
             )
         }
+        is AppAction.StartVideoCall -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`chatId`)
+            )
+        }
         is AppAction.AcceptCall -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
@@ -3329,6 +3616,12 @@ public object FfiConverterTypeAppAction : FfiConverterRustBuffer<AppAction>{
             )
         }
         is AppAction.ToggleMute -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is AppAction.ToggleCamera -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
                 4UL
@@ -3371,6 +3664,52 @@ public object FfiConverterTypeAppAction : FfiConverterRustBuffer<AppAction>{
                 4UL
                 + FfiConverterString.allocationSize(value.`chatId`)
                 + FfiConverterString.allocationSize(value.`name`)
+            )
+        }
+        is AppAction.AddMyDevice -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`keyPackageEventJson`)
+            )
+        }
+        is AppAction.FetchMyDevices -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is AppAction.SetAutoAddDevices -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterBoolean.allocationSize(value.`enabled`)
+            )
+        }
+        is AppAction.AcceptPendingDevice -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`fingerprint`)
+            )
+        }
+        is AppAction.RejectPendingDevice -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`fingerprint`)
+            )
+        }
+        is AppAction.AcceptAllPendingDevices -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is AppAction.RejectAllPendingDevices -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
             )
         }
         is AppAction.ArchiveChat -> {
@@ -3586,116 +3925,157 @@ public object FfiConverterTypeAppAction : FfiConverterRustBuffer<AppAction>{
                 FfiConverterString.write(value.`chatId`, buf)
                 Unit
             }
-            is AppAction.AcceptCall -> {
+            is AppAction.StartVideoCall -> {
                 buf.putInt(23)
                 FfiConverterString.write(value.`chatId`, buf)
                 Unit
             }
-            is AppAction.RejectCall -> {
+            is AppAction.AcceptCall -> {
                 buf.putInt(24)
                 FfiConverterString.write(value.`chatId`, buf)
                 Unit
             }
-            is AppAction.EndCall -> {
+            is AppAction.RejectCall -> {
                 buf.putInt(25)
+                FfiConverterString.write(value.`chatId`, buf)
                 Unit
             }
-            is AppAction.ToggleMute -> {
+            is AppAction.EndCall -> {
                 buf.putInt(26)
                 Unit
             }
-            is AppAction.CreateGroupChat -> {
+            is AppAction.ToggleMute -> {
                 buf.putInt(27)
+                Unit
+            }
+            is AppAction.ToggleCamera -> {
+                buf.putInt(28)
+                Unit
+            }
+            is AppAction.CreateGroupChat -> {
+                buf.putInt(29)
                 FfiConverterSequenceString.write(value.`peerNpubs`, buf)
                 FfiConverterString.write(value.`groupName`, buf)
                 Unit
             }
             is AppAction.AddGroupMembers -> {
-                buf.putInt(28)
+                buf.putInt(30)
                 FfiConverterString.write(value.`chatId`, buf)
                 FfiConverterSequenceString.write(value.`peerNpubs`, buf)
                 Unit
             }
             is AppAction.RemoveGroupMembers -> {
-                buf.putInt(29)
+                buf.putInt(31)
                 FfiConverterString.write(value.`chatId`, buf)
                 FfiConverterSequenceString.write(value.`memberPubkeys`, buf)
                 Unit
             }
             is AppAction.LeaveGroup -> {
-                buf.putInt(30)
-                FfiConverterString.write(value.`chatId`, buf)
-                Unit
-            }
-            is AppAction.RenameGroup -> {
-                buf.putInt(31)
-                FfiConverterString.write(value.`chatId`, buf)
-                FfiConverterString.write(value.`name`, buf)
-                Unit
-            }
-            is AppAction.ArchiveChat -> {
                 buf.putInt(32)
                 FfiConverterString.write(value.`chatId`, buf)
                 Unit
             }
-            is AppAction.ReactToMessage -> {
+            is AppAction.RenameGroup -> {
                 buf.putInt(33)
+                FfiConverterString.write(value.`chatId`, buf)
+                FfiConverterString.write(value.`name`, buf)
+                Unit
+            }
+            is AppAction.AddMyDevice -> {
+                buf.putInt(34)
+                FfiConverterString.write(value.`keyPackageEventJson`, buf)
+                Unit
+            }
+            is AppAction.FetchMyDevices -> {
+                buf.putInt(35)
+                Unit
+            }
+            is AppAction.SetAutoAddDevices -> {
+                buf.putInt(36)
+                FfiConverterBoolean.write(value.`enabled`, buf)
+                Unit
+            }
+            is AppAction.AcceptPendingDevice -> {
+                buf.putInt(37)
+                FfiConverterString.write(value.`fingerprint`, buf)
+                Unit
+            }
+            is AppAction.RejectPendingDevice -> {
+                buf.putInt(38)
+                FfiConverterString.write(value.`fingerprint`, buf)
+                Unit
+            }
+            is AppAction.AcceptAllPendingDevices -> {
+                buf.putInt(39)
+                Unit
+            }
+            is AppAction.RejectAllPendingDevices -> {
+                buf.putInt(40)
+                Unit
+            }
+            is AppAction.ArchiveChat -> {
+                buf.putInt(41)
+                FfiConverterString.write(value.`chatId`, buf)
+                Unit
+            }
+            is AppAction.ReactToMessage -> {
+                buf.putInt(42)
                 FfiConverterString.write(value.`chatId`, buf)
                 FfiConverterString.write(value.`messageId`, buf)
                 FfiConverterString.write(value.`emoji`, buf)
                 Unit
             }
             is AppAction.TypingStarted -> {
-                buf.putInt(34)
+                buf.putInt(43)
                 FfiConverterString.write(value.`chatId`, buf)
                 Unit
             }
             is AppAction.ClearToast -> {
-                buf.putInt(35)
+                buf.putInt(44)
                 Unit
             }
             is AppAction.Foregrounded -> {
-                buf.putInt(36)
+                buf.putInt(45)
                 Unit
             }
             is AppAction.NostrConnectCallback -> {
-                buf.putInt(37)
+                buf.putInt(46)
                 FfiConverterString.write(value.`url`, buf)
                 Unit
             }
             is AppAction.ReloadConfig -> {
-                buf.putInt(38)
+                buf.putInt(47)
                 Unit
             }
             is AppAction.OpenPeerProfile -> {
-                buf.putInt(39)
+                buf.putInt(48)
                 FfiConverterString.write(value.`pubkey`, buf)
                 Unit
             }
             is AppAction.ClosePeerProfile -> {
-                buf.putInt(40)
+                buf.putInt(49)
                 Unit
             }
             is AppAction.SetPushToken -> {
-                buf.putInt(41)
+                buf.putInt(50)
                 FfiConverterString.write(value.`token`, buf)
                 Unit
             }
             is AppAction.ReregisterPush -> {
-                buf.putInt(42)
+                buf.putInt(51)
                 Unit
             }
             is AppAction.RefreshFollowList -> {
-                buf.putInt(43)
+                buf.putInt(52)
                 Unit
             }
             is AppAction.FollowUser -> {
-                buf.putInt(44)
+                buf.putInt(53)
                 FfiConverterString.write(value.`pubkey`, buf)
                 Unit
             }
             is AppAction.UnfollowUser -> {
-                buf.putInt(45)
+                buf.putInt(54)
                 FfiConverterString.write(value.`pubkey`, buf)
                 Unit
             }
@@ -4298,6 +4678,9 @@ sealed class Screen {
         companion object
     }
     
+    object DeviceManagement : Screen()
+    
+    
 
     
 
@@ -4324,6 +4707,7 @@ public object FfiConverterTypeScreen : FfiConverterRustBuffer<Screen>{
             6 -> Screen.GroupInfo(
                 FfiConverterString.read(buf),
                 )
+            7 -> Screen.DeviceManagement
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
         }
     }
@@ -4367,6 +4751,12 @@ public object FfiConverterTypeScreen : FfiConverterRustBuffer<Screen>{
                 + FfiConverterString.allocationSize(value.`chatId`)
             )
         }
+        is Screen.DeviceManagement -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
     }
 
     override fun write(value: Screen, buf: ByteBuffer) {
@@ -4395,6 +4785,10 @@ public object FfiConverterTypeScreen : FfiConverterRustBuffer<Screen>{
             is Screen.GroupInfo -> {
                 buf.putInt(6)
                 FfiConverterString.write(value.`chatId`, buf)
+                Unit
+            }
+            is Screen.DeviceManagement -> {
+                buf.putInt(7)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -4626,6 +5020,71 @@ internal object uniffiCallbackInterfaceExternalSignerBridge {
  * @suppress
  */
 public object FfiConverterTypeExternalSignerBridge: FfiConverterCallbackInterface<ExternalSignerBridge>()
+
+
+
+
+
+/**
+ * Platform-side callback for receiving decoded video frames from remote peers.
+ * Called from the video worker thread at ~30fps during active video calls.
+ */
+public interface VideoFrameReceiver {
+    
+    fun `onVideoFrame`(`callId`: kotlin.String, `payload`: kotlin.ByteArray)
+    
+    companion object
+}
+
+
+
+// Put the implementation in an object so we don't pollute the top-level namespace
+internal object uniffiCallbackInterfaceVideoFrameReceiver {
+    internal object `onVideoFrame`: UniffiCallbackInterfaceVideoFrameReceiverMethod0 {
+        override fun callback(`uniffiHandle`: Long,`callId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,) {
+            val uniffiObj = FfiConverterTypeVideoFrameReceiver.handleMap.get(uniffiHandle)
+            val makeCall = { ->
+                uniffiObj.`onVideoFrame`(
+                    FfiConverterString.lift(`callId`),
+                    FfiConverterByteArray.lift(`payload`),
+                )
+            }
+            val writeReturn = { _: Unit -> Unit }
+            uniffiTraitInterfaceCall(uniffiCallStatus, makeCall, writeReturn)
+        }
+    }
+
+    internal object uniffiFree: UniffiCallbackInterfaceFree {
+        override fun callback(handle: Long) {
+            FfiConverterTypeVideoFrameReceiver.handleMap.remove(handle)
+        }
+    }
+
+    internal object uniffiClone: UniffiCallbackInterfaceClone {
+        override fun callback(handle: Long): Long {
+            return FfiConverterTypeVideoFrameReceiver.handleMap.clone(handle)
+        }
+    }
+
+    internal var vtable = UniffiVTableCallbackInterfaceVideoFrameReceiver.UniffiByValue(
+        uniffiFree,
+        uniffiClone,
+        `onVideoFrame`,
+    )
+
+    // Registers the foreign callback with the Rust side.
+    // This method is generated for each callback interface.
+    internal fun register(lib: UniffiLib) {
+        lib.uniffi_pika_core_fn_init_callback_vtable_videoframereceiver(vtable)
+    }
+}
+
+/**
+ * The ffiConverter which transforms the Callbacks in to handles to pass to Rust.
+ *
+ * @suppress
+ */
+public object FfiConverterTypeVideoFrameReceiver: FfiConverterCallbackInterface<VideoFrameReceiver>()
 
 
 
@@ -5023,6 +5482,34 @@ public object FfiConverterSequenceTypeChatSummary: FfiConverterRustBuffer<List<C
         buf.putInt(value.size)
         value.iterator().forEach {
             FfiConverterTypeChatSummary.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterSequenceTypeDeviceInfo: FfiConverterRustBuffer<List<DeviceInfo>> {
+    override fun read(buf: ByteBuffer): List<DeviceInfo> {
+        val len = buf.getInt()
+        return List<DeviceInfo>(len) {
+            FfiConverterTypeDeviceInfo.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<DeviceInfo>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeDeviceInfo.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<DeviceInfo>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeDeviceInfo.write(it, buf)
         }
     }
 }

--- a/android/app/src/main/java/com/pika/app/ui/PikaApp.kt
+++ b/android/app/src/main/java/com/pika/app/ui/PikaApp.kt
@@ -23,6 +23,7 @@ import com.pika.app.rust.Screen
 import com.pika.app.ui.screens.CallSurface
 import com.pika.app.ui.screens.ChatListScreen
 import com.pika.app.ui.screens.ChatScreen
+import com.pika.app.ui.screens.DeviceManagementScreen
 import com.pika.app.ui.screens.GroupInfoScreen
 import com.pika.app.ui.screens.LoginScreen
 import com.pika.app.ui.screens.NewChatScreen
@@ -93,6 +94,7 @@ fun PikaApp(manager: AppManager) {
                             )
                         is Screen.GroupInfo -> GroupInfoScreen(manager = manager, chatId = screen.chatId, padding = padding)
                         is Screen.Login -> LoginScreen(manager = manager, padding = padding)
+                        is Screen.DeviceManagement -> DeviceManagementScreen(manager = manager, padding = padding)
                     }
                 }
             }

--- a/android/app/src/main/java/com/pika/app/ui/screens/DeviceManagementScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/DeviceManagementScreen.kt
@@ -1,0 +1,245 @@
+package com.pika.app.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pika.app.AppManager
+import com.pika.app.rust.AppAction
+import com.pika.app.rust.DeviceInfo
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun DeviceManagementScreen(manager: AppManager, padding: PaddingValues) {
+    val devices = manager.state.myDevices
+    val pendingDevices = manager.state.pendingDevices
+    val autoAddDevices = manager.state.autoAddDevices
+
+    LaunchedEffect(Unit) {
+        manager.dispatch(AppAction.FetchMyDevices)
+    }
+
+    Scaffold(
+        modifier = Modifier.padding(padding),
+        topBar = {
+            TopAppBar(
+                title = { Text("Devices") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = {
+                            val stack = manager.state.router.screenStack
+                            manager.dispatch(AppAction.UpdateScreenStack(stack.dropLast(1)))
+                        },
+                    ) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { inner ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(inner),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Auto-add toggle
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            "Auto-add new devices",
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Text(
+                            "Automatically detect and invite new devices to all groups.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Switch(
+                        checked = autoAddDevices,
+                        onCheckedChange = { manager.dispatch(AppAction.SetAutoAddDevices(it)) },
+                    )
+                }
+            }
+
+            // Pending devices section
+            if (pendingDevices.isNotEmpty()) {
+                item { HorizontalDivider() }
+
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            "Pending Devices (${pendingDevices.size})",
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(
+                                onClick = { manager.dispatch(AppAction.AcceptAllPendingDevices) },
+                            ) {
+                                Text("Accept All", style = MaterialTheme.typography.labelSmall)
+                            }
+                            Button(
+                                onClick = { manager.dispatch(AppAction.RejectAllPendingDevices) },
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.error,
+                                ),
+                            ) {
+                                Text("Reject All", style = MaterialTheme.typography.labelSmall)
+                            }
+                        }
+                    }
+                }
+
+                items(pendingDevices, key = { it.fingerprint }) { device ->
+                    PendingDeviceRow(
+                        device = device,
+                        onAccept = { manager.dispatch(AppAction.AcceptPendingDevice(device.fingerprint)) },
+                        onReject = { manager.dispatch(AppAction.RejectPendingDevice(device.fingerprint)) },
+                    )
+                }
+            }
+
+            item { HorizontalDivider() }
+
+            // Devices header
+            item {
+                Text(
+                    "My Devices (${devices.size})",
+                    style = MaterialTheme.typography.titleSmall,
+                )
+            }
+
+            if (devices.isEmpty()) {
+                item {
+                    Text(
+                        "No devices found",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                items(devices, key = { it.fingerprint }) { device ->
+                    DeviceRow(device)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PendingDeviceRow(device: DeviceInfo, onAccept: () -> Unit, onReject: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                deviceDisplayName(device),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "Published: ${formatTimestamp(device.publishedAt)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(onClick = onAccept) {
+            Icon(
+                Icons.Default.Check,
+                contentDescription = "Accept",
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+        IconButton(onClick = onReject) {
+            Icon(
+                Icons.Default.Close,
+                contentDescription = "Reject",
+                tint = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DeviceRow(device: DeviceInfo) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    deviceDisplayName(device),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                if (device.isCurrentDevice) {
+                    Text(
+                        "This device",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "Published: ${formatTimestamp(device.publishedAt)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun deviceDisplayName(device: DeviceInfo): String {
+    return "Device ${device.fingerprint}"
+}
+
+private fun formatTimestamp(epochSecs: Long): String {
+    val sdf = SimpleDateFormat("MMM d, yyyy h:mm a", Locale.getDefault())
+    return sdf.format(Date(epochSecs * 1000))
+}

--- a/crates/pika-desktop/src/views/device_management.rs
+++ b/crates/pika-desktop/src/views/device_management.rs
@@ -1,0 +1,194 @@
+use iced::widget::{button, column, container, row, rule, scrollable, text, toggler, Space};
+use iced::{Alignment, Element, Fill, Theme};
+use pika_core::DeviceInfo;
+
+use crate::theme;
+use crate::Message;
+
+/// Device management screen shown in the center pane.
+pub fn device_management_view<'a>(
+    devices: &'a [DeviceInfo],
+    pending_devices: &'a [DeviceInfo],
+    auto_add_devices: bool,
+) -> Element<'a, Message, Theme> {
+    let mut content = column![].spacing(16).padding([24, 32]).width(Fill);
+
+    // ── Header ────────────────────────────────────────────────────────
+    content = content.push(text("Devices").size(22).color(theme::TEXT_PRIMARY));
+
+    // ── Auto-add toggle ───────────────────────────────────────────────
+    let toggle_row = row![
+        column![
+            text("Auto-add new devices")
+                .size(14)
+                .color(theme::TEXT_PRIMARY),
+            text("Automatically detect and invite new devices to all groups.")
+                .size(12)
+                .color(theme::TEXT_SECONDARY),
+        ]
+        .spacing(4)
+        .width(Fill),
+        toggler(auto_add_devices).on_toggle(|_| Message::ToggleAutoAddDevices),
+    ]
+    .spacing(16)
+    .align_y(Alignment::Center);
+
+    content = content.push(toggle_row);
+    content = content.push(rule::horizontal(1));
+
+    // ── Pending devices ──────────────────────────────────────────────
+    if !pending_devices.is_empty() {
+        let header_row = row![
+            text(format!("Pending Devices ({})", pending_devices.len()))
+                .size(16)
+                .color(theme::TEXT_PRIMARY),
+            Space::new().width(Fill),
+            button(text("Accept All").size(12).center())
+                .on_press(Message::AcceptAllPendingDevices)
+                .padding([6, 14])
+                .style(theme::primary_button_style),
+            button(text("Reject All").size(12).center())
+                .on_press(Message::RejectAllPendingDevices)
+                .padding([6, 14])
+                .style(theme::danger_button_style),
+        ]
+        .spacing(8)
+        .align_y(Alignment::Center);
+
+        content = content.push(header_row);
+
+        let pending_list = pending_devices
+            .iter()
+            .fold(column![].spacing(4), |col, device| {
+                col.push(pending_device_row(device))
+            });
+        content = content.push(pending_list);
+        content = content.push(rule::horizontal(1));
+    }
+
+    // ── Device list header ────────────────────────────────────────────
+    content = content.push(
+        text(format!("My Devices ({})", devices.len()))
+            .size(16)
+            .color(theme::TEXT_PRIMARY),
+    );
+
+    // ── Device list ───────────────────────────────────────────────────
+    if devices.is_empty() {
+        content = content.push(text("No devices found").size(14).color(theme::TEXT_FADED));
+    } else {
+        let device_list = devices.iter().fold(column![].spacing(4), |col, device| {
+            col.push(device_row(device))
+        });
+        content = content.push(scrollable(device_list).height(Fill).width(Fill));
+    }
+
+    // ── Close button ──────────────────────────────────────────────────
+    content = content.push(
+        container(
+            button(text("Close").size(13).color(theme::TEXT_SECONDARY).center())
+                .on_press(Message::CloseDeviceManagement)
+                .padding([8, 20])
+                .style(theme::secondary_button_style),
+        )
+        .width(Fill)
+        .align_x(Alignment::Center),
+    );
+
+    container(content)
+        .width(Fill)
+        .height(Fill)
+        .style(theme::surface_style)
+        .into()
+}
+
+fn pending_device_row<'a>(device: &'a DeviceInfo) -> Element<'a, Message, Theme> {
+    let name = format!("Device {}", device.fingerprint);
+    let ts = relative_time(device.published_at);
+    let fp = device.fingerprint.clone();
+    let fp2 = device.fingerprint.clone();
+
+    let row_content = row![
+        column![
+            text(name).size(14).color(theme::TEXT_PRIMARY),
+            text(format!("Published: {ts}"))
+                .size(12)
+                .color(theme::TEXT_FADED),
+        ]
+        .spacing(2),
+        Space::new().width(Fill),
+        button(text("Accept").size(12).center())
+            .on_press(Message::AcceptPendingDevice(fp))
+            .padding([4, 12])
+            .style(theme::primary_button_style),
+        button(text("Reject").size(12).center())
+            .on_press(Message::RejectPendingDevice(fp2))
+            .padding([4, 12])
+            .style(theme::danger_button_style),
+    ]
+    .spacing(8)
+    .align_y(Alignment::Center);
+
+    container(row_content).width(Fill).padding([8, 12]).into()
+}
+
+fn device_row<'a>(device: &'a DeviceInfo) -> Element<'a, Message, Theme> {
+    let name = format!("Device {}", device.fingerprint);
+    let ts = relative_time(device.published_at);
+
+    let mut name_row = row![text(name).size(14).color(theme::TEXT_PRIMARY),]
+        .spacing(8)
+        .align_y(Alignment::Center);
+
+    if device.is_current_device {
+        name_row = name_row.push(
+            container(
+                text("This device")
+                    .size(11)
+                    .color(iced::Color::WHITE)
+                    .center(),
+            )
+            .padding([2, 8])
+            .style(|_: &Theme| container::Style {
+                background: Some(iced::Background::Color(theme::ACCENT_BLUE)),
+                border: iced::border::rounded(10),
+                ..Default::default()
+            }),
+        );
+    }
+
+    let row_content = row![
+        column![
+            name_row,
+            text(format!("Published: {ts}"))
+                .size(12)
+                .color(theme::TEXT_FADED),
+        ]
+        .spacing(2),
+        Space::new().width(Fill),
+    ]
+    .spacing(10)
+    .align_y(Alignment::Center);
+
+    container(row_content).width(Fill).padding([8, 12]).into()
+}
+
+fn relative_time(published_at: i64) -> String {
+    use std::time::{Duration, UNIX_EPOCH};
+    let dt = UNIX_EPOCH + Duration::from_secs(published_at as u64);
+    let days_ago = std::time::SystemTime::now()
+        .duration_since(dt)
+        .unwrap_or_default()
+        .as_secs()
+        / 86400;
+    if days_ago == 0 {
+        "today".to_string()
+    } else if days_ago == 1 {
+        "yesterday".to_string()
+    } else if days_ago < 30 {
+        format!("{days_ago} days ago")
+    } else {
+        let secs = dt.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        format!("epoch {secs}")
+    }
+}

--- a/crates/pika-desktop/src/views/mod.rs
+++ b/crates/pika-desktop/src/views/mod.rs
@@ -3,6 +3,7 @@ pub mod call_banner;
 pub mod call_screen;
 pub mod chat_rail;
 pub mod conversation;
+pub mod device_management;
 pub mod empty_state;
 pub mod group_info;
 pub mod login;

--- a/crates/pika-desktop/src/views/my_profile.rs
+++ b/crates/pika-desktop/src/views/my_profile.rs
@@ -117,6 +117,18 @@ pub fn my_profile_view<'a>(
 
     content = content.push(container(version_row).width(Fill));
 
+    // ── Devices ────────────────────────────────────────────────────
+    content = content.push(
+        container(
+            button(text("Devices").size(14).center())
+                .on_press(Message::ShowDeviceManagement)
+                .padding([10, 24])
+                .style(theme::secondary_button_style),
+        )
+        .width(Fill)
+        .align_x(Alignment::Center),
+    );
+
     // ── Logout ──────────────────────────────────────────────────────
     content = content.push(Space::new().height(Fill));
 

--- a/ios/Sources/ContentView.swift
+++ b/ios/Sources/ContentView.swift
@@ -227,7 +227,17 @@ private func screenView(
             isDeveloperModeEnabledProvider: { manager.isDeveloperModeEnabled },
             onEnableDeveloperMode: { manager.enableDeveloperMode() },
             onWipeLocalData: { manager.wipeLocalDataForDeveloperTools() },
-            nsecProvider: { manager.getNsec() }
+            nsecProvider: { manager.getNsec() },
+            devices: state.myDevices,
+            autoAddDevices: state.autoAddDevices,
+            onToggleAutoAddDevices: { enabled in manager.dispatch(.setAutoAddDevices(enabled: enabled)) },
+            onFetchDevices: { manager.dispatch(.fetchMyDevices) },
+            onAddDevice: { json in manager.dispatch(.addMyDevice(keyPackageEventJson: json)) },
+            pendingDevices: state.pendingDevices,
+            onAcceptDevice: { fp in manager.dispatch(.acceptPendingDevice(fingerprint: fp)) },
+            onRejectDevice: { fp in manager.dispatch(.rejectPendingDevice(fingerprint: fp)) },
+            onAcceptAll: { manager.dispatch(.acceptAllPendingDevices) },
+            onRejectAll: { manager.dispatch(.rejectAllPendingDevices) }
         )
     case .newChat:
         NewChatView(
@@ -328,6 +338,19 @@ private func screenView(
                 )
             }
         }
+    case .deviceManagement:
+        DeviceManagementView(
+            devices: state.myDevices,
+            pendingDevices: state.pendingDevices,
+            autoAddDevices: state.autoAddDevices,
+            onToggleAutoAdd: { enabled in manager.dispatch(.setAutoAddDevices(enabled: enabled)) },
+            onAddDevice: { json in manager.dispatch(.addMyDevice(keyPackageEventJson: json)) },
+            onAcceptDevice: { fp in manager.dispatch(.acceptPendingDevice(fingerprint: fp)) },
+            onRejectDevice: { fp in manager.dispatch(.rejectPendingDevice(fingerprint: fp)) },
+            onAcceptAll: { manager.dispatch(.acceptAllPendingDevices) },
+            onRejectAll: { manager.dispatch(.rejectAllPendingDevices) },
+            onRefresh: { manager.dispatch(.fetchMyDevices) }
+        )
     }
 }
 

--- a/ios/Sources/PreviewData.swift
+++ b/ios/Sources/PreviewData.swift
@@ -222,6 +222,9 @@ enum PreviewAppState {
         followList: [FollowListEntry] = [],
         activeCall: CallState? = nil,
         callTimeline: [CallTimelineEvent] = [],
+        myDevices: [DeviceInfo] = [],
+        pendingDevices: [DeviceInfo] = [],
+        autoAddDevices: Bool = true,
         toast: String? = nil
     ) -> AppState {
         AppState(
@@ -236,6 +239,9 @@ enum PreviewAppState {
             peerProfile: nil,
             activeCall: activeCall,
             callTimeline: callTimeline,
+            myDevices: myDevices,
+            pendingDevices: pendingDevices,
+            autoAddDevices: autoAddDevices,
             toast: toast
         )
     }

--- a/ios/Sources/Views/ChatListView.swift
+++ b/ios/Sources/Views/ChatListView.swift
@@ -15,6 +15,16 @@ struct ChatListView: View {
     let onEnableDeveloperMode: @MainActor () -> Void
     let onWipeLocalData: @MainActor () -> Void
     let nsecProvider: @MainActor () -> String?
+    let devices: [DeviceInfo]
+    let autoAddDevices: Bool
+    let onToggleAutoAddDevices: @MainActor (_ enabled: Bool) -> Void
+    let onFetchDevices: @MainActor () -> Void
+    let onAddDevice: @MainActor (_ json: String) -> Void
+    let pendingDevices: [DeviceInfo]
+    let onAcceptDevice: @MainActor (_ fingerprint: String) -> Void
+    let onRejectDevice: @MainActor (_ fingerprint: String) -> Void
+    let onAcceptAll: @MainActor () -> Void
+    let onRejectAll: @MainActor () -> Void
     @State private var showMyNpub = false
 
     var body: some View {
@@ -99,7 +109,17 @@ struct ChatListView: View {
                             onLogout: onLogout,
                             isDeveloperModeEnabledProvider: isDeveloperModeEnabledProvider,
                             onEnableDeveloperMode: onEnableDeveloperMode,
-                            onWipeLocalData: onWipeLocalData
+                            onWipeLocalData: onWipeLocalData,
+                            devices: devices,
+                            autoAddDevices: autoAddDevices,
+                            onToggleAutoAddDevices: onToggleAutoAddDevices,
+                            onFetchDevices: onFetchDevices,
+                            onAddDevice: onAddDevice,
+                            pendingDevices: pendingDevices,
+                            onAcceptDevice: onAcceptDevice,
+                            onRejectDevice: onRejectDevice,
+                            onAcceptAll: onAcceptAll,
+                            onRejectAll: onRejectAll
                         )
                     }
                 }
@@ -180,7 +200,17 @@ struct ChatListView: View {
             isDeveloperModeEnabledProvider: { false },
             onEnableDeveloperMode: {},
             onWipeLocalData: {},
-            nsecProvider: { nil }
+            nsecProvider: { nil },
+            devices: [],
+            autoAddDevices: true,
+            onToggleAutoAddDevices: { _ in },
+            onFetchDevices: {},
+            onAddDevice: { _ in },
+            pendingDevices: [],
+            onAcceptDevice: { _ in },
+            onRejectDevice: { _ in },
+            onAcceptAll: {},
+            onRejectAll: {}
         )
     }
 }
@@ -204,7 +234,17 @@ struct ChatListView: View {
             isDeveloperModeEnabledProvider: { false },
             onEnableDeveloperMode: {},
             onWipeLocalData: {},
-            nsecProvider: { nil }
+            nsecProvider: { nil },
+            devices: [],
+            autoAddDevices: true,
+            onToggleAutoAddDevices: { _ in },
+            onFetchDevices: {},
+            onAddDevice: { _ in },
+            pendingDevices: [],
+            onAcceptDevice: { _ in },
+            onRejectDevice: { _ in },
+            onAcceptAll: {},
+            onRejectAll: {}
         )
     }
 }
@@ -228,7 +268,17 @@ struct ChatListView: View {
             isDeveloperModeEnabledProvider: { false },
             onEnableDeveloperMode: {},
             onWipeLocalData: {},
-            nsecProvider: { nil }
+            nsecProvider: { nil },
+            devices: [],
+            autoAddDevices: true,
+            onToggleAutoAddDevices: { _ in },
+            onFetchDevices: {},
+            onAddDevice: { _ in },
+            pendingDevices: [],
+            onAcceptDevice: { _ in },
+            onRejectDevice: { _ in },
+            onAcceptAll: {},
+            onRejectAll: {}
         )
     }
 }

--- a/ios/Sources/Views/DeviceManagementView.swift
+++ b/ios/Sources/Views/DeviceManagementView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+struct DeviceManagementView: View {
+    let devices: [DeviceInfo]
+    let pendingDevices: [DeviceInfo]
+    let autoAddDevices: Bool
+    let onToggleAutoAdd: (Bool) -> Void
+    let onAddDevice: (String) -> Void
+    let onAcceptDevice: (String) -> Void
+    let onRejectDevice: (String) -> Void
+    let onAcceptAll: () -> Void
+    let onRejectAll: () -> Void
+    let onRefresh: () -> Void
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("Auto-add new devices", isOn: Binding(
+                    get: { autoAddDevices },
+                    set: { onToggleAutoAdd($0) }
+                ))
+            } footer: {
+                Text("When enabled, existing devices will automatically detect and invite new devices to all groups.")
+            }
+
+            if !pendingDevices.isEmpty {
+                Section {
+                    HStack {
+                        Text("Pending Devices")
+                            .font(.headline)
+                        Spacer()
+                        Button("Accept All") { onAcceptAll() }
+                            .font(.caption)
+                            .buttonStyle(.borderedProminent)
+                        Button("Reject All") { onRejectAll() }
+                            .font(.caption)
+                            .buttonStyle(.bordered)
+                            .tint(.red)
+                    }
+
+                    ForEach(pendingDevices, id: \.fingerprint) { device in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(deviceDisplayName(device))
+                                    .font(.body)
+                                Text("Published: \(formattedDate(device.publishedAt))")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Button { onAcceptDevice(device.fingerprint) } label: {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                            }
+                            .buttonStyle(.plain)
+                            Button { onRejectDevice(device.fingerprint) } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.red)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+
+            Section("My Devices") {
+                if devices.isEmpty {
+                    Text("No devices found")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(devices, id: \.fingerprint) { device in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack {
+                                    Text(deviceDisplayName(device))
+                                        .font(.body)
+                                    if device.isCurrentDevice {
+                                        Text("This device")
+                                            .font(.caption)
+                                            .foregroundStyle(.white)
+                                            .padding(.horizontal, 6)
+                                            .padding(.vertical, 2)
+                                            .background(.blue, in: Capsule())
+                                    }
+                                }
+                                Text("Published: \(formattedDate(device.publishedAt))")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Devices")
+        .onAppear { onRefresh() }
+    }
+
+    private func deviceDisplayName(_ device: DeviceInfo) -> String {
+        return "Device \(device.fingerprint)"
+    }
+
+    private func formattedDate(_ timestamp: Int64) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}

--- a/ios/Sources/Views/MyNpubQrSheet.swift
+++ b/ios/Sources/Views/MyNpubQrSheet.swift
@@ -15,6 +15,16 @@ struct MyNpubQrSheet: View {
     let isDeveloperModeEnabledProvider: @MainActor () -> Bool
     let onEnableDeveloperMode: @MainActor () -> Void
     let onWipeLocalData: @MainActor () -> Void
+    let devices: [DeviceInfo]
+    let autoAddDevices: Bool
+    let onToggleAutoAddDevices: @MainActor (_ enabled: Bool) -> Void
+    let onFetchDevices: @MainActor () -> Void
+    let onAddDevice: @MainActor (_ json: String) -> Void
+    let pendingDevices: [DeviceInfo]
+    let onAcceptDevice: @MainActor (_ fingerprint: String) -> Void
+    let onRejectDevice: @MainActor (_ fingerprint: String) -> Void
+    let onAcceptAll: @MainActor () -> Void
+    let onRejectAll: @MainActor () -> Void
 
     @Environment(\.dismiss) private var dismiss
     @State private var showNsec = false
@@ -47,6 +57,16 @@ struct MyNpubQrSheet: View {
         isDeveloperModeEnabledProvider: @MainActor @escaping () -> Bool,
         onEnableDeveloperMode: @MainActor @escaping () -> Void,
         onWipeLocalData: @MainActor @escaping () -> Void,
+        devices: [DeviceInfo] = [],
+        autoAddDevices: Bool = false,
+        onToggleAutoAddDevices: @MainActor @escaping (_ enabled: Bool) -> Void = { _ in },
+        onFetchDevices: @MainActor @escaping () -> Void = {},
+        onAddDevice: @MainActor @escaping (_ json: String) -> Void = { _ in },
+        pendingDevices: [DeviceInfo] = [],
+        onAcceptDevice: @MainActor @escaping (_ fingerprint: String) -> Void = { _ in },
+        onRejectDevice: @MainActor @escaping (_ fingerprint: String) -> Void = { _ in },
+        onAcceptAll: @MainActor @escaping () -> Void = {},
+        onRejectAll: @MainActor @escaping () -> Void = {},
         showLogoutConfirm: Bool = false
     ) {
         self.npub = npub
@@ -59,6 +79,16 @@ struct MyNpubQrSheet: View {
         self.isDeveloperModeEnabledProvider = isDeveloperModeEnabledProvider
         self.onEnableDeveloperMode = onEnableDeveloperMode
         self.onWipeLocalData = onWipeLocalData
+        self.devices = devices
+        self.autoAddDevices = autoAddDevices
+        self.onToggleAutoAddDevices = onToggleAutoAddDevices
+        self.onFetchDevices = onFetchDevices
+        self.onAddDevice = onAddDevice
+        self.pendingDevices = pendingDevices
+        self.onAcceptDevice = onAcceptDevice
+        self.onRejectDevice = onRejectDevice
+        self.onAcceptAll = onAcceptAll
+        self.onRejectAll = onRejectAll
         self._showLogoutConfirm = State(initialValue: showLogoutConfirm)
     }
 
@@ -221,6 +251,26 @@ struct MyNpubQrSheet: View {
     }
 
     @ViewBuilder
+    private var devicesSection: some View {
+        Section {
+            NavigationLink("Devices") {
+                DeviceManagementView(
+                    devices: devices,
+                    pendingDevices: pendingDevices,
+                    autoAddDevices: autoAddDevices,
+                    onToggleAutoAdd: onToggleAutoAddDevices,
+                    onAddDevice: onAddDevice,
+                    onAcceptDevice: onAcceptDevice,
+                    onRejectDevice: onRejectDevice,
+                    onAcceptAll: onAcceptAll,
+                    onRejectAll: onRejectAll,
+                    onRefresh: onFetchDevices
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
     private var notificationsSection: some View {
         Section {
             NavigationLink("Notifications") {
@@ -290,6 +340,7 @@ struct MyNpubQrSheet: View {
         }
         appVersionSection
         developerSection
+        devicesSection
         notificationsSection
         logoutSection
     }
@@ -519,7 +570,12 @@ struct MyNpubQrSheet: View {
         onLogout: {},
         isDeveloperModeEnabledProvider: { false },
         onEnableDeveloperMode: {},
-        onWipeLocalData: {}
+        onWipeLocalData: {},
+        devices: [],
+        autoAddDevices: true,
+        onToggleAutoAddDevices: { _ in },
+        onFetchDevices: {},
+        onAddDevice: { _ in }
     )
 }
 
@@ -535,6 +591,11 @@ struct MyNpubQrSheet: View {
         isDeveloperModeEnabledProvider: { false },
         onEnableDeveloperMode: {},
         onWipeLocalData: {},
+        devices: [],
+        autoAddDevices: true,
+        onToggleAutoAddDevices: { _ in },
+        onFetchDevices: {},
+        onAddDevice: { _ in },
         showLogoutConfirm: true
     )
 }

--- a/rust/src/actions.rs
+++ b/rust/src/actions.rs
@@ -106,6 +106,23 @@ pub enum AppAction {
         name: String,
     },
 
+    // Multi-device
+    AddMyDevice {
+        key_package_event_json: String,
+    },
+    FetchMyDevices,
+    SetAutoAddDevices {
+        enabled: bool,
+    },
+    AcceptPendingDevice {
+        fingerprint: String,
+    },
+    RejectPendingDevice {
+        fingerprint: String,
+    },
+    AcceptAllPendingDevices,
+    RejectAllPendingDevices,
+
     // Chat management
     ArchiveChat {
         chat_id: String,
@@ -195,6 +212,15 @@ impl AppAction {
             AppAction::RemoveGroupMembers { .. } => "RemoveGroupMembers",
             AppAction::LeaveGroup { .. } => "LeaveGroup",
             AppAction::RenameGroup { .. } => "RenameGroup",
+
+            // Multi-device
+            AppAction::AddMyDevice { .. } => "AddMyDevice",
+            AppAction::FetchMyDevices => "FetchMyDevices",
+            AppAction::SetAutoAddDevices { .. } => "SetAutoAddDevices",
+            AppAction::AcceptPendingDevice { .. } => "AcceptPendingDevice",
+            AppAction::RejectPendingDevice { .. } => "RejectPendingDevice",
+            AppAction::AcceptAllPendingDevices => "AcceptAllPendingDevices",
+            AppAction::RejectAllPendingDevices => "RejectAllPendingDevices",
 
             // Chat management
             AppAction::ArchiveChat { .. } => "ArchiveChat",

--- a/rust/src/core/config.rs
+++ b/rust/src/core/config.rs
@@ -38,6 +38,8 @@ pub(super) struct AppConfig {
     pub(super) notification_url: Option<String>,
     // Dev-only: run a one-shot QUIC+TLS probe on startup and log PASS/FAIL.
     pub(super) moq_probe_on_start: Option<bool>,
+    // Multi-device: automatically add new devices to all groups (default: true).
+    pub(super) auto_add_devices: Option<bool>,
 }
 
 pub(super) fn load_app_config(data_dir: &str) -> AppConfig {

--- a/rust/src/core/interop.rs
+++ b/rust/src/core/interop.rs
@@ -1,5 +1,16 @@
 use base64::Engine as _;
 use nostr_sdk::prelude::*;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// Compute a short hex fingerprint from arbitrary bytes.
+/// Uses a fast non-crypto hash — this is for display only, not security.
+pub(super) fn fingerprint_hash(data: &[u8]) -> String {
+    let mut hasher = DefaultHasher::new();
+    data.hash(&mut hasher);
+    let h = hasher.finish();
+    format!("{:08x}", h as u32)
+}
 
 pub(super) fn extract_relays_from_key_package_event(event: &Event) -> Option<Vec<RelayUrl>> {
     for t in event.tags.iter() {

--- a/rust/src/route_projection.rs
+++ b/rust/src/route_projection.rs
@@ -43,6 +43,7 @@ pub enum DesktopDetailPane {
     None,
     GroupInfo { chat_id: String },
     PeerProfile { pubkey: String },
+    DeviceManagement,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -90,6 +91,8 @@ pub fn project_desktop(state: &AppState) -> DesktopRouteState {
         DesktopDetailPane::GroupInfo {
             chat_id: chat_id.clone(),
         }
+    } else if matches!(active_screen, Screen::DeviceManagement) {
+        DesktopDetailPane::DeviceManagement
     } else {
         DesktopDetailPane::None
     };

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -19,7 +19,27 @@ pub struct AppState {
     pub peer_profile: Option<PeerProfileState>,
     pub active_call: Option<CallState>,
     pub call_timeline: Vec<CallTimelineEvent>,
+    pub my_devices: Vec<DeviceInfo>,
+    pub pending_devices: Vec<DeviceInfo>,
+    pub auto_add_devices: bool,
     pub toast: Option<String>,
+}
+
+/// Info about one of the user's own devices (derived from key packages on relays).
+#[derive(uniffi::Record, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct DeviceInfo {
+    /// Hex event ID of the key package event.
+    pub key_package_event_id: String,
+    /// JSON of the full key package event (for use with AddMyDevice).
+    pub key_package_event_json: String,
+    /// Stable short identifier for display (e.g. "a3f8b2c1").
+    /// For the current device: derived from local device ID.
+    /// For other devices: derived from key package content hash.
+    pub fingerprint: String,
+    /// Timestamp the key package was published (created_at).
+    pub published_at: i64,
+    /// Whether this is the current device's key package.
+    pub is_current_device: bool,
 }
 
 impl AppState {
@@ -39,6 +59,9 @@ impl AppState {
             peer_profile: None,
             active_call: None,
             call_timeline: vec![],
+            my_devices: vec![],
+            pending_devices: vec![],
+            auto_add_devices: true,
             toast: None,
         }
     }
@@ -181,6 +204,7 @@ pub enum Screen {
     NewChat,
     NewGroupChat,
     GroupInfo { chat_id: String },
+    DeviceManagement,
 }
 
 #[derive(uniffi::Enum, Clone, Debug, PartialEq)]

--- a/rust/src/updates.rs
+++ b/rust/src/updates.rs
@@ -58,6 +58,7 @@ pub enum InternalEvent {
     KeyPackagePublished {
         ok: bool,
         error: Option<String>,
+        event_id: Option<String>,
     },
     PushSubscriptionsSynced {
         groups: Vec<String>,
@@ -70,7 +71,7 @@ pub enum InternalEvent {
     // Async CreateChat fetch result (1:1)
     PeerKeyPackageFetched {
         peer_pubkey: nostr_sdk::prelude::PublicKey,
-        key_package_event: Option<nostr_sdk::prelude::Event>,
+        key_package_events: Vec<nostr_sdk::prelude::Event>,
         error: Option<String>,
     },
 
@@ -172,5 +173,15 @@ pub enum InternalEvent {
     // Video frame sent from platform (camera capture → H.264 NALUs).
     VideoFrameFromPlatform {
         payload: Vec<u8>,
+    },
+
+    // Multi-device: new key packages for our own pubkey discovered on relays.
+    OtherDeviceKeyPackagesFetched {
+        key_package_events: Vec<nostr_sdk::prelude::Event>,
+    },
+
+    // Multi-device: own key packages fetched from relays for device list display.
+    MyDevicesFetched {
+        devices: Vec<crate::state::DeviceInfo>,
     },
 }


### PR DESCRIPTION
## Summary

- Fetch all key packages per peer (not just newest) so every device gets invited to groups
- Auto-detect and add new devices on startup via relay key package polling
- Device management screen (iOS, Android, Desktop) with auto-add toggle and pending device approval
- 3 new e2e tests covering multi-device invite, AddMyDevice, and auto-add flows

## Test plan

- [ ] Log in on two devices with the same nsec, verify both get invited to new groups
- [ ] Log in on a new device after already being in groups, verify auto-add invites it
- [ ] Disable auto-add, log in on a new device, verify it appears as pending
- [ ] Accept/reject pending devices from the devices screen
- [ ] Verify member counts don't double-count devices (1 user = 1 member)
- [ ] `cargo test -p pika_core --test e2e_local_relay` passes all 8 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)