### PR TITLE
get rid of global-agents.md ref in agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,3 @@
-Read `~/configs/GLOBAL-AGENTS.md` (fallback: https://raw.githubusercontent.com/justinmoon/configs/master/GLOBAL-AGENTS.md). Skip if both unavailable.
 Run `./scripts/agent-brief` first thing to get a live context snapshot.
 
 ## Related codebases


### PR DESCRIPTION
this PR was written by hand, with love

if there's anything we want from justin's global agents.md we can copy it in, but this was causing churn / failure on every new session