### PR TITLE
Filter self from follow list

### DIFF
--- a/android/app/src/main/java/com/pika/app/ui/screens/NewChatScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/NewChatScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.pika.app.AppManager
 import com.pika.app.rust.AppAction
+import com.pika.app.rust.AuthState
 import com.pika.app.rust.FollowListEntry
 import com.pika.app.ui.Avatar
 import com.pika.app.ui.PeerKeyNormalizer
@@ -60,12 +61,14 @@ fun NewChatScreen(manager: AppManager, padding: PaddingValues) {
     val isLoading = manager.state.busy.creatingChat
     val isFetchingFollows = manager.state.busy.fetchingFollowList
     val followList = manager.state.followList
+    val myNpub = (manager.state.auth as? AuthState.LoggedIn)?.npub
 
-    val filteredFollows = remember(followList, searchText) {
-        if (searchText.isBlank()) followList
+    val filteredFollows = remember(followList, searchText, myNpub) {
+        val base = followList.filter { it.npub != myNpub }
+        if (searchText.isBlank()) base
         else {
             val query = searchText.lowercase()
-            followList.filter { entry ->
+            base.filter { entry ->
                 entry.name?.lowercase()?.contains(query) == true ||
                     entry.username?.lowercase()?.contains(query) == true ||
                     entry.npub.lowercase().contains(query) ||

--- a/android/app/src/main/java/com/pika/app/ui/screens/NewGroupChatScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/NewGroupChatScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.pika.app.AppManager
 import com.pika.app.rust.AppAction
+import com.pika.app.rust.AuthState
 import com.pika.app.rust.FollowListEntry
 import com.pika.app.ui.Avatar
 import com.pika.app.ui.PeerKeyNormalizer
@@ -72,12 +73,14 @@ fun NewGroupChatScreen(manager: AppManager, padding: PaddingValues) {
     val isCreating = manager.state.busy.creatingChat
     val isFetchingFollows = manager.state.busy.fetchingFollowList
     val followList = manager.state.followList
+    val myNpub = (manager.state.auth as? AuthState.LoggedIn)?.npub
 
-    val filteredFollows = remember(followList, searchText) {
-        if (searchText.isBlank()) followList
+    val filteredFollows = remember(followList, searchText, myNpub) {
+        val base = followList.filter { it.npub != myNpub }
+        if (searchText.isBlank()) base
         else {
             val query = searchText.lowercase()
-            followList.filter { entry ->
+            base.filter { entry ->
                 entry.name?.lowercase()?.contains(query) == true ||
                     entry.username?.lowercase()?.contains(query) == true ||
                     entry.npub.lowercase().contains(query) ||

--- a/crates/pika-desktop/src/main.rs
+++ b/crates/pika-desktop/src/main.rs
@@ -1184,12 +1184,23 @@ impl DesktopApp {
             &self.state.follow_list
         };
 
+        // Filter out ourselves from the list.
+        let my_npub = match &self.state.auth {
+            AuthState::LoggedIn { npub, .. } => Some(npub.as_str()),
+            _ => None,
+        };
+        let base: Vec<_> = source
+            .iter()
+            .filter(|e| my_npub != Some(e.npub.as_str()))
+            .cloned()
+            .collect();
+
         if self.new_chat_search.is_empty() {
-            self.filtered_follows = source.clone();
+            self.filtered_follows = base;
         } else {
             let q = self.new_chat_search.to_lowercase();
-            self.filtered_follows = source
-                .iter()
+            self.filtered_follows = base
+                .into_iter()
                 .filter(|e| {
                     e.name.as_deref().unwrap_or("").to_lowercase().contains(&q)
                         || e.username
@@ -1199,7 +1210,6 @@ impl DesktopApp {
                             .contains(&q)
                         || e.npub.to_lowercase().contains(&q)
                 })
-                .cloned()
                 .collect();
         }
     }

--- a/ios/Sources/ContentView.swift
+++ b/ios/Sources/ContentView.swift
@@ -388,7 +388,8 @@ private func newChatState(from state: AppState) -> NewChatViewState {
     NewChatViewState(
         isCreatingChat: state.busy.creatingChat,
         isFetchingFollowList: state.busy.fetchingFollowList,
-        followList: state.followList
+        followList: state.followList,
+        myNpub: myNpub(from: state)
     )
 }
 
@@ -397,7 +398,8 @@ private func newGroupChatState(from state: AppState) -> NewGroupChatViewState {
     NewGroupChatViewState(
         isCreatingChat: state.busy.creatingChat,
         isFetchingFollowList: state.busy.fetchingFollowList,
-        followList: state.followList
+        followList: state.followList,
+        myNpub: myNpub(from: state)
     )
 }
 

--- a/ios/Sources/ViewState.swift
+++ b/ios/Sources/ViewState.swift
@@ -15,12 +15,14 @@ struct NewChatViewState: Equatable {
     let isCreatingChat: Bool
     let isFetchingFollowList: Bool
     let followList: [FollowListEntry]
+    let myNpub: String?
 }
 
 struct NewGroupChatViewState: Equatable {
     let isCreatingChat: Bool
     let isFetchingFollowList: Bool
     let followList: [FollowListEntry]
+    let myNpub: String?
 }
 
 struct ChatScreenState: Equatable {

--- a/ios/Sources/Views/NewChatView.swift
+++ b/ios/Sources/Views/NewChatView.swift
@@ -11,9 +11,10 @@ struct NewChatView: View {
     @State private var showScanner = false
 
     private var filteredFollowList: [FollowListEntry] {
-        guard !searchText.isEmpty else { return state.followList }
+        let base = state.followList.filter { $0.npub != state.myNpub }
+        guard !searchText.isEmpty else { return base }
         let query = searchText.lowercased()
-        return state.followList.filter { entry in
+        return base.filter { entry in
             if let name = entry.name, name.lowercased().contains(query) { return true }
             if let username = entry.username, username.lowercased().contains(query) { return true }
             if entry.npub.lowercased().contains(query) { return true }

--- a/ios/Sources/Views/NewGroupChatView.swift
+++ b/ios/Sources/Views/NewGroupChatView.swift
@@ -13,9 +13,10 @@ struct NewGroupChatView: View {
     @State private var showScanner = false
 
     private var filteredFollowList: [FollowListEntry] {
-        guard !searchText.isEmpty else { return state.followList }
+        let base = state.followList.filter { $0.npub != state.myNpub }
+        guard !searchText.isEmpty else { return base }
         let query = searchText.lowercased()
-        return state.followList.filter { entry in
+        return base.filter { entry in
             if let name = entry.name, name.lowercased().contains(query) { return true }
             if let username = entry.username, username.lowercased().contains(query) { return true }
             if entry.npub.lowercased().contains(query) { return true }


### PR DESCRIPTION
## Summary
- Filters the current user out of the follow list so they don't appear when creating a new chat or group chat
- Applied at the UI layer on iOS, Android, and desktop

## Test plan
- [x] Open new chat view and verify you don't see yourself in the follow list
- [x] Open new group chat view and verify you don't see yourself in the follow list
- [x] Verify on all three platforms (iOS, Android, desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)