### PR TITLE
fix(ios): stabilize chat view scroll/layout with composer focus

### DIFF
--- a/ios/Sources/Views/ChatView.swift
+++ b/ios/Sources/Views/ChatView.swift
@@ -404,6 +404,11 @@ struct ChatView: View {
                         scrollToBottom(using: proxy, animated: false)
                     }
                 }
+                .onChange(of: isInputFocused) { _, focused in
+                    guard focused else { return }
+                    guard shouldStickToBottom else { return }
+                    scrollToBottom(using: proxy, animated: false)
+                }
                 .overlay(alignment: .bottomTrailing) {
                     if !isAtBottom {
                         Button {
@@ -1160,25 +1165,9 @@ private struct FloatingInputBarModifier<Bar: View>: ViewModifier {
     @ViewBuilder var content: Bar
 
     func body(content view: Content) -> some View {
-        #if compiler(>=6.2)
-        if #available(iOS 26.0, *) {
-            view.safeAreaBar(edge: .bottom) { content }
-        } else {
-            view.safeAreaInset(edge: .bottom) {
-                VStack(spacing: 0) {
-                    Divider()
-                    content
-                }
-            }
+        view.safeAreaInset(edge: .bottom, spacing: 0) {
+            content
         }
-        #else
-        view.safeAreaInset(edge: .bottom) {
-            VStack(spacing: 0) {
-                Divider()
-                content
-            }
-        }
-        #endif
     }
 }
 


### PR DESCRIPTION
## Summary
This fixes iOS chat layout jumps when opening a chat and when focusing the composer.

### Changes
- Use `safeAreaInset(edge: .bottom, spacing: 0)` for the chat input bar container in `ChatView`.
- Remove the extra divider above the composer.
- When the composer gains focus, re-anchor to bottom only when sticky mode is active.
- Add UI regression coverage:
  - `testChatLayout_reopenAndFocusComposer_keepsLatestMessageVisible`
  - helper methods for composer lookup + viewport visibility checks.

## Why
The previous iOS 26 chat input bar behavior could intermittently leave a large blank area below content and could jump content too far upward when keyboard focus started.

## Testing
- `./tools/xcode-run xcodebuild -project ios/Pika.xcodeproj -scheme Pika -derivedDataPath ios/build -destination "id=<sim-udid>" test ARCHS=arm64 ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO PIKA_APP_BUNDLE_ID=org.pikachat.pika.dev -only-testing:PikaUITests/PikaUITests/testChatLayout_reopenAndFocusComposer_keepsLatestMessageVisible`

## Related
- Context/troubleshooting issue for stale simulator incremental state: #332
