### PR TITLE
release: marmotd v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "marmotd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/crates/marmotd/Cargo.toml
+++ b/crates/marmotd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marmotd"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 
 [dependencies]

--- a/openclaw-marmot/openclaw/extensions/marmot/package.json
+++ b/openclaw-marmot/openclaw/extensions/marmot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justinmoon/marmot",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OpenClaw Marmot channel plugin (Rust sidecar)",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Bump marmotd and @justinmoon/marmot plugin from 0.5.0 to 0.5.1.

After merging, run the `marmotd release` workflow with version `0.5.1` to tag, build, and publish.