### PR TITLE
Wire Darwin builds to pinned Xcode toolchain

### DIFF
--- a/crates/rmp-cli/src/init.rs
+++ b/crates/rmp-cli/src/init.rs
@@ -730,9 +730,18 @@ fn tpl_flake_nix() -> String {
             export PATH=$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH
 
             if [ "$(uname -s)" = "Darwin" ]; then
-              DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort -V | tail -n 1 || true)"
-              if [ -n "$DEV_DIR" ]; then
+              if [ -n "''${DEVELOPER_DIR:-}" ] && [ -x "''${DEVELOPER_DIR}/usr/bin/simctl" ]; then
+                DEV_DIR="$DEVELOPER_DIR"
+              else
+                DEV_DIR="$(xcode-select -p 2>/dev/null || true)"
+              fi
+              if [ -n "$DEV_DIR" ] && [ -d "$DEV_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin" ]; then
                 export DEVELOPER_DIR="$DEV_DIR"
+                TOOLCHAIN_BIN="$DEV_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+                export CC="$TOOLCHAIN_BIN/clang"
+                export CXX="$TOOLCHAIN_BIN/clang++"
+                export AR="$TOOLCHAIN_BIN/ar"
+                export RANLIB="$TOOLCHAIN_BIN/ranlib"
               fi
             fi
 

--- a/flake.nix
+++ b/flake.nix
@@ -441,6 +441,18 @@
                 fi
                 echo ""
               fi
+
+              # Ensure Cargo C/C++ build scripts use the pinned Xcode toolchain
+              # (not nix clang-wrapper), which avoids target-wrapper mismatches.
+              if [ -n "''${DEVELOPER_DIR:-}" ] && [ -d "''${DEVELOPER_DIR}/Toolchains/XcodeDefault.xctoolchain/usr/bin" ]; then
+                TOOLCHAIN_BIN="''${DEVELOPER_DIR}/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+                export CC="$TOOLCHAIN_BIN/clang"
+                export CXX="$TOOLCHAIN_BIN/clang++"
+                export AR="$TOOLCHAIN_BIN/ar"
+                export RANLIB="$TOOLCHAIN_BIN/ranlib"
+                export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="$TOOLCHAIN_BIN/clang"
+                export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="$TOOLCHAIN_BIN/clang"
+              fi
             fi
 
             ${if hasAndroidSdk then ''

--- a/justfile
+++ b/justfile
@@ -722,7 +722,7 @@ desktop-check:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "$(uname -s)" == "Darwin" ]]; then
-      CC=/usr/bin/clang CXX=/usr/bin/clang++ cargo check -p pika-desktop
+      ./tools/cargo-with-xcode check -p pika-desktop
     else
       cargo check -p pika-desktop
     fi
@@ -733,7 +733,13 @@ desktop-ui-test:
 
 # Run the desktop ICED app.
 run-desktop *ARGS:
-    cargo run -p pika-desktop {{ ARGS }}
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      ./tools/cargo-with-xcode run -p pika-desktop {{ ARGS }}
+    else
+      cargo run -p pika-desktop {{ ARGS }}
+    fi
 
 # Check iOS dev environment (Xcode, simulators, runtimes).
 doctor-ios:

--- a/tools/cargo-with-xcode
+++ b/tools/cargo-with-xcode
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  exec cargo "$@"
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_DIR="$("$ROOT/tools/xcode-dev-dir")"
+TOOLCHAIN_BIN="$DEV_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+CLANG_BIN="$TOOLCHAIN_BIN/clang"
+
+exec env \
+  -u SDKROOT \
+  -u MACOSX_DEPLOYMENT_TARGET \
+  -u IPHONEOS_DEPLOYMENT_TARGET \
+  DEVELOPER_DIR="$DEV_DIR" \
+  CC="$CLANG_BIN" \
+  CXX="$TOOLCHAIN_BIN/clang++" \
+  AR="$TOOLCHAIN_BIN/ar" \
+  RANLIB="$TOOLCHAIN_BIN/ranlib" \
+  CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="$CLANG_BIN" \
+  CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="$CLANG_BIN" \
+  cargo "$@"

--- a/tools/ios-runtime-doctor
+++ b/tools/ios-runtime-doctor
@@ -8,12 +8,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1 || true)"
-if [ -z "${DEV_DIR:-}" ]; then
-  echo "error: Xcode not found under /Applications." >&2
-  echo "Install Xcode first, then retry." >&2
-  exit 1
-fi
+DEV_DIR="$("$ROOT/tools/xcode-dev-dir")"
 export DEVELOPER_DIR="$DEV_DIR"
 
 SIMCTL="$DEV_DIR/usr/bin/simctl"

--- a/tools/ios-sim-ensure
+++ b/tools/ios-sim-ensure
@@ -6,11 +6,8 @@ set -euo pipefail
 # This does NOT download iOS simulator runtimes. If no runtimes are installed, it prints
 # a clear error message and exits non-zero.
 
-DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1 || true)"
-if [ -z "${DEV_DIR:-}" ]; then
-  echo "error: Xcode not found under /Applications" >&2
-  exit 1
-fi
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_DIR="$("$ROOT/tools/xcode-dev-dir")"
 export DEVELOPER_DIR="$DEV_DIR"
 
 SIMCTL="$DEV_DIR/usr/bin/simctl"

--- a/tools/simctl
+++ b/tools/simctl
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1 || true)"
-if [ -z "${DEV_DIR:-}" ]; then
-  echo "error: Xcode not found under /Applications (needed for simctl)" >&2
-  exit 1
-fi
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_DIR="$("$ROOT/tools/xcode-dev-dir")"
 
 exec "$DEV_DIR/usr/bin/simctl" "$@"

--- a/tools/xcode-dev-dir
+++ b/tools/xcode-dev-dir
@@ -1,13 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Print the most recent Xcode Developer directory under /Applications.
-# Errors if not found.
+# Resolve an Xcode Developer directory with deterministic precedence:
+# 1) Respect DEVELOPER_DIR if already set (flake shell pins this).
+# 2) Respect xcode-select (xcode-wrapper may pin this in nix shells).
+# 3) Fallback to latest /Applications/Xcode*.app for non-nix usage.
 
-DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1 || true)"
-if [ -z "${DEV_DIR:-}" ]; then
-  echo "error: Xcode not found under /Applications" >&2
-  exit 1
+is_valid_dev_dir() {
+  local dir="${1:-}"
+  [ -n "$dir" ] \
+    && [ -x "$dir/usr/bin/simctl" ] \
+    && [ -x "$dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" ]
+}
+
+if is_valid_dev_dir "${DEVELOPER_DIR:-}"; then
+  echo "$DEVELOPER_DIR"
+  exit 0
 fi
-echo "$DEV_DIR"
 
+SELECTED_DIR="$(xcode-select -p 2>/dev/null || true)"
+if is_valid_dev_dir "$SELECTED_DIR"; then
+  echo "$SELECTED_DIR"
+  exit 0
+fi
+
+LATEST_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort -V | tail -n 1 || true)"
+if is_valid_dev_dir "$LATEST_DIR"; then
+  echo "$LATEST_DIR"
+  exit 0
+fi
+
+echo "error: no full Xcode install found (need .../Contents/Developer with simctl + clang)" >&2
+exit 1

--- a/tools/xcode-run
+++ b/tools/xcode-run
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # Run a command with a working Xcode toolchain env even inside Nix/direnv shells:
-# - chooses /Applications/Xcode*.app Developer dir
+# - resolves the pinned Xcode Developer dir
 # - unsets common Nix compiler env vars that break xcodebuild
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEV_DIR="$("$TOOLS_DIR/xcode-dev-dir")"
-exec env -u LD -u CC -u CXX DEVELOPER_DIR="$DEV_DIR" "$@"
+exec env -u LD -u CC -u CXX -u AR -u RANLIB -u SDKROOT -u MACOSX_DEPLOYMENT_TARGET DEVELOPER_DIR="$DEV_DIR" "$@"

--- a/tools/xcrun
+++ b/tools/xcrun
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-DEV_DIR="$(ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -n 1 || true)"
-if [ -n "${DEV_DIR:-}" ]; then
-  export DEVELOPER_DIR="$DEV_DIR"
-fi
-exec /usr/bin/xcrun "$@"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_DIR="$("$ROOT/tools/xcode-dev-dir")"
+exec env DEVELOPER_DIR="$DEV_DIR" /usr/bin/xcrun "$@"


### PR DESCRIPTION
## Summary
- route macOS desktop Cargo commands through a new `tools/cargo-with-xcode` wrapper
- unify Xcode resolution via `tools/xcode-dev-dir` (DEVELOPER_DIR -> xcode-select -> /Applications fallback)
- update Xcode helper scripts (`xcode-run`, `xcrun`, `simctl`, iOS doctor/sim helpers) to use the shared resolver
- export Xcode toolchain compiler vars in Darwin dev shells (including RMP init template) so C/C++ build scripts avoid nix `clang-wrapper` mismatch

## Validation
- `just desktop-check`
- `just run-desktop` reaches app launch (`Running target/debug/pika-desktop`)
