### PR TITLE
Add voice message recording and playback

### DIFF
--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -47,7 +47,9 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Scan QR codes to start new chats.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Voice calls require microphone access.</string>
+	<string>Voice calls and voice messages require microphone access.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Speech recognition is used to transcribe your voice messages.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Save photos from chats to your photo library.</string>
 	<key>NSUserActivityTypes</key>

--- a/ios/Sources/Views/ChatView.swift
+++ b/ios/Sources/Views/ChatView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import MarkdownUI
 import PhotosUI
+import AVFAudio
 
 struct ChatView: View {
     let chatId: String
@@ -31,6 +32,8 @@ struct ChatView: View {
     @State private var insertedMentions: [(display: String, npub: String)] = []
     @State private var replyDraftMessage: ChatMessage?
     @State private var fullscreenImageAttachment: ChatMediaAttachment?
+    @State private var voiceRecorder = VoiceRecorder()
+    @State private var showMicPermissionDenied = false
     @FocusState private var isInputFocused: Bool
 
     private let scrollButtonBottomPadding: CGFloat = 12
@@ -572,98 +575,127 @@ struct ChatView: View {
     @ViewBuilder
     private func messageInputBar(chat: ChatViewState) -> some View {
         VStack(spacing: 0) {
-            if showMentionPicker, chat.isGroup {
-                MentionPickerPopup(members: chat.members, query: mentionQuery) { member in
-                    let displayTag = "@\(member.name ?? String(member.npub.prefix(8)))"
-                    // Remove the "@" + any partial query that triggered the picker.
-                    if let atIdx = messageText.lastIndex(of: "@") {
-                        messageText = String(messageText[..<atIdx])
-                    }
-                    messageText += "\(displayTag) "
-                    insertedMentions.append((display: displayTag, npub: member.npub))
-                    mentionQuery = ""
-                    showMentionPicker = false
-                }
-            }
-
-            if let replying = replyDraftMessage {
-                HStack(spacing: 10) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Replying to \(replySenderLabel(replying))")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                        Text(replySnippet(replying))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                    Spacer()
-                    Button {
-                        replyDraftMessage = nil
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.body)
-                            .foregroundStyle(.tertiary)
-                    }
-                    .buttonStyle(.plain)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(.ultraThinMaterial)
-                .overlay(alignment: .leading) {
-                    Rectangle()
-                        .fill(Color.blue)
-                        .frame(width: 3)
-                }
-                .padding(.horizontal, 12)
-            }
-
-            HStack(spacing: 10) {
-                if onSendMedia != nil {
-                    PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
-                        Image(systemName: "plus.circle.fill")
-                            .font(.title2)
-                    }
-                    .tint(.secondary)
-                }
-
-                TextEditor(text: $messageText)
-                    .focused($isInputFocused)
-                    .frame(minHeight: 36, maxHeight: 150)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .scrollContentBackground(.hidden)
-                    .onAppear {
-                        if ProcessInfo.processInfo.isiOSAppOnMac {
-                            isInputFocused = true
+            if voiceRecorder.isRecording {
+                VoiceRecordingView(
+                    recorder: voiceRecorder,
+                    onSend: {
+                        Task {
+                            // Capture transcript before stopRecording resets state
+                            let transcriptText = voiceRecorder.transcript
+                            guard let url = await voiceRecorder.stopRecording() else { return }
+                            guard let data = try? Data(contentsOf: url) else { return }
+                            let timestamp = Int(Date().timeIntervalSince1970)
+                            // Send transcript as italic markdown caption
+                            let caption = transcriptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                ? ""
+                                : "*\(transcriptText.trimmingCharacters(in: .whitespacesAndNewlines))*"
+                            onSendMedia?(chatId, data, "audio/mp4", "voice_\(timestamp).m4a", caption)
+                            try? FileManager.default.removeItem(at: url)
                         }
+                    },
+                    onCancel: {
+                        voiceRecorder.cancelRecording()
                     }
-                    .onKeyPress(.return, phases: .down) { keyPress in
-                        if keyPress.modifiers.contains(.shift) {
-                            return .ignored
+                )
+                .modifier(GlassInputModifier())
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            } else {
+                if showMentionPicker, chat.isGroup {
+                    MentionPickerPopup(members: chat.members, query: mentionQuery) { member in
+                        let displayTag = "@\(member.name ?? String(member.npub.prefix(8)))"
+                        // Remove the "@" + any partial query that triggered the picker.
+                        if let atIdx = messageText.lastIndex(of: "@") {
+                            messageText = String(messageText[..<atIdx])
                         }
-                        sendMessage()
-                        return .handled
+                        messageText += "\(displayTag) "
+                        insertedMentions.append((display: displayTag, npub: member.npub))
+                        mentionQuery = ""
+                        showMentionPicker = false
                     }
-                    .overlay(alignment: .topLeading) {
-                        if messageText.isEmpty {
-                            Text("Message")
+                }
+
+                if let replying = replyDraftMessage {
+                    HStack(spacing: 10) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Replying to \(replySenderLabel(replying))")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            Text(replySnippet(replying))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        Spacer()
+                        Button {
+                            replyDraftMessage = nil
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.body)
                                 .foregroundStyle(.tertiary)
-                                .padding(.leading, 5)
-                                .padding(.top, 8)
-                                .allowsHitTesting(false)
                         }
+                        .buttonStyle(.plain)
                     }
-                    .onChange(of: messageText) { _, newValue in
-                        if chat.isGroup {
-                            if let atIdx = newValue.lastIndex(of: "@") {
-                                let prefix = newValue[..<atIdx]
-                                let isWordStart = prefix.isEmpty || prefix.last == " " || prefix.last == "\n"
-                                if isWordStart {
-                                    let query = String(newValue[newValue.index(after: atIdx)...])
-                                    if !query.contains(" ") {
-                                        showMentionPicker = true
-                                        mentionQuery = query
-                                    } else {
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(.ultraThinMaterial)
+                    .overlay(alignment: .leading) {
+                        Rectangle()
+                            .fill(Color.blue)
+                            .frame(width: 3)
+                    }
+                    .padding(.horizontal, 12)
+                }
+
+                HStack(spacing: 10) {
+                    if onSendMedia != nil {
+                        PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
+                            Image(systemName: "plus.circle.fill")
+                                .font(.title2)
+                        }
+                        .tint(.secondary)
+                    }
+
+                    TextEditor(text: $messageText)
+                        .focused($isInputFocused)
+                        .frame(minHeight: 36, maxHeight: 150)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .scrollContentBackground(.hidden)
+                        .onAppear {
+                            if ProcessInfo.processInfo.isiOSAppOnMac {
+                                isInputFocused = true
+                            }
+                        }
+                        .onKeyPress(.return, phases: .down) { keyPress in
+                            if keyPress.modifiers.contains(.shift) {
+                                return .ignored
+                            }
+                            sendMessage()
+                            return .handled
+                        }
+                        .overlay(alignment: .topLeading) {
+                            if messageText.isEmpty {
+                                Text("Message")
+                                    .foregroundStyle(.tertiary)
+                                    .padding(.leading, 5)
+                                    .padding(.top, 8)
+                                    .allowsHitTesting(false)
+                            }
+                        }
+                        .onChange(of: messageText) { _, newValue in
+                            if chat.isGroup {
+                                if let atIdx = newValue.lastIndex(of: "@") {
+                                    let prefix = newValue[..<atIdx]
+                                    let isWordStart = prefix.isEmpty || prefix.last == " " || prefix.last == "\n"
+                                    if isWordStart {
+                                        let query = String(newValue[newValue.index(after: atIdx)...])
+                                        if !query.contains(" ") {
+                                            showMentionPicker = true
+                                            mentionQuery = query
+                                        } else {
+                                            showMentionPicker = false
+                                            mentionQuery = ""
+                                        }
+                                    } else if showMentionPicker {
                                         showMentionPicker = false
                                         mentionQuery = ""
                                     }
@@ -671,57 +703,88 @@ struct ChatView: View {
                                     showMentionPicker = false
                                     mentionQuery = ""
                                 }
-                            } else if showMentionPicker {
-                                showMentionPicker = false
-                                mentionQuery = ""
+                            }
+                            if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                onTypingStarted?()
                             }
                         }
-                        if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            onTypingStarted?()
+                        .accessibilityIdentifier(TestIds.chatMessageInput)
+
+                    if messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, onSendMedia != nil {
+                        Button {
+                            startVoiceRecording()
+                        } label: {
+                            Image(systemName: "mic.fill")
+                                .font(.title2)
                         }
-                    }
-                    .accessibilityIdentifier(TestIds.chatMessageInput)
-
-                Button(action: { sendMessage() }) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.title2)
-                }
-                .disabled(messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                .accessibilityIdentifier(TestIds.chatSend)
-            }
-            .modifier(GlassInputModifier())
-            .onChange(of: selectedPhotoItem) { _, item in
-                guard let item else { return }
-                Task {
-                    defer { selectedPhotoItem = nil }
-                    guard let data = try? await item.loadTransferable(type: Data.self) else { return }
-
-                    // Determine MIME type from supported content types
-                    let mimeType: String
-                    if let contentType = item.supportedContentTypes.first {
-                        mimeType = contentType.preferredMIMEType ?? "image/jpeg"
+                        .transition(.scale.combined(with: .opacity))
                     } else {
-                        mimeType = "image/jpeg"
+                        Button(action: { sendMessage() }) {
+                            Image(systemName: "arrow.up.circle.fill")
+                                .font(.title2)
+                        }
+                        .disabled(messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .accessibilityIdentifier(TestIds.chatSend)
+                        .transition(.scale.combined(with: .opacity))
                     }
-
-                    // Determine filename from MIME type
-                    let ext = switch mimeType {
-                    case "image/png": "png"
-                    case "image/gif": "gif"
-                    case "image/webp": "webp"
-                    case "image/heic": "heic"
-                    default: "jpg"
-                    }
-                    let filename = "photo.\(ext)"
-
-                    // Use message text as caption if non-empty
-                    let caption = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !caption.isEmpty {
-                        messageText = ""
-                    }
-
-                    onSendMedia?(chatId, data, mimeType, filename, caption)
                 }
+                .animation(.easeInOut(duration: 0.15), value: messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .modifier(GlassInputModifier())
+                .onChange(of: selectedPhotoItem) { _, item in
+                    guard let item else { return }
+                    Task {
+                        defer { selectedPhotoItem = nil }
+                        guard let data = try? await item.loadTransferable(type: Data.self) else { return }
+
+                        // Determine MIME type from supported content types
+                        let mimeType: String
+                        if let contentType = item.supportedContentTypes.first {
+                            mimeType = contentType.preferredMIMEType ?? "image/jpeg"
+                        } else {
+                            mimeType = "image/jpeg"
+                        }
+
+                        // Determine filename from MIME type
+                        let ext = switch mimeType {
+                        case "image/png": "png"
+                        case "image/gif": "gif"
+                        case "image/webp": "webp"
+                        case "image/heic": "heic"
+                        default: "jpg"
+                        }
+                        let filename = "photo.\(ext)"
+
+                        // Use message text as caption if non-empty
+                        let caption = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !caption.isEmpty {
+                            messageText = ""
+                        }
+
+                        onSendMedia?(chatId, data, mimeType, filename, caption)
+                    }
+                }
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: voiceRecorder.isRecording)
+        .alert("Microphone Access Denied", isPresented: $showMicPermissionDenied) {
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Enable microphone access in Settings to send voice messages.")
+        }
+    }
+
+    private func startVoiceRecording() {
+        Task {
+            let granted = await CallMicrophonePermission.ensureGranted()
+            if granted {
+                voiceRecorder.startRecording()
+            } else {
+                showMicPermissionDenied = true
             }
         }
     }

--- a/ios/Sources/Views/MessageBubbleViews.swift
+++ b/ios/Sources/Views/MessageBubbleViews.swift
@@ -289,6 +289,10 @@ struct MediaAttachmentView: View {
         attachment.mimeType.hasPrefix("image/")
     }
 
+    private var isAudio: Bool {
+        attachment.mimeType.hasPrefix("audio/")
+    }
+
     private var aspectRatio: CGFloat {
         if let w = attachment.width, let h = attachment.height, w > 0, h > 0 {
             return CGFloat(w) / CGFloat(h)
@@ -308,6 +312,12 @@ struct MediaAttachmentView: View {
     var body: some View {
         if isImage {
             imageContent
+        } else if isAudio {
+            VoiceMessageView(
+                attachment: attachment,
+                isMine: isMine,
+                onDownload: onDownload
+            )
         } else {
             fileRow
         }

--- a/ios/Sources/Views/VoiceMessageView.swift
+++ b/ios/Sources/Views/VoiceMessageView.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+import AVFoundation
+import Accelerate
+
+struct VoiceMessageView: View {
+    let attachment: ChatMediaAttachment
+    let isMine: Bool
+    var onDownload: (() -> Void)? = nil
+
+    @State private var player = VoiceMessagePlayer()
+
+    var body: some View {
+        if let localPath = attachment.localPath {
+            playerContent(localPath: localPath)
+        } else {
+            downloadRow
+        }
+    }
+
+    @ViewBuilder
+    private func playerContent(localPath: String) -> some View {
+        HStack(spacing: 8) {
+            Button {
+                player.toggle(url: URL(fileURLWithPath: localPath))
+            } label: {
+                Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
+                    .font(.title3)
+                    .foregroundStyle(isMine ? .white : .primary)
+                    .frame(width: 28, height: 28)
+            }
+
+            StaticWaveformView(
+                samples: player.waveformSamples,
+                progress: player.progress,
+                isMine: isMine,
+                maxBarHeight: 24
+            )
+
+            Text(player.isPlaying ? formatTime(player.currentTime) : formatTime(player.duration))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(isMine ? .white.opacity(0.78) : .secondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 10)
+        .frame(width: 220)
+        .onAppear {
+            player.loadWaveform(from: localPath)
+        }
+    }
+
+    private var downloadRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "waveform")
+                .font(.title3)
+                .foregroundStyle(isMine ? .white.opacity(0.8) : .secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Voice Message")
+                    .font(.subheadline)
+                    .foregroundStyle(isMine ? .white : .primary)
+                Text(attachment.mimeType)
+                    .font(.caption2)
+                    .foregroundStyle(isMine ? .white.opacity(0.6) : .secondary)
+            }
+
+            Spacer(minLength: 0)
+
+            Button {
+                onDownload?()
+            } label: {
+                Image(systemName: "arrow.down.circle")
+                    .font(.title3)
+                    .foregroundStyle(isMine ? .white : .blue)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: 240)
+    }
+
+    private func formatTime(_ time: TimeInterval) -> String {
+        let minutes = Int(time) / 60
+        let seconds = Int(time) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+// MARK: - Playback helper
+
+@Observable
+@MainActor
+final class VoiceMessagePlayer: NSObject {
+    private(set) var isPlaying = false
+    private(set) var currentTime: TimeInterval = 0
+    private(set) var duration: TimeInterval = 0
+    private(set) var progress: CGFloat = 0
+    private(set) var waveformSamples: [CGFloat] = []
+
+    private var audioPlayer: AVAudioPlayer?
+    private var timer: Timer?
+    private var currentURL: URL?
+
+    func toggle(url: URL) {
+        if isPlaying, currentURL == url {
+            pause()
+        } else {
+            play(url: url)
+        }
+    }
+
+    func loadWaveform(from path: String) {
+        guard waveformSamples.isEmpty else { return }
+        let url = URL(fileURLWithPath: path)
+        Task.detached { [weak self] in
+            let samples = VoiceMessagePlayer.extractWaveform(from: url, sampleCount: 20)
+            await MainActor.run {
+                self?.waveformSamples = samples
+            }
+        }
+        // Also load duration
+        do {
+            let player = try AVAudioPlayer(contentsOf: url)
+            duration = player.duration
+        } catch {
+            // Duration will stay 0
+        }
+    }
+
+    // MARK: - Private
+
+    private func play(url: URL) {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+            try session.setActive(true)
+
+            let player = try AVAudioPlayer(contentsOf: url)
+            player.delegate = self
+            player.play()
+
+            audioPlayer = player
+            currentURL = url
+            duration = player.duration
+            isPlaying = true
+
+            startTimer()
+        } catch {
+            print("VoiceMessagePlayer: playback error: \(error)")
+        }
+    }
+
+    private func pause() {
+        audioPlayer?.pause()
+        isPlaying = false
+        stopTimer()
+    }
+
+    private func startTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 15.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.updateProgress()
+            }
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func updateProgress() {
+        guard let player = audioPlayer else { return }
+        currentTime = player.currentTime
+        progress = duration > 0 ? CGFloat(currentTime / duration) : 0
+    }
+
+    private func playbackFinished() {
+        isPlaying = false
+        currentTime = 0
+        progress = 0
+        stopTimer()
+    }
+
+    // Extract waveform samples from audio file
+    private nonisolated static func extractWaveform(from url: URL, sampleCount: Int) -> [CGFloat] {
+        guard let audioFile = try? AVAudioFile(forReading: url) else { return [] }
+        let format = audioFile.processingFormat
+        let frameCount = AVAudioFrameCount(audioFile.length)
+        guard frameCount > 0,
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)
+        else { return [] }
+
+        do {
+            try audioFile.read(into: buffer)
+        } catch {
+            return []
+        }
+
+        guard let channelData = buffer.floatChannelData?[0] else { return [] }
+        let totalFrames = Int(buffer.frameLength)
+        let samplesPerBin = max(1, totalFrames / sampleCount)
+        var samples: [CGFloat] = []
+
+        for i in 0..<sampleCount {
+            let start = i * samplesPerBin
+            let end = min(start + samplesPerBin, totalFrames)
+            guard start < totalFrames else { break }
+
+            var rms: Float = 0
+            vDSP_measqv(channelData.advanced(by: start), 1, &rms, vDSP_Length(end - start))
+            rms = sqrtf(rms)
+            let db = 20 * log10f(max(rms, 1e-6))
+            let normalized = CGFloat(max(0, min(1, (db + 50) / 50)))
+            samples.append(normalized)
+        }
+        return samples
+    }
+}
+
+extension VoiceMessagePlayer: @preconcurrency AVAudioPlayerDelegate {
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor [weak self] in
+            self?.playbackFinished()
+        }
+    }
+}
+
+// MARK: - Static waveform
+
+private struct StaticWaveformView: View {
+    let samples: [CGFloat]
+    let progress: CGFloat
+    let isMine: Bool
+    var maxBarHeight: CGFloat = 28
+
+    private let barWidth: CGFloat = 3
+    private let barSpacing: CGFloat = 2
+
+    var body: some View {
+        HStack(alignment: .center, spacing: barSpacing) {
+            ForEach(Array(samples.enumerated()), id: \.offset) { index, level in
+                let barProgress = samples.isEmpty ? 0 : CGFloat(index) / CGFloat(samples.count)
+                let isPlayed = barProgress <= progress
+                RoundedRectangle(cornerRadius: 1.5)
+                    .fill(barColor(isPlayed: isPlayed))
+                    .frame(width: barWidth, height: max(2, level * maxBarHeight))
+            }
+        }
+        .frame(height: maxBarHeight)
+    }
+
+    private func barColor(isPlayed: Bool) -> Color {
+        if isMine {
+            return isPlayed ? .white : .white.opacity(0.4)
+        }
+        return isPlayed ? .accentColor : Color(uiColor: .tertiaryLabel)
+    }
+}

--- a/ios/Sources/Views/VoiceRecordingView.swift
+++ b/ios/Sources/Views/VoiceRecordingView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct VoiceRecordingView: View {
+    let recorder: VoiceRecorder
+    let onSend: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 8) {
+            // Transcript (scrolling, appears as text comes in)
+            if !recorder.transcript.isEmpty {
+                ScrollView(.vertical, showsIndicators: false) {
+                    Text(recorder.transcript)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 60)
+            }
+
+            // Duration + waveform
+            HStack(spacing: 10) {
+                // Recording indicator dot + duration
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(Color.red)
+                        .frame(width: 8, height: 8)
+                        .opacity(recorder.isPaused ? 0.4 : 1)
+
+                    Text(formattedDuration)
+                        .font(.subheadline.monospacedDigit())
+                        .foregroundStyle(.primary)
+                }
+                .frame(width: 64, alignment: .leading)
+
+                WaveformView(levels: recorder.levels)
+                    .frame(height: 28)
+            }
+
+            // Controls: delete, pause/resume, send
+            HStack {
+                Button {
+                    onCancel()
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 36, height: 36)
+                }
+
+                Spacer()
+
+                Button {
+                    if recorder.isPaused {
+                        recorder.resumeRecording()
+                    } else {
+                        recorder.pauseRecording()
+                    }
+                } label: {
+                    Image(systemName: recorder.isPaused ? "record.circle" : "pause.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.primary)
+                        .frame(width: 36, height: 36)
+                }
+
+                Spacer()
+
+                Button {
+                    onSend()
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                        .frame(width: 36, height: 36)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var formattedDuration: String {
+        let minutes = Int(recorder.duration) / 60
+        let seconds = Int(recorder.duration) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+private struct WaveformView: View {
+    let levels: [CGFloat]
+
+    private let barWidth: CGFloat = 3
+    private let barSpacing: CGFloat = 2
+
+    var body: some View {
+        GeometryReader { geo in
+            let maxBars = Int(geo.size.width / (barWidth + barSpacing))
+            let visibleLevels = levels.suffix(maxBars)
+            let height = geo.size.height
+
+            HStack(alignment: .center, spacing: barSpacing) {
+                ForEach(Array(visibleLevels.enumerated()), id: \.offset) { _, level in
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(Color.accentColor.opacity(0.7))
+                        .frame(width: barWidth, height: max(2, level * height))
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+        }
+    }
+}

--- a/ios/Sources/VoiceRecorder.swift
+++ b/ios/Sources/VoiceRecorder.swift
@@ -1,0 +1,263 @@
+import AVFoundation
+import Accelerate
+import Speech
+
+@Observable
+@MainActor
+final class VoiceRecorder {
+    private(set) var isRecording = false
+    private(set) var isPaused = false
+    private(set) var duration: TimeInterval = 0
+    private(set) var levels: [CGFloat] = []
+    private(set) var recordingURL: URL?
+    private(set) var transcript: String = ""
+
+    private var audioEngine: AVAudioEngine?
+    private var audioFile: AVAudioFile?
+    private var tempCAFURL: URL?
+    private var timer: Timer?
+    private var recordingStartTime: Date?
+    private var pausedDuration: TimeInterval = 0
+    private var pauseStartTime: Date?
+
+    private var speechRecognizer: SFSpeechRecognizer?
+    private var speechRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var speechTask: SFSpeechRecognitionTask?
+
+    // Latest RMS power from the tap callback, read on main actor by the timer.
+    private nonisolated(unsafe) var latestPower: Float = 0
+
+    func startRecording() {
+        // Activate audio session BEFORE creating the engine / querying the
+        // input format. After a previous stopEngine() deactivates the session,
+        // inputNode.outputFormat returns an invalid format (0 Hz / 0 ch).
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
+            try session.setActive(true)
+        } catch {
+            print("VoiceRecorder: failed to activate audio session: \(error)")
+            return
+        }
+
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+
+        // Temp file for raw PCM recording
+        let tempDir = FileManager.default.temporaryDirectory
+        let cafURL = tempDir.appendingPathComponent("voice_\(UUID().uuidString).caf")
+        tempCAFURL = cafURL
+
+        do {
+            audioFile = try AVAudioFile(forWriting: cafURL, settings: inputFormat.settings)
+        } catch {
+            print("VoiceRecorder: failed to create audio file: \(error)")
+            return
+        }
+
+        // Set up speech recognition (best-effort, non-blocking)
+        startSpeechRecognition()
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { [weak self] buffer, _ in
+            guard let self else { return }
+            // Write PCM to file
+            try? self.audioFile?.write(from: buffer)
+
+            // Feed speech recognizer
+            self.speechRequest?.append(buffer)
+
+            // Compute RMS power
+            guard let channelData = buffer.floatChannelData?[0] else { return }
+            let frames = buffer.frameLength
+            var rms: Float = 0
+            vDSP_measqv(channelData, 1, &rms, vDSP_Length(frames))
+            rms = sqrtf(rms)
+            self.latestPower = rms
+        }
+
+        do {
+            try engine.start()
+        } catch {
+            print("VoiceRecorder: failed to start engine: \(error)")
+            return
+        }
+
+        audioEngine = engine
+        isRecording = true
+        isPaused = false
+        duration = 0
+        levels = []
+        transcript = ""
+        pausedDuration = 0
+        recordingStartTime = Date()
+
+        // 30Hz timer to poll duration + append power levels
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.timerTick()
+            }
+        }
+    }
+
+    func stopRecording() async -> URL? {
+        stopEngine()
+
+        guard let cafURL = tempCAFURL else {
+            resetState()
+            return nil
+        }
+
+        // Convert CAF (PCM) -> M4A (AAC)
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice_\(UUID().uuidString).m4a")
+
+        let success = await convertToM4A(from: cafURL, to: outputURL)
+
+        // Clean up temp CAF
+        try? FileManager.default.removeItem(at: cafURL)
+
+        let result: URL?
+        if success == true {
+            recordingURL = outputURL
+            result = outputURL
+        } else {
+            result = nil
+        }
+
+        resetState()
+        return result
+    }
+
+    func cancelRecording() {
+        stopEngine()
+        if let cafURL = tempCAFURL {
+            try? FileManager.default.removeItem(at: cafURL)
+        }
+        resetState()
+    }
+
+    func pauseRecording() {
+        guard isRecording, !isPaused else { return }
+        audioEngine?.pause()
+        isPaused = true
+        pauseStartTime = Date()
+    }
+
+    func resumeRecording() {
+        guard isRecording, isPaused else { return }
+        if let pauseStart = pauseStartTime {
+            pausedDuration += Date().timeIntervalSince(pauseStart)
+        }
+        pauseStartTime = nil
+        try? audioEngine?.start()
+        isPaused = false
+    }
+
+    // MARK: - Speech Recognition
+
+    private func startSpeechRecognition() {
+        let recognizer = SFSpeechRecognizer()
+        guard let recognizer, recognizer.isAvailable else { return }
+
+        // Check authorization status — only proceed if already authorized.
+        // We don't prompt here; the permission is requested lazily by the system
+        // when the recognition task starts if status is .notDetermined.
+        let status = SFSpeechRecognizer.authorizationStatus()
+        guard status == .authorized || status == .notDetermined else { return }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        request.addsPunctuation = true
+
+        speechRecognizer = recognizer
+        speechRequest = request
+
+        speechTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self, let result else { return }
+            Task { @MainActor [weak self] in
+                self?.transcript = result.bestTranscription.formattedString
+            }
+        }
+    }
+
+    private func stopSpeechRecognition() {
+        speechRequest?.endAudio()
+        speechTask?.cancel()
+        speechRequest = nil
+        speechTask = nil
+        speechRecognizer = nil
+    }
+
+    // MARK: - Private
+
+    private func timerTick() {
+        guard isRecording, !isPaused, let startTime = recordingStartTime else { return }
+
+        var currentPausedDuration = pausedDuration
+        if let pauseStart = pauseStartTime {
+            currentPausedDuration += Date().timeIntervalSince(pauseStart)
+        }
+        duration = Date().timeIntervalSince(startTime) - currentPausedDuration
+
+        let rms = latestPower
+        let db = 20 * log10f(max(rms, 1e-6))
+        let normalized = CGFloat(max(0, min(1, (db + 50) / 50)))
+        levels.append(normalized)
+    }
+
+    private func stopEngine() {
+        timer?.invalidate()
+        timer = nil
+
+        stopSpeechRecognition()
+
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+        audioFile = nil
+
+        // Deactivate and reset to default mode so subsequent playback
+        // doesn't inherit the .measurement receiver route.
+        let session = AVAudioSession.sharedInstance()
+        try? session.setActive(false, options: .notifyOthersOnDeactivation)
+        try? session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+    }
+
+    private func resetState() {
+        isRecording = false
+        isPaused = false
+        duration = 0
+        levels = []
+        recordingURL = nil
+        tempCAFURL = nil
+        recordingStartTime = nil
+        pausedDuration = 0
+        pauseStartTime = nil
+        latestPower = 0
+        // transcript is intentionally NOT reset here — the caller reads it after stop
+    }
+
+    private func convertToM4A(from inputURL: URL, to outputURL: URL) async -> Bool? {
+        let asset = AVAsset(url: inputURL)
+
+        guard let exportSession = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
+            return nil
+        }
+
+        exportSession.outputURL = outputURL
+        exportSession.outputFileType = .m4a
+
+        await exportSession.export()
+
+        switch exportSession.status {
+        case .completed:
+            return true
+        default:
+            if let error = exportSession.error {
+                print("VoiceRecorder: export failed: \(error)")
+            }
+            return false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Record voice messages with live waveform via AVAudioEngine, convert to AAC (.m4a) on send
- Play back voice messages inline as audio bubbles with static waveform and progress
- Live speech-to-text transcription (SFSpeechRecognizer) sent as italic markdown caption
- Mic button replaces send button when text field is empty
- No Rust changes, no new dependencies

## New files
- `ios/Sources/VoiceRecorder.swift` — AVAudioEngine recording + power metering + speech recognition
- `ios/Sources/Views/VoiceRecordingView.swift` — Recording overlay UI
- `ios/Sources/Views/VoiceMessageView.swift` — Inline audio playback bubble

## Modified files
- `ios/Sources/Views/ChatView.swift` — Mic button, recording state, send callback
- `ios/Sources/Views/MessageBubbleViews.swift` — Route `audio/*` attachments to VoiceMessageView
- `ios/Info.plist` — Updated mic description, added speech recognition key

## Test plan
- [ ] Open a chat, verify mic button appears when text field is empty
- [ ] Type text, verify mic button animates to send button
- [ ] Tap mic, grant permission, verify recording UI with live waveform
- [ ] Tap send, verify voice message appears as audio bubble with transcript caption
- [ ] Tap play on audio bubble, verify playback through main speaker with waveform progress
- [ ] Record a second voice message without crash
- [ ] Receive a voice message from another device, verify download + playback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)