### PR TITLE
Allow APNS key to be passed as base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5744,6 +5744,7 @@ dependencies = [
  "a2",
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "diesel",
  "diesel_migrations",

--- a/crates/pika-notifications/Cargo.toml
+++ b/crates/pika-notifications/Cargo.toml
@@ -23,4 +23,5 @@ serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.12.0", features = ["full"] }
 a2 = "0.10"
+base64 = "0.22"
 fcm-rs = "0.2"


### PR DESCRIPTION
## Summary
- Add `APNS_KEY_BASE64` env var as an alternative to `APNS_KEY_PATH` for the .p8 key in pika-notifications
- Useful for container/CI environments where mounting a key file is inconvenient
- `APNS_KEY_BASE64` takes priority if both are set

## Test plan
- [ ] Set `APNS_KEY_BASE64` with a base64-encoded .p8 key and verify APNS client initializes
- [ ] Verify existing `APNS_KEY_PATH` flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)