### PR TITLE
Fix photo picker not presenting from attachment menu

### DIFF
--- a/ios/Sources/Views/ChatInputBar.swift
+++ b/ios/Sources/Views/ChatInputBar.swift
@@ -12,6 +12,8 @@ struct ChatInputBar: View {
     let onSend: () -> Void
     let onStartVoiceRecording: () -> Void
 
+    @State private var showPhotoPicker = false
+
     var body: some View {
         HStack(alignment: .bottom, spacing: 8) {
             if showAttachButton {
@@ -25,10 +27,9 @@ struct ChatInputBar: View {
                         Label("File", systemImage: "doc")
                     }
 
-                    PhotosPicker(
-                        selection: $selectedPhotoItem,
-                        matching: .any(of: [.images, .videos])
-                    ) {
+                    Button {
+                        showPhotoPicker = true
+                    } label: {
                         Label("Photos & Videos", systemImage: "photo.on.rectangle")
                     }
                 } label: {
@@ -38,6 +39,11 @@ struct ChatInputBar: View {
                 }
                 .tint(.secondary)
                 .modifier(GlassCircleModifier())
+                .photosPicker(
+                    isPresented: $showPhotoPicker,
+                    selection: $selectedPhotoItem,
+                    matching: .any(of: [.images, .videos])
+                )
             }
 
             HStack(spacing: 10) {


### PR DESCRIPTION
## Summary
- The file picker PR (#273) placed `PhotosPicker` directly inside a `Menu`, which loses its presentation context when the menu dismisses — the photo library sheet never appears
- Replace with a plain `Button` that sets a flag, driving the picker via the `.photosPicker(isPresented:)` view modifier attached outside the `Menu`

## Test plan
- [ ] Tap "+" attachment button, tap "Photos & Videos" — photo picker should appear
- [ ] Select a photo/video — verify it sends correctly
- [ ] Tap "+" then "File" — file picker should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)