### PR TITLE
Fix clippy warnings and enforce workspace-wide clippy in CI

### DIFF
--- a/crates/pika-desktop/src/main.rs
+++ b/crates/pika-desktop/src/main.rs
@@ -130,6 +130,7 @@ pub enum Message {
     WindowEvent(iced::Event),
 }
 
+#[allow(clippy::large_enum_variant)]
 enum DesktopApp {
     BootError {
         error: String,
@@ -262,7 +263,7 @@ impl DesktopApp {
                 Message::Home(message) => {
                     if let Screen::Home(ref mut home_state) = screen {
                         if let Some(event) =
-                            home_state.update(message, state, manager, &cached_profiles)
+                            home_state.update(message, state, manager, cached_profiles)
                         {
                             match event {
                                 screen::home::Event::AppAction(action) => {
@@ -397,13 +398,13 @@ impl DesktopApp {
             } => match screen {
                 Screen::Home(ref home) => home
                     .view(
-                        &state,
-                        &avatar_cache,
-                        &app_version_display,
+                        state,
+                        avatar_cache,
+                        app_version_display,
                         *active_theme_index,
                     )
                     .map(Message::Home),
-                Screen::Login(ref login) => login.view(&state, &manager).map(Message::Login),
+                Screen::Login(ref login) => login.view(state, manager).map(Message::Login),
             },
         }
     }
@@ -449,7 +450,7 @@ impl DesktopApp {
 
                 // Delegate screen-specific sync.
                 if let Screen::Home(ref mut home) = screen {
-                    home.sync_from_update(&state, &latest, manager, &cached_profiles);
+                    home.sync_from_update(state, &latest, manager, cached_profiles);
                 }
 
                 *state = latest;

--- a/crates/pika-desktop/src/views/command_palette.rs
+++ b/crates/pika-desktop/src/views/command_palette.rs
@@ -579,11 +579,11 @@ fn build_snippet(text: &str, query_lower: &str, max_chars: usize) -> String {
 
     let mut snippet = String::new();
     if start > 0 {
-        snippet.push_str("\u{2026}");
+        snippet.push('\u{2026}');
     }
     snippet.push_str(&text[start..end]);
     if end < text.len() {
-        snippet.push_str("\u{2026}");
+        snippet.push('\u{2026}');
     }
     snippet
 }

--- a/crates/pika-desktop/src/views/conversation.rs
+++ b/crates/pika-desktop/src/views/conversation.rs
@@ -29,6 +29,7 @@ pub struct State {
 // ── Messages ────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
+#[allow(clippy::enum_variant_names)]
 pub enum Message {
     MessageChanged(String),
     SendMessage,
@@ -268,6 +269,7 @@ impl State {
         let picture_url = chat.members.first().and_then(|m| m.picture_url.as_deref());
 
         // Call buttons for 1:1 chats
+        #[allow(clippy::type_complexity)]
         let (call_button, video_call_button): (
             Option<Element<'a, Message, Theme>>,
             Option<Element<'a, Message, Theme>>,
@@ -637,9 +639,7 @@ pub fn jump_to_message_task(chat: &ChatViewState, message_id: &str) -> Option<Ta
     if chat.messages.is_empty() {
         return None;
     }
-    let Some(index) = chat.messages.iter().position(|m| m.id == message_id) else {
-        return None;
-    };
+    let index = chat.messages.iter().position(|m| m.id == message_id)?;
     let denom = chat.messages.len().saturating_sub(1) as f32;
     let y = if denom <= 0.0 {
         1.0

--- a/crates/pika-media/examples/duplex_test.rs
+++ b/crates/pika-media/examples/duplex_test.rs
@@ -39,7 +39,7 @@ fn make_keys(label: &str) -> FrameKeyMaterial {
 
 #[cfg(feature = "network")]
 struct Party {
-    name: String,
+    _name: String,
     relay: NetworkRelay,
     tx_track: TrackAddress,
     rx_track: TrackAddress,
@@ -69,7 +69,7 @@ fn main() {
 
     // Alice publishes to alice's broadcast, subscribes to bob's
     let alice = Party {
-        name: "Alice".to_string(),
+        _name: "Alice".to_string(),
         relay: NetworkRelay::new(relay_url).expect("alice relay"),
         tx_track: TrackAddress {
             broadcast_path: format!("{broadcast_base}/{alice_label}"),
@@ -88,7 +88,7 @@ fn main() {
 
     // Bob publishes to bob's broadcast, subscribes to alice's
     let bob = Party {
-        name: "Bob".to_string(),
+        _name: "Bob".to_string(),
         relay: NetworkRelay::new(relay_url).expect("bob relay"),
         tx_track: TrackAddress {
             broadcast_path: format!("{broadcast_base}/{bob_label}"),

--- a/crates/rmp-cli/src/init.rs
+++ b/crates/rmp-cli/src/init.rs
@@ -491,6 +491,7 @@ fn tpl_workspace_toml(include_iced: bool) -> String {
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn tpl_rmp_toml(
     project_name: &str,
     org: &str,

--- a/crates/vm-spawner/src/main.rs
+++ b/crates/vm-spawner/src/main.rs
@@ -47,9 +47,8 @@ async fn main() -> anyhow::Result<()> {
         let mut interval = tokio::time::interval(Duration::from_secs(30));
         loop {
             interval.tick().await;
-            match health_manager.list().await.len() {
-                count => info!(vm_count = count, "vm-spawner health tick"),
-            }
+            let count = health_manager.list().await.len();
+            info!(vm_count = count, "vm-spawner health tick");
         }
     });
 

--- a/crates/vm-spawner/src/manager.rs
+++ b/crates/vm-spawner/src/manager.rs
@@ -943,6 +943,7 @@ fn find_in_path(bin_name: &str) -> Option<PathBuf> {
     None
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_runtime_metadata(
     vm_state_dir: &Path,
     public_key: &str,

--- a/justfile
+++ b/justfile
@@ -218,22 +218,16 @@ fmt:
 
 # Lint with clippy.
 clippy *ARGS:
-    cargo clippy -p pika_core {{ ARGS }} -- -D warnings
+    cargo clippy --all-targets {{ ARGS }} -- -D warnings
 
 # Local pre-commit checks (fmt + clippy + justfile + docs checks).
-pre-commit: fmt
+pre-commit: fmt clippy
     just --fmt --check --unstable
     npx --yes @justinmoon/agent-tools check-docs
     npx --yes @justinmoon/agent-tools check-justfile
-    just clippy --lib --tests
-    cargo clippy -p pikachat --tests -- -D warnings
-    cargo clippy -p pikachat-sidecar --tests -- -D warnings
-    cargo clippy -p pika-server --tests -- -D warnings
-    cargo clippy -p pikahub -- -D warnings
 
 # CI-safe pre-merge for the Pika app lane.
-pre-merge-pika: fmt
-    just clippy --lib --tests
+pre-merge-pika: fmt clippy
     just test --lib --tests
     cd android && ./gradlew :app:compileDebugAndroidTestKotlin
     cargo build -p pikachat


### PR DESCRIPTION
## Summary
- Fix all clippy warnings across the workspace (dead code, needless borrows, single-char push_str, match-as-let, etc.)
- Expand `just clippy` from `pika_core`-only to `--all-targets` (full workspace)
- Wire `clippy` as a dependency of `pre-merge-pika` and `pre-commit` so CI catches regressions

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes cleanly
- [x] `cargo fmt --all --check` passes
- [ ] CI pre-merge-pika lane passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)