### PR TITLE
Add paul as pika-build user and fix nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
           outputHashes = {
             "mdk-core-0.6.0" = "sha256-7U9hTItXHOo5VtdvfxwOUo2M22wUnHK4Oi3TlmfjM+4=";
             "moq-lite-0.14.0" = "sha256-CVoVjbuezyC21gl/pEnU/S/2oRaDlvn2st7WBoUnWo8=";
+            "hypernote-mdx-0.3.0" = "sha256-40WIlLAR3MevImSErv9im12ogPd5/oAG6saRiVKpNPY=";
           };
         };
         cargoBuildFlags = [ "-p" "pika-server" ];
@@ -91,9 +92,10 @@
           outputHashes = {
             "mdk-core-0.6.0" = "sha256-7U9hTItXHOo5VtdvfxwOUo2M22wUnHK4Oi3TlmfjM+4=";
             "moq-lite-0.14.0" = "sha256-CVoVjbuezyC21gl/pEnU/S/2oRaDlvn2st7WBoUnWo8=";
+            "hypernote-mdx-0.3.0" = "sha256-40WIlLAR3MevImSErv9im12ogPd5/oAG6saRiVKpNPY=";
           };
         };
-        cargoBuildFlags = [ "-p" "vm-spawner" "-p" "marmotd" ];
+        cargoBuildFlags = [ "-p" "vm-spawner" ];
         doCheck = false;
         nativeBuildInputs = [ serverPkgs.pkg-config ];
         buildInputs = [ serverPkgs.openssl serverPkgs.postgresql.lib ];

--- a/infra/nix/modules/builder.nix
+++ b/infra/nix/modules/builder.nix
@@ -79,7 +79,7 @@ in
 
   # ── Nix settings ──────────────────────────────────────────────────────
   nix.settings = {
-    trusted-users = [ "root" "justin" "ben" ];
+    trusted-users = [ "root" "justin" "ben" "paul" ];
     auto-optimise-store = true;
   };
 
@@ -130,6 +130,13 @@ in
     isNormalUser = true;
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKuWEkTPjRZTq4AH+bw4+vL4KXx1R3GeMfS8SDna0r5f ben@ben-x1"
+    ];
+  };
+
+  users.users.paul = {
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHqbHvWlrXRkTc0403ubkqNE/Ge4YbPvKwWuRBoLPVAW paul@paul.lol"
     ];
   };
 


### PR DESCRIPTION
## Summary
- Add Paul's SSH key and user to pika-build so he can use it as a remote Nix builder
- Add missing `hypernote-mdx-0.3.0` outputHash to fix cargo vendoring
- Remove non-existent `marmotd` from vm-spawner `cargoBuildFlags`

## Test plan
- [x] Deployed to pika-build successfully via `just build-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)