### PR TITLE
pikahub: deterministic port range (19400-19402) with retry on conflict

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ info:
     @echo
     @echo "Agent demos"
     @echo "  Local backend (postgres + relay + server):"
-    @echo "    just run-server"
+    @echo "    just pikahub"
     @echo "  Fly demo (against local backend):"
     @echo "    just agent-fly-local"
     @echo "  Fly demo (against deployed backend):"
@@ -748,14 +748,14 @@ relay-build:
 # Start local backend (postgres, pika-relay, pika-server with agent control).
 
 # State persists in .pikahub/. Press Ctrl-C to stop all services.
-run-server:
+pikahub:
     cargo run -p pikahub -- up --profile backend
 
 # TUI: pikahub + component logs + interactive shell via mprocs.
 pikahut:
     mprocs
 
-# Run agent-fly against local backend (requires `just run-server` in another terminal).
+# Run agent-fly against local backend (requires `just pikahub` in another terminal).
 agent-fly-local *ARGS="":
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
Re-implements #320 on top of current `master` after the revert in `f0cd0c6`.

- sets deterministic default ports for local pikahub backend (`19400-19402`)
- keeps conflict handling by falling back to random available ports
- renames `just run-server` to `just pikahub` in the justfile guidance and target name

Context: #320 was reverted because it landed before CI was green. This reopens the same change so CI can run cleanly on the current baseline.
