### PR TITLE
Add file upload and drag-and-drop media to desktop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "askama"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +426,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +463,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -1826,6 +1870,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
 ]
 
@@ -5755,6 +5801,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 name = "pika-desktop"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "flume",
  "iced",
  "image 0.24.9",
@@ -5762,6 +5809,7 @@ dependencies = [
  "openh264",
  "pika-media",
  "pika_core",
+ "rfd",
  "tempfile",
 ]
 
@@ -6043,6 +6091,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "poly1305"
@@ -6702,6 +6756,30 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8523,6 +8601,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10211,6 +10295,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow",
  "zvariant_derive",
  "zvariant_utils",

--- a/crates/pika-desktop/Cargo.toml
+++ b/crates/pika-desktop/Cargo.toml
@@ -12,6 +12,8 @@ nokhwa = { version = "0.10", features = ["input-native"] }
 openh264 = "0.6"
 pika_core = { path = "../../rust" }
 pika-media = { path = "../pika-media" }
+rfd = "0.15"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/pika-desktop/src/design/styles.rs
+++ b/crates/pika-desktop/src/design/styles.rs
@@ -360,6 +360,38 @@ impl PikaTheme {
         }
     }
 
+    // ── Drop zone overlay ────────────────────────────────────────────────
+
+    /// Overlay style for the file drop target (shown when dragging files over
+    /// the conversation area). Semi-transparent accent wash with a dashed-look
+    /// border to clearly indicate the drop zone.
+    pub fn drop_zone(&self) -> container::Style {
+        container::Style {
+            text_color: Some(self.accent.on),
+            background: Some(Background::Color(self.accent.base.scale_alpha(0.10))),
+            border: Border {
+                color: self.accent.base.scale_alpha(0.6),
+                width: 2.0,
+                radius: border::radius(self.radii.m),
+            },
+            ..Default::default()
+        }
+    }
+
+    /// Style for a media attachment chip (non-image file) inside a bubble.
+    pub fn media_chip(&self, is_mine: bool) -> container::Style {
+        let bg = if is_mine {
+            Color::WHITE.scale_alpha(0.12)
+        } else {
+            self.background.component.hover
+        };
+        container::Style {
+            background: Some(Background::Color(bg)),
+            border: border::rounded(self.radii.s),
+            ..Default::default()
+        }
+    }
+
     // ── Text input style ───────────────────────────────────────────────
 
     pub fn text_input(&self, status: text_input::Status) -> text_input::Style {

--- a/crates/pika-desktop/src/icons.rs
+++ b/crates/pika-desktop/src/icons.rs
@@ -59,6 +59,11 @@ pub const KEY: &str = "\u{e0fd}";
 pub const INFO: &str = "\u{e0f9}";
 #[allow(dead_code)]
 pub const AT_SIGN: &str = "\u{e04e}";
+pub const PAPERCLIP: &str = "\u{e12d}";
+pub const DOWNLOAD: &str = "\u{e0a7}";
+pub const FILE: &str = "\u{e0c4}";
+#[allow(dead_code)]
+pub const IMAGE_ICON: &str = "\u{e0ed}";
 
 // ── Helper ──────────────────────────────────────────────────────────────────
 

--- a/crates/pika-desktop/src/theme.rs
+++ b/crates/pika-desktop/src/theme.rs
@@ -87,6 +87,16 @@ pub fn checkbox_style(is_checked: bool) -> impl Fn(&Theme) -> container::Style {
     move |_theme: &Theme| design::DARK.checkbox_indicator(is_checked)
 }
 
+// ── Media / file upload ─────────────────────────────────────────────────────
+
+pub fn drop_zone_style(_theme: &Theme) -> container::Style {
+    design::DARK.drop_zone()
+}
+
+pub fn media_chip_style(is_mine: bool) -> impl Fn(&Theme) -> container::Style {
+    move |_theme: &Theme| design::DARK.media_chip(is_mine)
+}
+
 // ── Call screen ─────────────────────────────────────────────────────────────
 
 pub fn incoming_call_banner_style(_theme: &Theme) -> container::Style {

--- a/rust/src/core/chat_media.rs
+++ b/rust/src/core/chat_media.rs
@@ -12,27 +12,38 @@ use super::*;
 
 const MAX_CHAT_MEDIA_BYTES: usize = 32 * 1024 * 1024;
 
+/// Map file extension to a MIME type that MDK's encrypted-media allowlist
+/// accepts.  Types not on MDK's `SUPPORTED_MIME_TYPES` list must map to
+/// `application/octet-stream` (MDK's escape-hatch type) so that arbitrary
+/// files can be uploaded without validation errors.
 fn mime_type_for_extension(ext: &str) -> &'static str {
     match ext.to_ascii_lowercase().as_str() {
+        // Image types (on MDK allowlist)
         "jpg" | "jpeg" => "image/jpeg",
         "png" => "image/png",
         "gif" => "image/gif",
         "webp" => "image/webp",
-        "heic" | "heif" => "image/heic",
-        "svg" => "image/svg+xml",
+        "bmp" => "image/bmp",
+        "ico" => "image/x-icon",
+        "tiff" | "tif" => "image/tiff",
+        "avif" => "image/avif",
+        // Video types (on MDK allowlist)
         "mp4" => "video/mp4",
         "mov" => "video/quicktime",
-        "m4v" => "video/x-m4v",
+        "mkv" => "video/x-matroska",
         "webm" => "video/webm",
         "avi" => "video/x-msvideo",
-        "mp3" => "audio/mpeg",
-        "m4a" => "audio/mp4",
+        // Audio types (on MDK allowlist)
         "ogg" => "audio/ogg",
+        "flac" => "audio/flac",
+        "aac" => "audio/aac",
+        "m4a" => "audio/mp4",
+        "mp3" => "audio/mpeg",
         "wav" => "audio/wav",
+        // Document types (on MDK allowlist)
         "pdf" => "application/pdf",
-        "zip" => "application/zip",
-        "json" => "application/json",
         "txt" => "text/plain",
+        // Everything else → octet-stream (MDK escape hatch, skips validation)
         _ => "application/octet-stream",
     }
 }


### PR DESCRIPTION
## Summary
- Adds a paperclip attachment button with native file picker (via `rfd`) for sending any file type
- Adds drag-and-drop file zone with a visual overlay indicator
- Renders inline images for downloaded image attachments, and a file chip UI for all other file types (with download/open actions)
- Reserves space for hover action icons on message bubbles to prevent layout jumps
- Fixes MIME type mapping in `chat_media.rs` to align with MDK's `SUPPORTED_MIME_TYPES` allowlist (unsupported types now use `application/octet-stream` escape hatch, fixing "Invalid MIME type format: application/zip" errors)

## Test plan
- [ ] Send an image via the paperclip button and verify it uploads + renders inline
- [ ] Send a non-image file (e.g. .zip, .pdf) and verify it shows as a file chip
- [ ] Drag and drop a file onto the conversation area and verify the drop overlay appears and the file sends
- [ ] Receive a media message and verify download button works, then file opens
- [ ] Hover over message bubbles and verify no layout jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)