### PR TITLE
Fix iOS build: add missing myNpub to preview constructors

### DIFF
--- a/ios/Sources/Views/NewChatView.swift
+++ b/ios/Sources/Views/NewChatView.swift
@@ -201,7 +201,8 @@ struct NewChatView: View {
             state: NewChatViewState(
                 isCreatingChat: false,
                 isFetchingFollowList: true,
-                followList: []
+                followList: [],
+                myNpub: nil
             ),
             onCreateChat: { _ in },
             onRefreshFollowList: {}
@@ -215,7 +216,8 @@ struct NewChatView: View {
             state: NewChatViewState(
                 isCreatingChat: false,
                 isFetchingFollowList: false,
-                followList: PreviewAppState.sampleFollowList
+                followList: PreviewAppState.sampleFollowList,
+                myNpub: nil
             ),
             onCreateChat: { _ in },
             onRefreshFollowList: {}
@@ -229,7 +231,8 @@ struct NewChatView: View {
             state: NewChatViewState(
                 isCreatingChat: true,
                 isFetchingFollowList: false,
-                followList: PreviewAppState.sampleFollowList
+                followList: PreviewAppState.sampleFollowList,
+                myNpub: nil
             ),
             onCreateChat: { _ in },
             onRefreshFollowList: {}

--- a/ios/Sources/Views/NewGroupChatView.swift
+++ b/ios/Sources/Views/NewGroupChatView.swift
@@ -281,7 +281,8 @@ struct NewGroupChatView: View {
             state: NewGroupChatViewState(
                 isCreatingChat: false,
                 isFetchingFollowList: true,
-                followList: []
+                followList: [],
+                myNpub: nil
             ),
             onCreateGroup: { _, _ in },
             onRefreshFollowList: {}
@@ -295,7 +296,8 @@ struct NewGroupChatView: View {
             state: NewGroupChatViewState(
                 isCreatingChat: false,
                 isFetchingFollowList: false,
-                followList: PreviewAppState.sampleFollowList
+                followList: PreviewAppState.sampleFollowList,
+                myNpub: nil
             ),
             onCreateGroup: { _, _ in },
             onRefreshFollowList: {}
@@ -309,7 +311,8 @@ struct NewGroupChatView: View {
             state: NewGroupChatViewState(
                 isCreatingChat: true,
                 isFetchingFollowList: false,
-                followList: PreviewAppState.sampleFollowList
+                followList: PreviewAppState.sampleFollowList,
+                myNpub: nil
             ),
             onCreateGroup: { _, _ in },
             onRefreshFollowList: {}


### PR DESCRIPTION
## Summary
- `NewChatViewState` and `NewGroupChatViewState` gained a `myNpub: String?` field but the `#Preview` blocks weren't updated, breaking the build
- Added `myNpub: nil` to all 6 preview constructors across `NewChatView.swift` and `NewGroupChatView.swift`

## Test plan
- [x] `tools/run-ios --device` builds and launches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)