### PR TITLE
Gitignore target symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+target
 target/
 .shared-target/
 

--- a/crates/vm-spawner/src/manager.rs
+++ b/crates/vm-spawner/src/manager.rs
@@ -134,7 +134,7 @@ impl VmManager {
     pub async fn list(&self) -> Vec<PersistedVm> {
         let guard = self.inner.lock().await;
         let mut values: Vec<_> = guard.vms.values().cloned().collect();
-        values.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        values.sort_by_key(|a| a.created_at);
         values
     }
 


### PR DESCRIPTION
## Summary

- `target/` (trailing slash) in `.gitignore` only matches directories, not symlinks. The [shared cargo target setup](docs/shared-cargo-target.md) creates a `target -> .shared-target` symlink, which was showing up as untracked. Adding `target` (no trailing slash) fixes this.
- Also fixes a pre-existing clippy lint in vm-spawner (`sort_by` -> `sort_by_key`).

## Test plan

- [x] `git status` no longer shows `target` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)