### PR TITLE
Add attachment context menu with file picker

### DIFF
--- a/ios/Sources/Views/ChatInputBar.swift
+++ b/ios/Sources/Views/ChatInputBar.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+import PhotosUI
+import UniformTypeIdentifiers
+
+struct ChatInputBar: View {
+    @Binding var messageText: String
+    @Binding var selectedPhotoItem: PhotosPickerItem?
+    @Binding var showFileImporter: Bool
+    let showAttachButton: Bool
+    let showMicButton: Bool
+    @FocusState.Binding var isInputFocused: Bool
+    let onSend: () -> Void
+    let onStartVoiceRecording: () -> Void
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            if showAttachButton {
+                Menu {
+                    // TODO: Contact
+                    // TODO: Stickers
+
+                    Button {
+                        showFileImporter = true
+                    } label: {
+                        Label("File", systemImage: "doc")
+                    }
+
+                    PhotosPicker(
+                        selection: $selectedPhotoItem,
+                        matching: .any(of: [.images, .videos])
+                    ) {
+                        Label("Photos & Videos", systemImage: "photo.on.rectangle")
+                    }
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.body.weight(.semibold))
+                        .frame(width: 52, height: 52)
+                }
+                .tint(.secondary)
+                .modifier(GlassCircleModifier())
+            }
+
+            HStack(spacing: 10) {
+                TextEditor(text: $messageText)
+                    .focused($isInputFocused)
+                    .frame(minHeight: 36, maxHeight: 150)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .scrollContentBackground(.hidden)
+                    .onAppear {
+                        if ProcessInfo.processInfo.isiOSAppOnMac {
+                            isInputFocused = true
+                        }
+                    }
+                    .onKeyPress(.return, phases: .down) { keyPress in
+                        if keyPress.modifiers.contains(.shift) {
+                            return .ignored
+                        }
+                        onSend()
+                        return .handled
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if messageText.isEmpty {
+                            Text("Message")
+                                .foregroundStyle(.tertiary)
+                                .padding(.leading, 5)
+                                .padding(.top, 8)
+                                .allowsHitTesting(false)
+                        }
+                    }
+                    .accessibilityIdentifier(TestIds.chatMessageInput)
+
+                let isEmpty = messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                if isEmpty, showMicButton {
+                    Button {
+                        onStartVoiceRecording()
+                    } label: {
+                        Image(systemName: "mic.fill")
+                            .font(.title2)
+                    }
+                    .transition(.scale.combined(with: .opacity))
+                } else {
+                    Button(action: { onSend() }) {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.title2)
+                    }
+                    .disabled(isEmpty)
+                    .accessibilityIdentifier(TestIds.chatSend)
+                    .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .animation(.easeInOut(duration: 0.15), value: messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .modifier(GlassInputModifier())
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 12)
+    }
+}
+
+// MARK: - Glass modifiers (shared)
+
+struct GlassInputModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        #if compiler(>=6.2)
+        if #available(iOS 26.0, *) {
+            content
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 20))
+        } else {
+            content
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+        }
+        #else
+        content
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+        #endif
+    }
+}
+
+struct GlassCircleModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        #if compiler(>=6.2)
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(.regular.interactive(), in: Circle())
+        } else {
+            content
+                .background(.ultraThinMaterial, in: Circle())
+        }
+        #else
+        content
+            .background(.ultraThinMaterial, in: Circle())
+        #endif
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+private struct ChatInputBarPreview: View {
+    @State var messageText = ""
+    @State var selectedPhotoItem: PhotosPickerItem?
+    @State var showFileImporter = false
+    @FocusState var isInputFocused: Bool
+
+    let showAttach: Bool
+    let showMic: Bool
+
+    var body: some View {
+        ChatInputBar(
+            messageText: $messageText,
+            selectedPhotoItem: $selectedPhotoItem,
+            showFileImporter: $showFileImporter,
+            showAttachButton: showAttach,
+            showMicButton: showMic,
+            isInputFocused: $isInputFocused,
+            onSend: {},
+            onStartVoiceRecording: {}
+        )
+    }
+}
+
+#Preview("Input Bar — Full") {
+    VStack {
+        Spacer()
+        ChatInputBarPreview(showAttach: true, showMic: true)
+    }
+    .background(Color(uiColor: .systemBackground))
+}
+
+#Preview("Input Bar — No Attach") {
+    VStack {
+        Spacer()
+        ChatInputBarPreview(showAttach: false, showMic: false)
+    }
+    .background(Color(uiColor: .systemBackground))
+}
+
+#Preview("Input Bar — With Text") {
+    VStack {
+        Spacer()
+        ChatInputBarPreview(showAttach: true, showMic: true)
+    }
+    .background(Color(uiColor: .systemBackground))
+    .onAppear {}
+}
+#endif

--- a/ios/Sources/Views/FileAttachmentRow.swift
+++ b/ios/Sources/Views/FileAttachmentRow.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+struct FileAttachmentRow: View {
+    let filename: String
+    let mimeType: String
+    let localPath: String?
+    let isMine: Bool
+    var onDownload: (() -> Void)? = nil
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "doc")
+                .font(.title3)
+                .foregroundStyle(isMine ? .white.opacity(0.8) : .secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(filename)
+                    .font(.subheadline)
+                    .foregroundStyle(isMine ? .white : .primary)
+                    .lineLimit(1)
+                Text(mimeType)
+                    .font(.caption2)
+                    .foregroundStyle(isMine ? .white.opacity(0.6) : .secondary)
+            }
+
+            Spacer(minLength: 4)
+
+            if let localPath {
+                ShareLink(item: URL(fileURLWithPath: localPath)) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.title3)
+                        .foregroundStyle(isMine ? .white : .blue)
+                }
+                .buttonStyle(.plain)
+            } else {
+                Button {
+                    onDownload?()
+                } label: {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.title3)
+                        .foregroundStyle(isMine ? .white : .blue)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+}
+
+#if DEBUG
+#Preview("File Row — Mine, Downloaded") {
+    FileAttachmentRow(
+        filename: "sunset pirate.txt",
+        mimeType: "text/plain",
+        localPath: "/tmp/fake",
+        isMine: true
+    )
+    .background(Color.blue)
+    .clipShape(RoundedRectangle(cornerRadius: 16))
+    .padding()
+}
+
+#Preview("File Row — Mine, Not Downloaded") {
+    FileAttachmentRow(
+        filename: "quarterly-report.pdf",
+        mimeType: "application/pdf",
+        localPath: nil,
+        isMine: true
+    )
+    .background(Color.blue)
+    .clipShape(RoundedRectangle(cornerRadius: 16))
+    .padding()
+}
+
+#Preview("File Row — Incoming, Downloaded") {
+    FileAttachmentRow(
+        filename: "meeting-notes.pdf",
+        mimeType: "application/pdf",
+        localPath: "/tmp/fake",
+        isMine: false
+    )
+    .background(Color.gray.opacity(0.2))
+    .clipShape(RoundedRectangle(cornerRadius: 16))
+    .padding()
+}
+
+#Preview("File Row — Incoming, Not Downloaded") {
+    FileAttachmentRow(
+        filename: "archive.zip",
+        mimeType: "application/zip",
+        localPath: nil,
+        isMine: false
+    )
+    .background(Color.gray.opacity(0.2))
+    .clipShape(RoundedRectangle(cornerRadius: 16))
+    .padding()
+}
+
+#Preview("File Row — Long Filename") {
+    FileAttachmentRow(
+        filename: "a-very-long-filename-that-should-be-truncated-with-ellipsis.docx",
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        localPath: "/tmp/fake",
+        isMine: true
+    )
+    .frame(maxWidth: 280)
+    .background(Color.blue)
+    .clipShape(RoundedRectangle(cornerRadius: 16))
+    .padding()
+}
+#endif

--- a/ios/Sources/Views/VoiceMessageView.swift
+++ b/ios/Sources/Views/VoiceMessageView.swift
@@ -76,7 +76,7 @@ struct VoiceMessageView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
-        .frame(maxWidth: 240)
+        .frame(maxWidth: .infinity)
     }
 
     private func formatTime(_ time: TimeInterval) -> String {


### PR DESCRIPTION
## Summary
- Replace the "+" PhotosPicker button with a context menu offering **Photos & Videos** (images + video via PhotosPicker) and **File** (any file type via `.fileImporter`)
- Move MIME type inference into Rust (`mime_type_for_filename`) so all platforms share the same extension→MIME mapping — Swift sends empty MIME, Rust infers from filename
- Extract `ChatInputBar` and `FileAttachmentRow` into standalone SwiftUI components with previews
- Separate the "+" button into its own liquid glass circle beside the input pill
- Add `ShareLink` on downloaded file attachments so users can export/share files
- Store media as `{hash}/{filename}` instead of `{hash}_{filename}` so share sheet shows the real filename
- Widen voice message download row and file attachment row to fill bubble width

## Files changed
| File | What |
|------|------|
| `rust/src/core/chat_media.rs` | `mime_type_for_extension` + `mime_type_for_filename` helpers; MIME fallback in `send_chat_media`; `{hash}/{filename}` storage path |
| `ios/Sources/Views/ChatInputBar.swift` | **New** — extracted input bar with attachment menu, text editor, mic/send toggle, glass modifiers |
| `ios/Sources/Views/FileAttachmentRow.swift` | **New** — extracted file attachment row with share/download button and previews |
| `ios/Sources/Views/ChatView.swift` | Uses `ChatInputBar`; adds `showFileImporter` state + `.fileImporter` modifier; UTType-based extension detection |
| `ios/Sources/Views/MessageBubbleViews.swift` | Uses `FileAttachmentRow`; file bubble gets background + inline timestamp; image-only floating timestamp |
| `ios/Sources/Views/VoiceMessageView.swift` | Download row fills bubble width |

## Test plan
- [ ] Open a chat, tap "+" — should see menu with "Photos & Videos" and "File"
- [ ] Select a photo → sends as before (renders as image)
- [ ] Select a video → sends (renders as file attachment, correct MIME in Rust logs)
- [ ] "File" → opens system file browser, select any file → sends (renders as file attachment with background)
- [ ] Downloaded file attachment shows share button (right-aligned), opens share sheet with correct filename
- [ ] Not-yet-downloaded file shows download button (right-aligned)
- [ ] Voice message recording still works (mic button when text is empty)
- [ ] "+" button height matches text input pill height
- [ ] 32 MB Rust-side limit rejects oversized files with a toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)