### PR TITLE
Add peer profile screen with follow/unfollow to desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ End-to-end encrypted messaging for iOS and Android, built on [MLS](https://messa
 | Interactive widgets (HTML) | ✅ | | |
 | QR code scan / display | ✅ | ✅ | |
 | Profile photo upload | ✅ | ✅ | |
-| Follow / unfollow contacts | ✅ | ✅ | |
+| Follow / unfollow contacts | ✅ | ✅ | ✅ |
 
 ## How it works
 

--- a/crates/pika-desktop/src/views/conversation.rs
+++ b/crates/pika-desktop/src/views/conversation.rs
@@ -151,6 +151,27 @@ pub fn conversation_view<'a>(
         )
         .width(Fill)
         .into()
+    } else if let Some(peer) = chat.members.first() {
+        let peer_pubkey = peer.pubkey.clone();
+        container(
+            button(header_content)
+                .on_press(Message::OpenPeerProfile(peer_pubkey))
+                .width(Fill)
+                .style(|_: &Theme, status: button::Status| {
+                    let bg = match status {
+                        button::Status::Hovered => theme::HOVER_BG,
+                        _ => theme::RAIL_BG,
+                    };
+                    button::Style {
+                        background: Some(iced::Background::Color(bg)),
+                        text_color: theme::TEXT_PRIMARY,
+                        border: iced::border::rounded(0),
+                        ..Default::default()
+                    }
+                }),
+        )
+        .width(Fill)
+        .into()
     } else {
         container(header_content)
             .width(Fill)

--- a/crates/pika-desktop/src/views/group_info.rs
+++ b/crates/pika-desktop/src/views/group_info.rs
@@ -138,13 +138,34 @@ fn member_row<'a>(
         display_name.clone()
     };
 
-    let mut row_content = row![
-        avatar,
-        text(label).size(14).color(theme::TEXT_PRIMARY),
-        Space::new().width(Fill),
-    ]
-    .spacing(10)
-    .align_y(Alignment::Center);
+    let pubkey_for_profile = member.pubkey.clone();
+    let profile_btn = button(
+        row![avatar, text(label).size(14).color(theme::TEXT_PRIMARY),]
+            .spacing(10)
+            .align_y(Alignment::Center),
+    )
+    .on_press_maybe(if is_me {
+        None
+    } else {
+        Some(Message::OpenPeerProfile(pubkey_for_profile))
+    })
+    .padding(0)
+    .style(|_: &Theme, status: button::Status| {
+        let bg = match status {
+            button::Status::Hovered => theme::HOVER_BG,
+            _ => iced::Color::TRANSPARENT,
+        };
+        button::Style {
+            background: Some(iced::Background::Color(bg)),
+            text_color: theme::TEXT_PRIMARY,
+            border: iced::border::rounded(6),
+            ..Default::default()
+        }
+    });
+
+    let mut row_content = row![profile_btn, Space::new().width(Fill),]
+        .spacing(10)
+        .align_y(Alignment::Center);
 
     if is_me && is_admin {
         row_content = row_content.push(text("Admin").size(12).color(theme::TEXT_FADED));

--- a/crates/pika-desktop/src/views/message_bubble.rs
+++ b/crates/pika-desktop/src/views/message_bubble.rs
@@ -148,8 +148,17 @@ pub fn message_bubble<'a>(
 
         let mut bubble_content = column![].spacing(2);
         if !sender_name.is_empty() {
-            bubble_content =
-                bubble_content.push(text(sender_name).size(12).color(theme::ACCENT_BLUE));
+            let sender_pk = msg.sender_pubkey.clone();
+            bubble_content = bubble_content.push(
+                button(text(sender_name).size(12).color(theme::ACCENT_BLUE))
+                    .on_press(Message::OpenPeerProfile(sender_pk))
+                    .padding(0)
+                    .style(|_: &Theme, _| button::Style {
+                        background: Some(Background::Color(Color::TRANSPARENT)),
+                        text_color: theme::ACCENT_BLUE,
+                        ..Default::default()
+                    }),
+            );
         }
         if let Some(preview) = make_reply_preview() {
             bubble_content = bubble_content.push(preview);

--- a/crates/pika-desktop/src/views/mod.rs
+++ b/crates/pika-desktop/src/views/mod.rs
@@ -11,4 +11,5 @@ pub mod message_bubble;
 pub mod my_profile;
 pub mod new_chat;
 pub mod new_group_chat;
+pub mod peer_profile;
 pub mod toast;

--- a/crates/pika-desktop/src/views/peer_profile.rs
+++ b/crates/pika-desktop/src/views/peer_profile.rs
@@ -1,0 +1,106 @@
+use iced::widget::{button, column, container, row, text, Space};
+use iced::{Alignment, Element, Fill, Theme};
+use pika_core::PeerProfileState;
+
+use crate::theme;
+use crate::views::avatar::avatar_circle;
+use crate::Message;
+
+pub fn peer_profile_view<'a>(
+    profile: &'a PeerProfileState,
+    avatar_cache: &mut super::avatar::AvatarCache,
+) -> Element<'a, Message, Theme> {
+    let mut content = column![].spacing(16).padding([32, 32]).width(Fill);
+
+    // ── Close button row ────────────────────────────────────────────
+    content = content.push(
+        row![
+            Space::new().width(Fill),
+            button(text("Close").size(14))
+                .on_press(Message::ClosePeerProfile)
+                .padding([6, 16])
+                .style(theme::secondary_button_style),
+        ]
+        .width(Fill),
+    );
+
+    // ── Avatar ──────────────────────────────────────────────────────
+    content = content.push(
+        container(avatar_circle(
+            profile.name.as_deref(),
+            profile.picture_url.as_deref(),
+            96.0,
+            avatar_cache,
+        ))
+        .width(Fill)
+        .center_x(Fill),
+    );
+
+    // ── Name / About ────────────────────────────────────────────────
+    if let Some(name) = &profile.name {
+        content = content.push(
+            container(text(name).size(20).color(theme::TEXT_PRIMARY))
+                .width(Fill)
+                .center_x(Fill),
+        );
+    }
+
+    if let Some(about) = &profile.about {
+        if !about.trim().is_empty() {
+            content = content.push(
+                container(text(about).size(14).color(theme::TEXT_SECONDARY))
+                    .width(Fill)
+                    .center_x(Fill),
+            );
+        }
+    }
+
+    // ── npub ────────────────────────────────────────────────────────
+    let npub_display = theme::truncated_npub_long(&profile.npub);
+    content = content.push(
+        row![
+            text(npub_display)
+                .size(12)
+                .color(theme::TEXT_FADED)
+                .width(Fill),
+            button(text("Copy").size(12))
+                .on_press(Message::CopyPeerNpub)
+                .padding([4, 10])
+                .style(theme::secondary_button_style),
+        ]
+        .spacing(8)
+        .align_y(Alignment::Center),
+    );
+
+    // ── Follow / Unfollow ───────────────────────────────────────────
+    let follow_btn = if profile.is_followed {
+        button(text("Unfollow").size(14).width(Fill).center())
+            .on_press(Message::UnfollowPeer)
+            .width(Fill)
+            .padding([10, 0])
+            .style(theme::danger_button_style)
+    } else {
+        button(text("Follow").size(14).width(Fill).center())
+            .on_press(Message::FollowPeer)
+            .width(Fill)
+            .padding([10, 0])
+            .style(theme::primary_button_style)
+    };
+
+    content = content.push(follow_btn);
+
+    // ── Message button ──────────────────────────────────────────────
+    content = content.push(
+        button(text("Message").size(14).width(Fill).center())
+            .on_press(Message::StartChatWith(profile.npub.clone()))
+            .width(Fill)
+            .padding([10, 0])
+            .style(theme::secondary_button_style),
+    );
+
+    container(content)
+        .width(Fill)
+        .height(Fill)
+        .style(theme::surface_style)
+        .into()
+}


### PR DESCRIPTION
Adds a peer profile view to the desktop (Iced) app, matching iOS's PeerProfileSheet:

- **Profile screen**: avatar, name, about, npub with copy button, follow/unfollow, and Message button
- **Clickable in 1:1 chats**: clicking the header bar (avatar + name) opens the peer's profile
- **Clickable in group chats**: clicking a sender name in message bubbles opens their profile
- **Clickable in group info**: clicking member names/avatars in the group info screen opens their profile (skipped for 'You')
- **Follow/Unfollow**: dispatches `FollowUser`/`UnfollowUser` actions to the Rust core

Also updates the README feature matrix to mark follow/unfollow contacts as supported on Desktop.