### PR TITLE
release: pikachat-openclaw v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "pikachat"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pikachat"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 
 [[bin]]

--- a/pikachat-openclaw/README.md
+++ b/pikachat-openclaw/README.md
@@ -66,9 +66,8 @@ Add the channel config to `~/.openclaw/openclaw.json`:
 ```json
 {
   "channels": {
-    "pikachat": {
+    "pikachat-openclaw": {
       "relays": ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net"],
-      "sidecarCmd": "pikachat",
       "stateDir": "~/.openclaw/.pikachat-state",
       "autoAcceptWelcomes": true,
       "groupPolicy": "open",
@@ -80,16 +79,18 @@ Add the channel config to `~/.openclaw/openclaw.json`:
 
 Replace `<hex-pubkey-of-allowed-sender>` with the Nostr public key(s) you want to accept messages from.
 
+> **Note:** The channel ID is `pikachat-openclaw` (matching the npm package name). All config goes under `channels.pikachat-openclaw`.
+
 ### Group Chat Support
 
 The plugin supports multi-participant MLS group chats with mention gating, sender identity resolution, and owner/friend permission tiers. See **[docs/group-chat.md](docs/group-chat.md)** for the full guide.
 
-Quick setup for group chats — add these fields to your `channels.pikachat` config:
+Quick setup for group chats — add these fields to your `channels.pikachat-openclaw` config:
 
 ```json
 {
   "channels": {
-    "pikachat": {
+    "pikachat-openclaw": {
       "groupPolicy": "open",
       "groupAllowFrom": ["<owner-pubkey>", "<friend-pubkey>"],
       "owner": "<owner-pubkey>",
@@ -109,7 +110,7 @@ Quick setup for group chats — add these fields to your `channels.pikachat` con
 - **Per-group sessions** — each group gets isolated conversation history
 - **Sender metadata** — exposes npub and owner/friend tag for verifiable identity
 
-> **Note:** Setting `sidecarCmd` to just `"pikachat"` (no path) tells the plugin to auto-download the correct prebuilt binary. Binaries are cached at `~/.openclaw/tools/pikachat/<tag>/pikachat`.
+> **Note:** Setting `sidecarCmd` to just `"pikachat"` (no path) in your plugin config tells the plugin to auto-download the correct prebuilt binary. Binaries are cached at `~/.openclaw/tools/pikachat/<tag>/pikachat`.
 
 ### 4. Restart OpenClaw gateway
 
@@ -129,6 +130,28 @@ You should see: `Pikachat | ON | OK | configured`
 
 Use [Pika](https://pika.team) (or another compatible client) to create a group and invite the bot's pubkey. With `autoAcceptWelcomes: true`, the bot joins automatically and starts responding.
 
+### Migration from `@justinmoon/marmot`
+
+If you were previously using the `@justinmoon/marmot` plugin:
+
+1. **Back up your config** — save your current `channels.marmot` and `plugins.entries.marmot` settings
+2. **Uninstall the old plugin:**
+   ```bash
+   openclaw plugins uninstall marmot
+   ```
+   > If this fails with a validation error, manually remove the `channels.marmot`, `plugins.entries.marmot`, `plugins.allow` (marmot entry), and `plugins.installs.marmot` sections from `~/.openclaw/openclaw.json`
+3. **Install the new plugin:**
+   ```bash
+   openclaw plugins install pikachat-openclaw
+   ```
+4. **Migrate your config** — move your settings from `channels.marmot` to `channels.pikachat-openclaw`. The config schema is identical; only the key name changes.
+5. **Restart:**
+   ```bash
+   openclaw gateway restart
+   ```
+
+Your existing MLS state directory (e.g. `~/.openclaw/.marmot-state`) can be reused as-is — just point `stateDir` to it in the new config.
+
 ### Gotchas
 
 - **`identity.json` needs both fields** — omitting `public_key_hex` causes a silent sidecar crash with no useful error.
@@ -141,13 +164,13 @@ Use [Pika](https://pika.team) (or another compatible client) to create a group a
 If you prefer to compile `pikachat` yourself (requires the Rust toolchain):
 
 ```bash
-This code lives in the Pika monorepo under `pikachat-openclaw/`.
+# This code lives in the Pika monorepo under `pikachat-openclaw/`.
 cd "$(git rev-parse --show-toplevel)"
 cargo build --release -p pikachat
 # binary at target/release/pikachat
 ```
 
-Then set `sidecarCmd` in your channel config to the absolute path of the binary:
+Then set `sidecarCmd` in your plugin config to the absolute path of the binary:
 
 ```json
 "sidecarCmd": "/path/to/pika/target/release/pikachat"

--- a/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/CHANGELOG.md
+++ b/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.3
+
+- Fix: align plugin/channel ID with npm package name (`pikachat` → `pikachat-openclaw`).
+  - Fixes `openclaw plugins install pikachat-openclaw` failing with validation error.
+  - Config path changes: `channels.pikachat` → `channels.pikachat-openclaw`.
+  - Extension directory: `extensions/pikachat` → `extensions/pikachat-openclaw`.
+- Fix: bump script path updated for renamed extension directory.
+
 ## 0.4.0
 
 - Fix: publish `i` (KeyPackageRef) tag on key package events for Pika v0.2.8+ compatibility.

--- a/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/package.json
+++ b/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pikachat-openclaw",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "OpenClaw Pikachat channel plugin (Rust sidecar)",
   "type": "module",
   "publishConfig": {

--- a/scripts/bump-pikachat.sh
+++ b/scripts/bump-pikachat.sh
@@ -12,13 +12,13 @@ TAG="pikachat-v${VERSION}"
 ROOT="$(git rev-parse --show-toplevel)"
 
 CARGO_TOML="$ROOT/cli/Cargo.toml"
-PACKAGE_JSON="$ROOT/pikachat-openclaw/openclaw/extensions/pikachat/package.json"
+PACKAGE_JSON="$ROOT/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/package.json"
 
 # Bump Cargo.toml
 sed "s/^version = \".*\"/version = \"${VERSION}\"/" "$CARGO_TOML" > "$CARGO_TOML.tmp" && mv "$CARGO_TOML.tmp" "$CARGO_TOML"
 
 # Bump package.json
-cd "$ROOT/pikachat-openclaw/openclaw/extensions/pikachat"
+cd "$ROOT/pikachat-openclaw/openclaw/extensions/pikachat-openclaw"
 npm version "$VERSION" --no-git-tag-version --allow-same-version
 
 # Update Cargo.lock


### PR DESCRIPTION
Version bump for the npm package to include the plugin/channel ID fix from #284.

### Changes
- Bump `pikachat-openclaw` npm package version: 0.5.2 → 0.5.3
- Update CHANGELOG with the plugin ID alignment fix
- Fix `scripts/bump-pikachat.sh` path (`extensions/pikachat` → `extensions/pikachat-openclaw`)

### After merge
Tag `pikachat-v0.5.3` and `npm publish` to release.