### PR TITLE
feat: --remote CLI mode via Unix domain socket

### DIFF
--- a/cli/src/remote.rs
+++ b/cli/src/remote.rs
@@ -1,0 +1,73 @@
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, anyhow};
+use pikachat_sidecar::OutMsg;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+/// Send a single JSONL command to the daemon socket, wait for Ok or Error response.
+pub async fn remote_call(
+    state_dir: &Path,
+    cmd_json: serde_json::Value,
+) -> anyhow::Result<serde_json::Value> {
+    let sock_path = state_dir.join("daemon.sock");
+    let stream = UnixStream::connect(&sock_path)
+        .await
+        .with_context(|| format!("connect to daemon at {}", sock_path.display()))?;
+
+    let (reader, mut writer) = stream.into_split();
+
+    // Inject request_id if not present
+    let request_id = format!(
+        "remote-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    );
+    let mut cmd = cmd_json;
+    if let Some(obj) = cmd.as_object_mut() {
+        obj.entry("request_id".to_string())
+            .or_insert(serde_json::Value::String(request_id.clone()));
+    }
+
+    let mut line = serde_json::to_string(&cmd)?;
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await?;
+
+    // Read lines until we get Ok or Error with matching request_id
+    let mut lines = tokio::io::BufReader::new(reader).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let msg: OutMsg = serde_json::from_str(trimmed)
+            .with_context(|| format!("parse daemon response: {trimmed}"))?;
+        match &msg {
+            OutMsg::Ok {
+                request_id: rid,
+                result,
+            } => {
+                if rid.as_deref() == Some(&request_id) {
+                    return Ok(result.clone().unwrap_or(serde_json::Value::Null));
+                }
+            }
+            OutMsg::Error {
+                request_id: rid,
+                code,
+                message,
+            } => {
+                if rid.as_deref() == Some(&request_id) {
+                    return Err(anyhow!("daemon error [{code}]: {message}"));
+                }
+            }
+            _ => {
+                // Ignore broadcast events
+                continue;
+            }
+        }
+    }
+    Err(anyhow!("daemon closed connection without response"))
+}

--- a/crates/pikachat-sidecar/src/lib.rs
+++ b/crates/pikachat-sidecar/src/lib.rs
@@ -5,6 +5,7 @@ mod call_tts;
 pub mod daemon;
 mod relay;
 
+pub use daemon::{DaemonCmd, InCmd, OutMsg};
 pub use pika_marmot_runtime::{
     IdentityFile, PikaMdk, ingest_application_message, ingest_welcome_from_giftwrap,
     load_or_create_keys, new_mdk, open_mdk,


### PR DESCRIPTION
## Summary

Adds a `--remote` global flag to the pikachat CLI that lets one-off commands talk to a running `pikachat daemon` via a Unix domain socket, instead of spinning up their own heavyweight MLS state + relay connections.

## Changes

### Daemon (pikachat-sidecar)
- **Unix socket listener** at `$state_dir/daemon.sock` — accepts JSONL connections alongside the existing stdin reader
- **Per-connection response routing** via a `pending_remotes` map keyed by `request_id`. The stdout writer checks each OutMsg; if its request_id matches a pending remote socket connection, routes it there instead of stdout.
- **New `GetMessages` command** — reads stored messages from the local MLS database (the daemon already had all other needed commands)
- Socket cleanup on startup (stale) and shutdown

### CLI
- **`--remote` global flag** — when set, builds the appropriate JSONL InCmd and sends it to the daemon socket
- **`cli/src/remote.rs`** — lightweight Unix socket client: connect, send JSONL, read responses until Ok/Error
- **Supported remote commands**: `groups`, `welcomes`, `accept-welcome`, `messages`, `send` (text and media via `--group`)

## Usage

```bash
# Terminal 1: start daemon
pikachat daemon

# Terminal 2: use --remote for lightweight commands
pikachat --remote groups
pikachat --remote messages --group <hex-group-id>
pikachat --remote send --group <hex-group-id> --content "hello"
pikachat --remote welcomes
pikachat --remote accept-welcome --wrapper-event-id <hex>
```

## Design Decisions

- **Request-ID routing** rather than broadcast channels — minimal changes to existing daemon code. Socket connections inject a unique request_id if missing, and the stdout writer routes matching responses.
- **One connection per command** — the remote client connects, sends one command, reads the response, disconnects. Simple and stateless.
- `--remote send --to` (peer resolution) is not yet supported since it requires relay lookups; users should use `--group` instead.