### PR TITLE
Fix synthetic audio and rustls provider for test reliability

### DIFF
--- a/rust/src/tls.rs
+++ b/rust/src/tls.rs
@@ -1,14 +1,3 @@
-use std::sync::Once;
-
-// rustls 0.23 selects a process-level CryptoProvider. If more than one provider
-// feature is present in the dependency graph (common with quinn/aws-lc-rs plus
-// nostr-sdk/ring), rustls requires an explicit choice.
-static INIT: Once = Once::new();
-
 pub fn init_rustls_crypto_provider() {
-    INIT.call_once(|| {
-        // Keep the historical behavior but delegate to the shared helper so
-        // other crates (e.g. pika-media) can do the same thing.
-        pika_tls::init_rustls_crypto_provider();
-    });
+    pika_tls::init_rustls_crypto_provider();
 }


### PR DESCRIPTION
## Summary

- Use `LazyLock` for the rustls `CryptoProvider` in `pika-tls` to fix parallel test flakiness
- Make `SyntheticAudio` alternate 1s tone / 1s silence (instead of continuous sine) so the bot's silence segmenter triggers quickly during Android E2E call tests
- Simplify `rust/src/tls.rs` by removing redundant `Once` wrapper

## Test plan

- [x] `cargo test -p pika_core --test app_flows` passes reliably in parallel (29/29)
- [x] `cargo build -p pika-tls -p pika_core` clean
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)