### PR TITLE
chore: bump hypernote-mdx to latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,8 +3245,8 @@ dependencies = [
 
 [[package]]
 name = "hypernote-mdx"
-version = "0.2.0"
-source = "git+https://github.com/futurepaul/hypernote-mdx?rev=041ea6ea3d217813933f96275d2a2be35ecfe854#041ea6ea3d217813933f96275d2a2be35ecfe854"
+version = "0.3.0"
+source = "git+https://github.com/futurepaul/hypernote-mdx?rev=9c73231c980a03e6b149f62ccce2e58c9563744f#9c73231c980a03e6b149f62ccce2e58c9563744f"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,5 @@ members = [
 mdk-core = { git = "https://github.com/marmot-protocol/mdk", rev = "d9f372743625de17f6fcd81eecd5084917a8ebb1", features = ["mip04"] }
 mdk-sqlite-storage = { git = "https://github.com/marmot-protocol/mdk", rev = "d9f372743625de17f6fcd81eecd5084917a8ebb1" }
 mdk-storage-traits = { git = "https://github.com/marmot-protocol/mdk", rev = "d9f372743625de17f6fcd81eecd5084917a8ebb1" }
-hypernote-mdx = { git = "https://github.com/futurepaul/hypernote-mdx", rev = "041ea6ea3d217813933f96275d2a2be35ecfe854", version = "0.2.0" }
+hypernote-mdx = { git = "https://github.com/futurepaul/hypernote-mdx", rev = "9c73231c980a03e6b149f62ccce2e58c9563744f", version = "0.3.0" }
 hypernote-protocol = { path = "crates/hypernote-protocol" }


### PR DESCRIPTION
## Summary
- bump `hypernote-mdx` git rev to latest `master` (`9c73231c980a03e6b149f62ccce2e58c9563744f`)
- update workspace dependency version from `0.2.0` to `0.3.0` to match upstream crate version
- refresh lockfile entry for `hypernote-mdx`

## Verification
- `cargo check -p pika_core`

(fixes a crash caused by hypernote choking on malformed hypernotes)