### PR TITLE
Android ux improvements

### DIFF
--- a/android/app/src/main/java/com/pika/app/ui/screens/LoginScreen.kt
+++ b/android/app/src/main/java/com/pika/app/ui/screens/LoginScreen.kt
@@ -129,6 +129,13 @@ fun LoginScreen(manager: AppManager, padding: PaddingValues) {
             singleLine = true,
             enabled = !anyBusy,
             label = { Text("bunker URI") },
+            trailingIcon = {
+                if (bunkerUri.isNotEmpty()) {
+                    IconButton(onClick = { bunkerUri = "" }) {
+                        Icon(Icons.Default.Clear, contentDescription = "Clear")
+                    }
+                }
+            },
             modifier = Modifier.fillMaxWidth().testTag(TestTags.LOGIN_BUNKER_URI),
         )
 


### PR DESCRIPTION
A set of Android-only UX improvements to the chat and login screens.

## Chat screen
- **Scroll fix**: keyboard appearing no longer hides the latest message
- **Auto-scroll to new messages**: incoming messages scroll into view when at the bottom
- **Unread message divider**: "NEW MESSAGES" marker shows where you left off when opening a chat with unreads
- **Scroll-to-bottom button**: appears when scrolled up, with a badge showing count of new incoming messages
- **Swipe to reply**: swipe right on any message bubble to trigger reply (with haptic feedback), in addition to the existing long-press menu
- **Timestamp on tap**: tap a message bubble to toggle its sent time below it
- **Copy text**: long-press menu now includes a "Copy text" option
- **Contact info button**: 1:1 chats now show an info button in the toolbar (same as group chats) to open the peer profile
- **Send button disabled when empty**: prevents accidental blank sends

## Login screen
- **Clear button** on nsec and bunker URI fields (× icon to clear a mispaste in one tap)
- **Show/hide toggle** on the nsec field