### PR TITLE
Use macos-26 runner for TestFlight CI

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   testflight:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v30


### PR DESCRIPTION
## Summary
- Switches the iOS TestFlight workflow runner from `macos-15` to `macos-26`
- `macos-15` ships Xcode 16.4 which lacks newer APIs used in the codebase (e.g. `allowBluetoothHFP`), causing archive to fail
- `macos-26` has Xcode 26.2 by default

## Test plan
- [ ] Merge and verify the TestFlight workflow succeeds (or manually trigger from Actions tab after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)