### PR TITLE
Search follow list by username handle

### DIFF
--- a/android/app/src/main/java/com/pika/app/rust/pika_core.kt
+++ b/android/app/src/main/java/com/pika/app/rust/pika_core.kt
@@ -2468,6 +2468,8 @@ data class FollowListEntry (
     , 
     var `name`: kotlin.String?
     , 
+    var `username`: kotlin.String?
+    , 
     var `pictureUrl`: kotlin.String?
     
 ){
@@ -2489,6 +2491,7 @@ public object FfiConverterTypeFollowListEntry: FfiConverterRustBuffer<FollowList
             FfiConverterString.read(buf),
             FfiConverterOptionalString.read(buf),
             FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
         )
     }
 
@@ -2496,6 +2499,7 @@ public object FfiConverterTypeFollowListEntry: FfiConverterRustBuffer<FollowList
             FfiConverterString.allocationSize(value.`pubkey`) +
             FfiConverterString.allocationSize(value.`npub`) +
             FfiConverterOptionalString.allocationSize(value.`name`) +
+            FfiConverterOptionalString.allocationSize(value.`username`) +
             FfiConverterOptionalString.allocationSize(value.`pictureUrl`)
     )
 
@@ -2503,6 +2507,7 @@ public object FfiConverterTypeFollowListEntry: FfiConverterRustBuffer<FollowList
             FfiConverterString.write(value.`pubkey`, buf)
             FfiConverterString.write(value.`npub`, buf)
             FfiConverterOptionalString.write(value.`name`, buf)
+            FfiConverterOptionalString.write(value.`username`, buf)
             FfiConverterOptionalString.write(value.`pictureUrl`, buf)
     }
 }

--- a/android/app/src/main/java/com/pika/app/ui/screens/NewChatScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/NewChatScreen.kt
@@ -67,6 +67,7 @@ fun NewChatScreen(manager: AppManager, padding: PaddingValues) {
             val query = searchText.lowercase()
             followList.filter { entry ->
                 entry.name?.lowercase()?.contains(query) == true ||
+                    entry.username?.lowercase()?.contains(query) == true ||
                     entry.npub.lowercase().contains(query) ||
                     entry.pubkey.lowercase().contains(query)
             }

--- a/android/app/src/main/java/com/pika/app/ui/screens/NewGroupChatScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/NewGroupChatScreen.kt
@@ -79,6 +79,7 @@ fun NewGroupChatScreen(manager: AppManager, padding: PaddingValues) {
             val query = searchText.lowercase()
             followList.filter { entry ->
                 entry.name?.lowercase()?.contains(query) == true ||
+                    entry.username?.lowercase()?.contains(query) == true ||
                     entry.npub.lowercase().contains(query) ||
                     entry.pubkey.lowercase().contains(query)
             }

--- a/crates/pika-desktop/src/main.rs
+++ b/crates/pika-desktop/src/main.rs
@@ -1025,6 +1025,11 @@ impl DesktopApp {
                 .iter()
                 .filter(|e| {
                     e.name.as_deref().unwrap_or("").to_lowercase().contains(&q)
+                        || e.username
+                            .as_deref()
+                            .unwrap_or("")
+                            .to_lowercase()
+                            .contains(&q)
                         || e.npub.to_lowercase().contains(&q)
                 })
                 .cloned()

--- a/ios/Sources/PreviewData.swift
+++ b/ios/Sources/PreviewData.swift
@@ -206,9 +206,9 @@ enum PreviewAppState {
     }
 
     static let sampleFollowList: [FollowListEntry] = [
-        FollowListEntry(pubkey: samplePeerPubkey, npub: samplePeerNpub, name: "Justin", pictureUrl: "https://blossom.nostr.pub/8dbc6f42ea8bf53f4af89af87eb0d9110fcaf4d263f7d2cb9f29d68f95f6f8ce"),
-        FollowListEntry(pubkey: sampleThirdPubkey, npub: sampleThirdNpub, name: "benthecarman", pictureUrl: nil),
-        FollowListEntry(pubkey: "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233", npub: "npub14wavxd9qqpy3x64hkvajjrf9s67qfze2gs3a2pxhzu3fjlf90xesqa2haj", name: nil, pictureUrl: nil),
+        FollowListEntry(pubkey: samplePeerPubkey, npub: samplePeerNpub, name: "Justin", username: "justin", pictureUrl: "https://blossom.nostr.pub/8dbc6f42ea8bf53f4af89af87eb0d9110fcaf4d263f7d2cb9f29d68f95f6f8ce"),
+        FollowListEntry(pubkey: sampleThirdPubkey, npub: sampleThirdNpub, name: "benthecarman", username: "benthecarman", pictureUrl: nil),
+        FollowListEntry(pubkey: "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233", npub: "npub14wavxd9qqpy3x64hkvajjrf9s67qfze2gs3a2pxhzu3fjlf90xesqa2haj", name: nil, username: nil, pictureUrl: nil),
     ]
 
     private static func base(

--- a/ios/Sources/Views/NewChatView.swift
+++ b/ios/Sources/Views/NewChatView.swift
@@ -15,6 +15,7 @@ struct NewChatView: View {
         let query = searchText.lowercased()
         return state.followList.filter { entry in
             if let name = entry.name, name.lowercased().contains(query) { return true }
+            if let username = entry.username, username.lowercased().contains(query) { return true }
             if entry.npub.lowercased().contains(query) { return true }
             if entry.pubkey.lowercased().contains(query) { return true }
             return false

--- a/ios/Sources/Views/NewGroupChatView.swift
+++ b/ios/Sources/Views/NewGroupChatView.swift
@@ -17,6 +17,7 @@ struct NewGroupChatView: View {
         let query = searchText.lowercased()
         return state.followList.filter { entry in
             if let name = entry.name, name.lowercased().contains(query) { return true }
+            if let username = entry.username, username.lowercased().contains(query) { return true }
             if entry.npub.lowercased().contains(query) { return true }
             if entry.pubkey.lowercased().contains(query) { return true }
             return false

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -270,6 +270,7 @@ pub struct FollowListEntry {
     pub pubkey: String,
     pub npub: String,
     pub name: Option<String>,
+    pub username: Option<String>,
     pub picture_url: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- Adds a `username` field to `FollowListEntry` and `ProfileCache` to store the nostr metadata `name` (handle, e.g. `@benthecarman`) separately from `display_name`
- Hooks username search into iOS, Android, and desktop follow list filters
- Fixes column index bug in `profile_db` when loading profiles from SQLite

## Test plan
- [ ] Search for a follow by their handle (e.g. "jack") and verify they appear
- [ ] Verify searching by display name and npub still works
- [ ] Test on iOS, Android, and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)