### PR TITLE
Fix desktop group creation UX to show spinner instead of blank screen

### DIFF
--- a/crates/pika-desktop/src/main.rs
+++ b/crates/pika-desktop/src/main.rs
@@ -454,7 +454,8 @@ impl DesktopApp {
                         group_name: self.group_name_input.clone(),
                     });
                 }
-                self.clear_all_overlays();
+                // Keep form open with spinner — sync_from_manager will close it
+                // when creating_chat transitions to false (matching iOS behavior).
                 self.optimistic_selected_chat_id = None;
             }
 


### PR DESCRIPTION
Keep the new-group form open while creating_chat is in progress so the user sees the 'Creating...' spinner. sync_from_manager already closes the form when the operation completes, matching iOS behavior.