### PR TITLE
Add @mention autocomplete to desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ End-to-end encrypted messaging for iOS and Android, built on [MLS](https://messa
 | Push notifications | ✅ | | |
 | Emoji reactions | ✅ | | ✅ |
 | Typing indicators | ✅ | | ✅ |
-| @mention autocomplete | ✅ | | |
+| @mention autocomplete | ✅ | | ✅ |
 | Markdown rendering | ✅ | ✅ | |
 | Polls | ✅ | ✅ | |
 | Interactive widgets (HTML) | ✅ | | |


### PR DESCRIPTION
Implements mention autocomplete for group chats in the desktop (Iced) app, matching iOS behavior:

- Typing `@` at a word boundary shows a filtered member picker above the input bar
- Members filter by name/npub prefix as you type after `@`
- Tab selects the top result (highlighted with a subtle background)
- Clicking a member inserts `@DisplayName` into the input
- On send, display tags are converted to `nostr:npub1...` wire format
- Focus is preserved on the text input when the picker opens/closes

Also updates the README feature matrix to mark @mention autocomplete as supported on Desktop.