### PR TITLE
Fix scroll jitter and add lightweight typing refresh

### DIFF
--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -3646,7 +3646,7 @@ impl AppCore {
                 let my_hex = self.session.as_ref().map(|s| s.pubkey.to_hex());
                 if my_hex.as_deref() != Some(sender_hex.as_str()) {
                     self.update_typing(chat_id, &sender_hex, msg.created_at.as_secs() as i64 + 10);
-                    self.refresh_current_chat_if_open(chat_id);
+                    self.refresh_typing_if_open(chat_id);
                 }
             }
             AppMessageKind::CallSignal => {

--- a/rust/src/core/storage.rs
+++ b/rust/src/core/storage.rs
@@ -335,6 +335,23 @@ impl AppCore {
         }
     }
 
+    /// Lightweight refresh that only updates typing indicators without re-fetching messages.
+    pub(super) fn refresh_typing_if_open(&mut self, chat_id: &str) {
+        let is_open = self
+            .state
+            .current_chat
+            .as_ref()
+            .map(|c| c.chat_id == chat_id)
+            .unwrap_or(false);
+        if is_open {
+            let typing = self.get_active_typers(chat_id);
+            if let Some(cur) = self.state.current_chat.as_mut() {
+                cur.typing_members = typing;
+            }
+            self.emit_current_chat();
+        }
+    }
+
     pub(super) fn refresh_current_chat(&mut self, chat_id: &str) {
         let Some(sess) = self.session.as_ref() else {
             self.state.current_chat = None;


### PR DESCRIPTION
Closes #364 (partial — typing indicator path)

## Summary
- **iOS**: Replace manual diff logic in `InvertedMessageList` with `UITableViewDiffableDataSource` for correct index computation. Only apply snapshots when row IDs actually change to prevent scroll-blocking feedback loops.
- **Rust**: Add `refresh_typing_if_open` for typing indicator updates without re-fetching messages from storage.

## Problem
1. The manual `insertRows`/`deleteRows` diff used wrong indices, causing scroll jitter during pagination
2. `updateUIView` was called on every binding change (including `isAtBottom` during scroll), reapplying the data source snapshot and blocking scrolling
3. Typing indicators triggered a full `refresh_current_chat` which re-fetches all loaded messages from storage

## Test plan
- [x] `cargo clippy` and `cargo test` pass
- [ ] Scrolling is smooth in chats of all sizes
- [ ] Pagination loads older messages without jitter
- [ ] Typing indicators update without lag
- [ ] New messages appear at bottom when at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)