### PR TITLE
ci: add clarkmoody to trusted actors

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -116,7 +116,7 @@ jobs:
     if: needs.detect-changes.outputs.marmotd == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     environment:
-      name: ${{ github.event_name == 'pull_request' && github.actor != 'justinmoon' && github.actor != 'futurepaul' && github.actor != 'AnthonyRonning' && github.actor != 'benthecarman' && 'ci-approval' || 'ci-auto' }}
+      name: ${{ github.event_name == 'pull_request' && github.actor != 'justinmoon' && github.actor != 'futurepaul' && github.actor != 'AnthonyRonning' && github.actor != 'benthecarman' && github.actor != 'clarkmoody' && 'ci-approval' || 'ci-auto' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add `clarkmoody` to the trusted actor list in `check-marmotd` so their PRs auto-run CI without manual approval.
- Collaborator invite (write access) sent separately via API.

## Test plan
- [x] Verified the environment condition syntax is correct
- [x] Collaborator invite confirmed sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)