### PR TITLE
pikachat-openclaw: agent tools, remove code fence hypernote parsing

### DIFF
--- a/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/index.ts
+++ b/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/index.ts
@@ -1,5 +1,10 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { pikachatPlugin } from "./src/channel.js";
+import {
+  pikachatPlugin,
+  createSendHypernoteToolFactory,
+  createSendReactionToolFactory,
+  createSubmitHypernoteActionToolFactory,
+} from "./src/channel.js";
 import { pikachatPluginConfigSchema } from "./src/config-schema.js";
 import { setPikachatRuntime } from "./src/runtime.js";
 
@@ -11,6 +16,9 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setPikachatRuntime(api.runtime);
     api.registerChannel({ plugin: pikachatPlugin });
+    api.registerTool(createSendHypernoteToolFactory() as any);
+    api.registerTool(createSendReactionToolFactory() as any);
+    api.registerTool(createSubmitHypernoteActionToolFactory() as any);
   },
 };
 

--- a/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/package.json
+++ b/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/package.json
@@ -10,7 +10,7 @@
     "bech32": "^2.0.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.1.0"
+    "openclaw": ">=2026.2.26"
   },
   "openclaw": {
     "extensions": [

--- a/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/src/types.ts
+++ b/pikachat-openclaw/openclaw/extensions/pikachat-openclaw/src/types.ts
@@ -21,7 +21,9 @@ export function listPikachatAccountIds(cfg: OpenClawConfig): string[] {
       .map((k) => normalizeAccountId(k))
       .filter(Boolean);
     if (ids.length > 0) {
-      return ids.toSorted();
+      // Include default account alongside named accounts
+      const set = new Set([DEFAULT_ACCOUNT_ID, ...ids]);
+      return [...set].toSorted();
     }
   }
   return [DEFAULT_ACCOUNT_ID];


### PR DESCRIPTION
## Summary

- **Register agent tools** (`send_hypernote`, `send_reaction`, `submit_hypernote_action`) via `api.registerTool()` — replaces fragile code-fence parsing where the LLM emitted ` ```pika-hypernote ` blocks
- **Remove `parseHypernoteOutbound` / `sendTextOrHypernote`** — all outbound text now goes through `sidecar.sendMessage()` directly; hypernotes go through the tool
- **Add `agentPrompt` facet** with `messageToolHints()` so the agent knows about available tools
- **Add `status` facet** with `buildAccountSnapshot()` exposing publicKey
- **Inject hypernote catalog** from sidecar into `GroupSystemPrompt` at startup
- **Fix multi-agent** — `listPikachatAccountIds()` now includes `DEFAULT_ACCOUNT_ID` alongside named accounts
- **Preserve pika-html docs** in system prompt (only hypernote code fences were wrong)
- **Bump openclaw peer dep** to `>=2026.2.26`

## Test plan

- [ ] Bot sends hypernotes via `send_hypernote` tool instead of code fences
- [ ] Bot can react to messages via `send_reaction` tool
- [ ] Bot can submit hypernote actions via `submit_hypernote_action` tool
- [ ] pika-html code blocks still work as before
- [ ] Multi-account setup starts both default + named account sidecars
- [ ] Hypernote catalog appears in agent system prompt when sidecar supports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)