### PR TITLE
Split pikahub into lib+bin and use library directly in Rust E2E tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5910,6 +5910,7 @@ dependencies = [
  "pika-media",
  "pika-relay-profiles",
  "pika-tls",
+ "pikahub",
  "rand 0.8.5",
  "regex",
  "reqwest",

--- a/crates/pikahub/Cargo.toml
+++ b/crates/pikahub/Cargo.toml
@@ -3,6 +3,9 @@ name = "pikahub"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 name = "pikahub"
 path = "src/main.rs"

--- a/crates/pikahub/src/lib.rs
+++ b/crates/pikahub/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod component;
+pub mod config;
+pub mod fixture;
+pub mod health;
+pub mod manifest;

--- a/crates/pikahub/src/main.rs
+++ b/crates/pikahub/src/main.rs
@@ -1,13 +1,8 @@
-mod component;
-mod config;
-mod fixture;
-mod health;
-mod manifest;
-
 use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use pikahub::{config, fixture};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -63,7 +63,9 @@ paranoid-android = "0.2"
 [dev-dependencies]
 futures-util = "0.3"
 nostr-connect = "0.44.0"
+pikahub = { path = "../crates/pikahub" }
 tempfile = "3"
+tokio = { version = "1.47", features = ["rt-multi-thread"] }
 tokio-tungstenite = "0.27"
 
 [target.'cfg(target_os = "ios")'.dependencies]

--- a/rust/tests/support/infra.rs
+++ b/rust/tests/support/infra.rs
@@ -1,13 +1,16 @@
 #![allow(dead_code)]
 
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::sync::OnceLock;
+use std::future::Future;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use pikahub::config::{ProfileName, ResolvedConfig};
+use pikahub::{fixture, manifest::Manifest};
 
 /// Provides relay + moq URLs for E2E tests.
 ///
 /// In local mode (default): starts pikahub in the background with a temp state dir.
-/// On Drop, runs `pikahub down` to clean up.
+/// On Drop, calls `pikahub::fixture::down_sync` to clean up.
 pub struct TestInfra {
     pub relay_url: String,
     pub moq_url: Option<String>,
@@ -15,70 +18,45 @@ pub struct TestInfra {
 }
 
 impl TestInfra {
-    /// Start local infra via pikahub.  `need_moq` controls whether moq-relay is included.
+    /// Start local infra via pikahub. `need_moq` controls whether moq-relay is included.
     pub fn start_local(need_moq: bool) -> Self {
-        let pikahub = pikahub_binary();
         let state_dir = tempfile::tempdir().expect("tempdir for pikahub").keep();
-        let profile = if need_moq { "relay-moq" } else { "relay" };
+        let profile = if need_moq {
+            ProfileName::RelayMoq
+        } else {
+            ProfileName::Relay
+        };
+        let resolved = ResolvedConfig::new(
+            profile,
+            None,
+            false,
+            Some(0),
+            need_moq.then_some(0),
+            None,
+            Some(state_dir.clone()),
+        )
+        .unwrap_or_else(|e| panic!("resolve pikahub config failed: {e:#}"));
 
-        let mut cmd = Command::new(&pikahub);
-        cmd.arg("up")
-            .arg("--profile")
-            .arg(profile)
-            .arg("--background")
-            .arg("--relay-port")
-            .arg("0")
-            .arg("--state-dir")
-            .arg(&state_dir);
-        if need_moq {
-            cmd.arg("--moq-port").arg("0");
-        }
-        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let startup_resolved = resolved.clone();
+        let startup_state_dir = state_dir.clone();
+        let startup: Result<Manifest> = run_async(async move {
+            fixture::up_background(&startup_resolved).await?;
+            let manifest = Manifest::load(&startup_state_dir)?.ok_or_else(|| {
+                anyhow!(
+                    "manifest missing after pikahub startup at {}",
+                    startup_state_dir.display()
+                )
+            })?;
+            fixture::wait(&startup_state_dir, 30).await?;
+            Ok(manifest)
+        });
+        let manifest = startup.unwrap_or_else(|e| panic!("start pikahub fixture failed: {e:#}"));
 
-        let output = cmd
-            .output()
-            .unwrap_or_else(|e| panic!("pikahub up failed: {e}"));
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            panic!("pikahub up --profile {profile} failed:\nstdout: {stdout}\nstderr: {stderr}");
-        }
-
-        // Read manifest to get URLs.
-        let manifest_path = state_dir.join("manifest.json");
-        let manifest_raw = std::fs::read_to_string(&manifest_path)
-            .unwrap_or_else(|e| panic!("read manifest at {}: {e}", manifest_path.display()));
-        let manifest: serde_json::Value =
-            serde_json::from_str(&manifest_raw).unwrap_or_else(|e| panic!("parse manifest: {e}"));
-
-        let relay_url = manifest["relay_url"]
-            .as_str()
-            .expect("manifest missing relay_url")
-            .to_string();
-
-        let moq_url = manifest["moq_url"].as_str().map(|s| s.to_string());
+        let relay_url = manifest.relay_url.expect("manifest missing relay_url");
+        let moq_url = manifest.moq_url;
 
         if need_moq && moq_url.is_none() {
             panic!("requested moq but pikahub manifest has no moq_url");
-        }
-
-        // Use pikahub wait for reliable health checking instead of manual TCP probe.
-        let wait_output = Command::new(&pikahub)
-            .arg("wait")
-            .arg("--timeout")
-            .arg("30")
-            .arg("--state-dir")
-            .arg(&state_dir)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .unwrap_or_else(|e| panic!("pikahub wait failed: {e}"));
-        if !wait_output.status.success() {
-            let stderr = String::from_utf8_lossy(&wait_output.stderr);
-            panic!(
-                "pikahub wait --state-dir {} failed:\n{stderr}",
-                state_dir.display()
-            );
         }
 
         eprintln!("[TestInfra] local relay={relay_url}");
@@ -106,24 +84,14 @@ impl TestInfra {
 
 impl Drop for TestInfra {
     fn drop(&mut self) {
-        if let Some(ref state_dir) = self.state_dir {
-            let pikahub = pikahub_binary();
-            let status = Command::new(&pikahub)
-                .arg("down")
-                .arg("--state-dir")
-                .arg(state_dir)
-                .stdout(Stdio::null())
-                .stderr(Stdio::piped())
-                .status();
-            if let Ok(s) = &status {
-                if !s.success() {
-                    eprintln!(
-                        "[TestInfra] WARNING: pikahub down failed (exit {})",
-                        s.code().unwrap_or(-1)
-                    );
-                }
+        if let Some(state_dir) = self.state_dir.take() {
+            if let Err(e) = fixture::down_sync(&state_dir) {
+                eprintln!(
+                    "[TestInfra] WARNING: pikahub down failed for {}: {e:#}",
+                    state_dir.display()
+                );
             }
-            if let Err(e) = std::fs::remove_dir_all(state_dir) {
+            if let Err(e) = std::fs::remove_dir_all(&state_dir) {
                 eprintln!(
                     "[TestInfra] WARNING: failed to remove {}: {e}",
                     state_dir.display()
@@ -133,48 +101,29 @@ impl Drop for TestInfra {
     }
 }
 
-fn pikahub_binary() -> String {
-    static PIKAHUB_BIN: OnceLock<String> = OnceLock::new();
-    PIKAHUB_BIN.get_or_init(resolve_pikahub_binary).clone()
-}
-
-fn resolve_pikahub_binary() -> String {
-    // CARGO_BIN_EXE_pikahub is set by cargo when the workspace has a [[bin]] target
-    // named "pikahub" and the test depends on that crate. This handles non-default
-    // target dirs and release profiles correctly.
-    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_pikahub") {
-        if Path::new(&bin).exists() {
-            return bin;
+fn run_async<F, T>(future: F) -> T
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    if tokio::runtime::Handle::try_current().is_ok() {
+        let join = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("create tokio runtime for TestInfra worker");
+            runtime.block_on(future)
+        })
+        .join();
+        match join {
+            Ok(output) => output,
+            Err(_) => panic!("tokio startup worker thread panicked"),
         }
-        eprintln!(
-            "[TestInfra] WARNING: CARGO_BIN_EXE_pikahub points to missing path: {bin}; falling back"
-        );
+    } else {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("create tokio runtime for TestInfra");
+        runtime.block_on(future)
     }
-
-    // Fallback: look relative to the workspace root.
-    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
-    let bin = repo_root.join("target/debug/pikahub");
-
-    let build = Command::new("cargo")
-        .arg("build")
-        .arg("-p")
-        .arg("pikahub")
-        .current_dir(&repo_root)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .unwrap_or_else(|e| panic!("failed to run cargo build -p pikahub: {e}"));
-
-    if !build.status.success() {
-        let stdout = String::from_utf8_lossy(&build.stdout);
-        let stderr = String::from_utf8_lossy(&build.stderr);
-        panic!("cargo build -p pikahub failed:\nstdout: {stdout}\nstderr: {stderr}");
-    }
-
-    assert!(
-        bin.exists(),
-        "pikahub binary not found at {} after build. Build it with: cargo build -p pikahub",
-        bin.display()
-    );
-    bin.to_string_lossy().to_string()
 }


### PR DESCRIPTION
## Summary
- split `crates/pikahub` into a proper lib+bin crate by adding `src/lib.rs` and wiring `main.rs` to import from the library
- keep CLI behavior unchanged while sharing one implementation between CLI and tests
- add `pikahub` as a `pika_core` dev-dependency
- rewrite Rust E2E test infra to call pikahub library APIs directly (`ResolvedConfig::new`, `fixture::up_background`, `Manifest::load`, `fixture::wait`) instead of shelling out to the binary
- add `fixture::down_sync` and use it in `Drop`
- make TestInfra startup runtime-safe when called under an existing Tokio runtime (e.g. `#[tokio::test]`) by running startup futures on a worker thread when needed
- remove binary resolution and auto-build logic from `rust/tests/support/infra.rs`

## Validation
- `cargo check -p pikahub`
- `cargo test -p pikahub`
- `cargo test -p pika_core --test e2e_messaging --no-run`

## Notes
- `just pre-merge-fixture` still depends on local Go relay build/tooling setup in this environment and is not a Rust compile/test regression from this change.
