### PR TITLE
Clean up storage.rs and fix load_older_messages

### DIFF
--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -229,6 +229,16 @@ impl AppMessageKind {
             Self::TypingIndicator | Self::CallSignal | Self::HypernoteResponse => false,
         }
     }
+
+    /// Whether this kind should be fetched for chat display (messages, reactions,
+    /// hypernotes, and their responses). Excludes ephemeral kinds like typing
+    /// indicators and call signals.
+    fn is_chat_visible(&self) -> bool {
+        match self {
+            Self::Chat | Self::Reaction | Self::Hypernote | Self::HypernoteResponse => true,
+            Self::TypingIndicator | Self::CallSignal => false,
+        }
+    }
 }
 
 fn is_pika_typing_indicator(msg: &message_types::Message) -> bool {
@@ -277,6 +287,19 @@ struct GroupMember {
     pubkey: PublicKey,
     name: Option<String>,
     picture_url: Option<String>,
+}
+
+impl GroupMember {
+    fn to_member_info(&self, admin_pubkeys: &[String]) -> crate::state::MemberInfo {
+        let hex = self.pubkey.to_hex();
+        crate::state::MemberInfo {
+            npub: self.pubkey.to_bech32().unwrap_or_else(|_| hex.clone()),
+            is_admin: admin_pubkeys.contains(&hex),
+            pubkey: hex,
+            name: self.name.clone(),
+            picture_url: self.picture_url.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- Extract shared helpers (`build_sender_names`, `build_member_profiles`, `build_chat_message`, `separate_messages`) to deduplicate code between `refresh_current_chat` and `load_older_messages`
- Add `GroupMember::to_member_info()` to deduplicate MemberInfo mapping
- Fix `load_older_messages` to handle reactions, hypernotes, and hypernote responses (was only filtering `ChatMessage`)
- Use `classify_app_message` / `AppMessageKind` for kind matching instead of raw `Kind` comparisons
- Add `is_chat_visible()` to filter out typing indicators and call signals from pagination batches
- Add 8 new unit tests for `separate_messages`, `build_chat_message`, and `is_chat_visible`
- Minor cleanups: `HashSet` for profile dedup, iterator-based `last_event_tag_id`, rename `dominated` → `is_newer`

## Test plan
- [x] `cargo check` and `cargo clippy` pass
- [x] All 29 storage tests pass (8 new)
- [ ] Verify chat list and message loading work as before on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)