### PR TITLE
Desktop: profile picture upload, chat avatars, and avatar rendering fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5798,6 +5798,7 @@ dependencies = [
  "pika_core",
  "rfd",
  "tempfile",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/pika-desktop/Cargo.toml
+++ b/crates/pika-desktop/Cargo.toml
@@ -14,6 +14,7 @@ pika_core = { path = "../../rust" }
 pika-media = { path = "../pika-media" }
 rfd = "0.15"
 base64 = "0.22"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/pika-desktop/src/main.rs
+++ b/crates/pika-desktop/src/main.rs
@@ -26,6 +26,15 @@ pub fn app_version_display() -> String {
 }
 
 pub fn main() -> iced::Result {
+    // Show core tracing output (errors, upload progress, etc.)
+    // Override with RUST_LOG env var, e.g. RUST_LOG=debug
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("pika_core=info,warn")),
+        )
+        .init();
+
     let window_settings = iced::window::Settings {
         size: Size::new(1024.0, 720.0),
         #[cfg(target_os = "macos")]

--- a/crates/pika-desktop/src/screen/home.rs
+++ b/crates/pika-desktop/src/screen/home.rs
@@ -154,8 +154,12 @@ impl State {
 
         // Sync my_profile drafts when profile state updates.
         if let Pane::MyProfile(ref mut profile) = self.pane {
-            if old_state.my_profile.name != new_state.my_profile.name {
+            if old_state.my_profile != new_state.my_profile {
                 profile.sync_profile(&new_state.my_profile);
+            }
+            // After SaveMyProfile completes, dispatch the deferred image upload.
+            if let Some(action) = profile.take_deferred_upload() {
+                manager.dispatch(action);
             }
         }
 
@@ -685,7 +689,27 @@ impl State {
             // ── My profile ────────────────────────────────────────────
             Message::MyProfile(msg) => {
                 if let Pane::MyProfile(ref mut profile_state) = self.pane {
-                    if let Some(event) = profile_state.update(msg) {
+                    let (event, profile_task) = profile_state.update(msg);
+
+                    // Forward iced::Task (e.g. file picker) if produced.
+                    if let Some(task) = profile_task {
+                        let mapped = task.map(Message::MyProfile);
+                        if let Some(event) = event {
+                            // Handle the event first, then return the task.
+                            match event {
+                                views::my_profile::Event::AppAction(action) => {
+                                    manager.dispatch(action);
+                                }
+                                views::my_profile::Event::Logout => {
+                                    return Some(Event::Logout);
+                                }
+                                _ => {}
+                            }
+                        }
+                        return Some(Event::Task(mapped));
+                    }
+
+                    if let Some(event) = event {
                         match event {
                             views::my_profile::Event::AppAction(action) => {
                                 return Some(Event::AppAction(action));

--- a/crates/pika-desktop/src/views/avatar.rs
+++ b/crates/pika-desktop/src/views/avatar.rs
@@ -32,8 +32,13 @@ impl AvatarCache {
         self.handles.clear();
     }
 
-    fn get_or_load(&mut self, path: &str, size: u32) -> Option<image::Handle> {
-        let key = format!("{path}@{size}");
+    fn get_or_load(
+        &mut self,
+        cache_key: &str,
+        file_path: &str,
+        size: u32,
+    ) -> Option<image::Handle> {
+        let key = format!("{cache_key}@{size}");
         if let Some(handle) = self.handles.get(&key) {
             return Some(handle.clone());
         }
@@ -44,7 +49,7 @@ impl AvatarCache {
         }
         self.spent += 1;
 
-        let handle = load_circular_image(path, size)?;
+        let handle = load_circular_image(file_path, size)?;
         self.handles.insert(key, handle.clone());
         Some(handle)
     }
@@ -60,12 +65,14 @@ pub fn avatar_circle<'a, M: 'a>(
     // Render at 2x for HiDPI displays (Retina). The image widget will
     // scale it down to `size` logical pixels, keeping it crisp at 2x.
     let render_px = (size * 2.0) as u32;
-    if let Some(path) = picture_url.and_then(local_path_from_url) {
-        if let Some(handle) = cache.get_or_load(&path, render_px) {
-            return image(handle)
-                .width(Length::Fixed(size))
-                .height(Length::Fixed(size))
-                .into();
+    if let Some(url) = picture_url {
+        if let Some(path) = local_path_from_url(url) {
+            if let Some(handle) = cache.get_or_load(url, &path, render_px) {
+                return image(handle)
+                    .width(Length::Fixed(size))
+                    .height(Length::Fixed(size))
+                    .into();
+            }
         }
     }
 
@@ -112,5 +119,7 @@ fn load_circular_image(path: &str, size: u32) -> Option<image::Handle> {
 }
 
 fn local_path_from_url(url: &str) -> Option<String> {
-    url.strip_prefix("file://").map(|s| s.to_string())
+    let path = url.strip_prefix("file://")?;
+    // Strip `?v=<mtime>` cache-buster appended by display_picture_url.
+    Some(path.split('?').next().unwrap_or(path).to_string())
 }

--- a/crates/pika-desktop/src/views/chat_rail.rs
+++ b/crates/pika-desktop/src/views/chat_rail.rs
@@ -114,11 +114,14 @@ fn chat_item<'a>(
         Space::new().width(0).into()
     };
 
-    let picture_url = chat
-        .members
-        .iter()
-        .find(|m| !m.npub.is_empty())
-        .and_then(|m| m.picture_url.as_deref());
+    let picture_url = if chat.is_group {
+        None
+    } else {
+        chat.members
+            .iter()
+            .find(|m| !m.npub.is_empty())
+            .and_then(|m| m.picture_url.as_deref())
+    };
 
     let avatar: Element<'a, Message, Theme> =
         avatar_circle(Some(&name), picture_url, 48.0, avatar_cache);

--- a/crates/pika-desktop/src/views/conversation.rs
+++ b/crates/pika-desktop/src/views/conversation.rs
@@ -266,7 +266,11 @@ impl State {
             header_info = header_info.push(text(subtitle).size(13).color(theme::text_secondary()));
         }
 
-        let picture_url = chat.members.first().and_then(|m| m.picture_url.as_deref());
+        let picture_url = if chat.is_group {
+            None
+        } else {
+            chat.members.first().and_then(|m| m.picture_url.as_deref())
+        };
 
         // Call buttons for 1:1 chats
         #[allow(clippy::type_complexity)]
@@ -374,6 +378,12 @@ impl State {
         let is_group = chat.is_group;
         let messages_by_id: HashMap<&str, &ChatMessage> =
             chat.messages.iter().map(|m| (m.id.as_str(), m)).collect();
+        // Build a pubkey → picture_url lookup from group members.
+        let member_pics: HashMap<&str, Option<&str>> = chat
+            .members
+            .iter()
+            .map(|m| (m.pubkey.as_str(), m.picture_url.as_deref()))
+            .collect();
         let messages = {
             let mut col = column![].padding([8, 16]);
             let msgs = &chat.messages;
@@ -407,6 +417,10 @@ impl State {
                     .and_then(|id| messages_by_id.get(id).copied());
                 let picker_open = self.emoji_picker_message_id.as_deref() == Some(msg.id.as_str());
                 let hovered = self.hovered_message_id.as_deref() == Some(msg.id.as_str());
+                let sender_pic = member_pics
+                    .get(msg.sender_pubkey.as_str())
+                    .copied()
+                    .flatten();
                 col = col.push(message_bubble(
                     msg,
                     is_group,
@@ -414,6 +428,8 @@ impl State {
                     picker_open,
                     hovered,
                     position,
+                    sender_pic,
+                    avatar_cache,
                 ));
             }
             col

--- a/crates/pika-desktop/src/views/message_bubble.rs
+++ b/crates/pika-desktop/src/views/message_bubble.rs
@@ -1,7 +1,8 @@
 use iced::widget::{button, column, container, image, mouse_area, row, text, Space};
-use iced::{border, Alignment, Background, Color, Element, Fill, Font, Theme};
+use iced::{border, Alignment, Background, Color, Element, Fill, Font, Length, Theme};
 use pika_core::{ChatMediaAttachment, ChatMediaKind, ChatMessage, MessageDeliveryState};
 
+use super::avatar::{avatar_circle, AvatarCache};
 use super::conversation::Message;
 use crate::design::{self, BubblePosition};
 use crate::icons;
@@ -33,6 +34,11 @@ const EMOJI_CHOICES: &[&str] = &[
 /// Layout mirrors Signal desktop: small action icons sit beside the bubble
 /// (to the left for sent messages, to the right for received messages).
 /// Icons only appear on hover. Existing reaction chips render below the bubble.
+/// Width of the avatar gutter (avatar + spacing) to the left of received
+/// messages in group chats. Used for alignment on middle/last messages.
+const AVATAR_GUTTER: f32 = 36.0;
+
+#[allow(clippy::too_many_arguments)]
 pub fn message_bubble<'a>(
     msg: &'a ChatMessage,
     is_group: bool,
@@ -40,6 +46,8 @@ pub fn message_bubble<'a>(
     emoji_picker_open: bool,
     hovered: bool,
     position: BubblePosition,
+    sender_picture_url: Option<&'a str>,
+    avatar_cache: &mut AvatarCache,
 ) -> Element<'a, Message, Theme> {
     let timestamp = theme::relative_time(msg.timestamp);
     let msg_id = msg.id.clone();
@@ -144,7 +152,10 @@ pub fn message_bubble<'a>(
         col.into()
     } else {
         // ── Received: left-aligned ──────────────────────────────
-        // Signal layout: [bubble] [icons] [spacer]
+        // Signal layout: [avatar?] [bubble] [icons] [spacer]
+        let show_avatar =
+            is_group && matches!(position, BubblePosition::First | BubblePosition::Single);
+
         // Only show sender on first/single message in a group
         let sender_name =
             if is_group && !matches!(position, BubblePosition::Middle | BubblePosition::Last) {
@@ -188,10 +199,29 @@ pub fn message_bubble<'a>(
             .max_width(500)
             .style(move |_theme: &Theme| design::current().bubble_received_grouped(position));
 
-        let mut bubble_row = row![bubble]
-            .spacing(6)
-            .align_y(iced::Alignment::Center)
-            .width(Fill);
+        // Build the row: [avatar gutter] [bubble] [icons] [spacer]
+        let mut bubble_row = row![].spacing(6).align_y(Alignment::End).width(Fill);
+
+        if is_group {
+            if show_avatar {
+                let avatar: Element<'a, Message, Theme> = avatar_circle(
+                    msg.sender_name.as_deref(),
+                    sender_picture_url,
+                    28.0,
+                    avatar_cache,
+                );
+                bubble_row = bubble_row.push(
+                    container(avatar)
+                        .width(Length::Fixed(AVATAR_GUTTER))
+                        .align_x(Alignment::Center),
+                );
+            } else {
+                // Reserve space so middle/last messages align with the first.
+                bubble_row = bubble_row.push(Space::new().width(Length::Fixed(AVATAR_GUTTER)));
+            }
+        }
+
+        bubble_row = bubble_row.push(bubble);
 
         // Always reserve space for action icons to prevent layout jumps on hover.
         if show_icons {
@@ -203,10 +233,25 @@ pub fn message_bubble<'a>(
 
         let mut col = column![bubble_row].spacing(2);
         if let Some(chips) = chips_row {
-            col = col.push(chips);
+            if is_group {
+                // Offset chips to align with the bubble (past the avatar gutter).
+                col = col.push(row![
+                    Space::new().width(Length::Fixed(AVATAR_GUTTER + 6.0)),
+                    chips
+                ]);
+            } else {
+                col = col.push(chips);
+            }
         }
         if let Some(p) = picker {
-            col = col.push(p);
+            if is_group {
+                col = col.push(row![
+                    Space::new().width(Length::Fixed(AVATAR_GUTTER + 6.0)),
+                    p
+                ]);
+            } else {
+                col = col.push(p);
+            }
         }
         col.into()
     };

--- a/crates/pika-desktop/src/views/my_profile.rs
+++ b/crates/pika-desktop/src/views/my_profile.rs
@@ -1,5 +1,8 @@
+use std::path::PathBuf;
+
+use base64::Engine as _;
 use iced::widget::{button, column, container, row, rule, text, text_input, Space};
-use iced::{Alignment, Element, Fill, Theme};
+use iced::{Alignment, Element, Fill, Task, Theme};
 use pika_core::{AppAction, MyProfileState};
 
 use crate::icons;
@@ -10,6 +13,21 @@ use crate::views::avatar::avatar_circle;
 pub struct State {
     about: String,
     name: String,
+    confirm_logout: bool,
+    /// Local file path for immediate preview of the picked image.
+    pending_picture_path: Option<String>,
+    /// Image data waiting to be uploaded when Save is clicked.
+    pending_image: Option<PendingImage>,
+    /// Dispatch UploadMyProfileImage once SaveMyProfile completes.
+    upload_after_save: bool,
+    /// True while the Blossom upload + kind-0 publish is in flight.
+    uploading: bool,
+}
+
+#[derive(Debug, Clone)]
+struct PendingImage {
+    image_base64: String,
+    mime_type: String,
 }
 
 #[derive(Debug, Clone)]
@@ -17,8 +35,12 @@ pub enum Message {
     AboutChanged(String),
     CopyAppVersion,
     CopyNpub,
-    Logout,
+    LogoutClicked,
+    LogoutConfirmed,
+    LogoutCancelled,
     NameChanged(String),
+    PickProfileImage,
+    ProfileImagePicked(Vec<PathBuf>),
     Save,
 }
 
@@ -34,28 +56,91 @@ impl State {
         State {
             about: my_profile_state.about.clone(),
             name: my_profile_state.name.clone(),
+            confirm_logout: false,
+            pending_picture_path: None,
+            pending_image: None,
+            upload_after_save: false,
+            uploading: false,
         }
     }
 
-    pub fn update(&mut self, message: Message) -> Option<Event> {
+    pub fn update(&mut self, message: Message) -> (Option<Event>, Option<Task<Message>>) {
         match message {
             Message::AboutChanged(about) => {
                 self.about = about;
             }
-            Message::CopyAppVersion => return Some(Event::CopyAppVersion),
-            Message::CopyNpub => return Some(Event::CopyNpub),
-            Message::Logout => return Some(Event::Logout),
+            Message::CopyAppVersion => return (Some(Event::CopyAppVersion), None),
+            Message::CopyNpub => return (Some(Event::CopyNpub), None),
+            Message::LogoutClicked => {
+                self.confirm_logout = true;
+            }
+            Message::LogoutConfirmed => return (Some(Event::Logout), None),
+            Message::LogoutCancelled => {
+                self.confirm_logout = false;
+            }
             Message::NameChanged(name) => {
                 self.name = name;
             }
+            Message::PickProfileImage => {
+                let task = Task::perform(
+                    async {
+                        let handle = rfd::AsyncFileDialog::new()
+                            .set_title("Choose profile picture")
+                            .add_filter("Images", &["png", "jpg", "jpeg", "webp", "gif"])
+                            .pick_file()
+                            .await;
+                        match handle {
+                            Some(h) => vec![h.path().to_path_buf()],
+                            None => vec![],
+                        }
+                    },
+                    Message::ProfileImagePicked,
+                );
+                return (None, Some(task));
+            }
+            Message::ProfileImagePicked(paths) => {
+                // Store image for upload on Save; show local preview now.
+                if let Some(img) = prepare_profile_image(&paths) {
+                    if let Some(path) = paths.first() {
+                        self.pending_picture_path =
+                            Some(format!("file://{}", path.to_string_lossy()));
+                    }
+                    self.pending_image = Some(img);
+                }
+            }
             Message::Save => {
-                return Some(Event::AppAction(AppAction::SaveMyProfile {
-                    name: self.name.clone(),
-                    about: self.about.clone(),
-                }));
+                if self.pending_image.is_some() {
+                    // Save name/about first; the deferred upload fires
+                    // after the save completes (see take_deferred_upload).
+                    self.upload_after_save = true;
+                    self.uploading = true;
+                }
+                return (
+                    Some(Event::AppAction(AppAction::SaveMyProfile {
+                        name: self.name.clone(),
+                        about: self.about.clone(),
+                    })),
+                    None,
+                );
             }
         }
 
+        (None, None)
+    }
+
+    /// Called by home when any state change is detected while the profile pane
+    /// is open. Returns an upload action to dispatch if a deferred upload is
+    /// ready (i.e. SaveMyProfile just completed).
+    pub fn take_deferred_upload(&mut self) -> Option<AppAction> {
+        if self.upload_after_save {
+            self.upload_after_save = false;
+            if let Some(img) = self.pending_image.take() {
+                return Some(AppAction::UploadMyProfileImage {
+                    image_base64: img.image_base64,
+                    mime_type: img.mime_type,
+                });
+            }
+        }
         None
     }
 
@@ -63,6 +148,11 @@ impl State {
     pub fn sync_profile(&mut self, profile: &MyProfileState) {
         self.name = profile.name.clone();
         self.about = profile.about.clone();
+        // Upload completed — backend now has the picture.
+        if profile.picture_url.is_some() && self.pending_image.is_none() {
+            self.pending_picture_path = None;
+            self.uploading = false;
+        }
     }
 
     pub fn view<'a>(
@@ -87,22 +177,54 @@ impl State {
             .padding([16, 0]),
         );
 
-        // ── Avatar (centered) ────────────────────────────────────────
+        // ── Avatar (clickable to change) ─────────────────────────────
         let display_name = if self.name.is_empty() {
             "Me"
         } else {
             self.name.as_str()
         };
+        let effective_picture = self.pending_picture_path.as_deref().or(picture_url);
+
+        let avatar_label = if self.uploading {
+            text("Uploading\u{2026}")
+                .size(12)
+                .color(theme::text_secondary())
+        } else {
+            text("Change photo").size(12).color(theme::accent_blue())
+        };
+
+        let avatar_button = button(
+            column![
+                avatar_circle(Some(display_name), effective_picture, 80.0, avatar_cache,),
+                avatar_label,
+            ]
+            .spacing(4)
+            .align_x(Alignment::Center),
+        )
+        .padding(4)
+        .style(|_: &Theme, status: button::Status| {
+            let bg = match status {
+                button::Status::Hovered => theme::hover_bg(),
+                _ => iced::Color::TRANSPARENT,
+            };
+            button::Style {
+                background: Some(iced::Background::Color(bg)),
+                border: iced::border::rounded(12),
+                ..Default::default()
+            }
+        });
+
+        let avatar_button = if self.uploading {
+            avatar_button
+        } else {
+            avatar_button.on_press(Message::PickProfileImage)
+        };
+
         content = content.push(
-            container(avatar_circle(
-                Some(display_name),
-                picture_url,
-                80.0,
-                avatar_cache,
-            ))
-            .width(Fill)
-            .center_x(Fill)
-            .padding([8, 0]),
+            container(avatar_button)
+                .width(Fill)
+                .center_x(Fill)
+                .padding([8, 0]),
         );
 
         // ── Name field (icon + input row) ────────────────────────────
@@ -122,16 +244,22 @@ impl State {
         ));
 
         // ── Save button ──────────────────────────────────────────────
+        let save_button =
+            button(text("Save Changes").size(14).font(icons::MEDIUM).center()).padding([10, 24]);
+
+        let save_button = if self.uploading {
+            save_button.style(theme::secondary_button_style)
+        } else {
+            save_button
+                .on_press(Message::Save)
+                .style(theme::primary_button_style)
+        };
+
         content = content.push(
-            container(
-                button(text("Save Changes").size(14).font(icons::MEDIUM).center())
-                    .on_press(Message::Save)
-                    .padding([10, 24])
-                    .style(theme::primary_button_style),
-            )
-            .width(Fill)
-            .center_x(Fill)
-            .padding([8, 24]),
+            container(save_button)
+                .width(Fill)
+                .center_x(Fill)
+                .padding([8, 24]),
         );
 
         content = content.push(container(rule::horizontal(1)).padding([8, 24]));
@@ -198,36 +326,69 @@ impl State {
 
         content = content.push(container(rule::horizontal(1)).padding([8, 24]));
 
-        // ── Logout (danger row) ──────────────────────────────────────
+        // ── Logout ────────────────────────────────────────────────────
         content = content.push(Space::new().height(Fill));
 
-        content = content.push(
-            button(
-                row![
-                    text(icons::LOG_OUT)
-                        .font(icons::LUCIDE_FONT)
-                        .size(18)
-                        .color(theme::danger()),
-                    text("Logout").size(14).color(theme::danger()),
-                ]
-                .spacing(12)
-                .align_y(Alignment::Center),
-            )
-            .on_press(Message::Logout)
-            .width(Fill)
-            .padding([12, 24])
-            .style(|_: &Theme, status: button::Status| {
-                let bg = match status {
-                    button::Status::Hovered => theme::hover_bg(),
-                    _ => iced::Color::TRANSPARENT,
-                };
-                button::Style {
-                    background: Some(iced::Background::Color(bg)),
-                    text_color: theme::danger(),
-                    ..Default::default()
-                }
-            }),
-        );
+        if self.confirm_logout {
+            content = content.push(
+                container(
+                    row![
+                        text("Log out?").size(14).color(theme::text_secondary()),
+                        Space::new().width(Fill),
+                        button(text("Cancel").size(13).center())
+                            .on_press(Message::LogoutCancelled)
+                            .padding([8, 16])
+                            .style(theme::secondary_button_style),
+                        button(text("Log out").size(13).center())
+                            .on_press(Message::LogoutConfirmed)
+                            .padding([8, 16])
+                            .style(|_: &Theme, status: button::Status| {
+                                let bg = match status {
+                                    button::Status::Hovered => theme::danger().scale_alpha(0.85),
+                                    _ => theme::danger(),
+                                };
+                                button::Style {
+                                    background: Some(iced::Background::Color(bg)),
+                                    text_color: iced::Color::WHITE,
+                                    border: iced::border::rounded(8),
+                                    ..Default::default()
+                                }
+                            }),
+                    ]
+                    .spacing(8)
+                    .align_y(Alignment::Center),
+                )
+                .padding([12, 24]),
+            );
+        } else {
+            content = content.push(
+                button(
+                    row![
+                        text(icons::LOG_OUT)
+                            .font(icons::LUCIDE_FONT)
+                            .size(18)
+                            .color(theme::danger()),
+                        text("Logout").size(14).color(theme::danger()),
+                    ]
+                    .spacing(12)
+                    .align_y(Alignment::Center),
+                )
+                .on_press(Message::LogoutClicked)
+                .width(Fill)
+                .padding([12, 24])
+                .style(|_: &Theme, status: button::Status| {
+                    let bg = match status {
+                        button::Status::Hovered => theme::hover_bg(),
+                        _ => iced::Color::TRANSPARENT,
+                    };
+                    button::Style {
+                        background: Some(iced::Background::Color(bg)),
+                        text_color: theme::danger(),
+                        ..Default::default()
+                    }
+                }),
+            );
+        }
 
         container(content)
             .width(Fill)
@@ -239,7 +400,6 @@ impl State {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-/// Signal-style ghost row: transparent by default, subtle hover bg.
 fn ghost_row_style(_theme: &Theme, status: button::Status) -> button::Style {
     let bg = match status {
         button::Status::Hovered => theme::hover_bg(),
@@ -252,7 +412,36 @@ fn ghost_row_style(_theme: &Theme, status: button::Status) -> button::Style {
     }
 }
 
-/// Icon + text_input row for editable fields.
+/// Read an image file and prepare base64 + mime type for later upload.
+fn prepare_profile_image(paths: &[PathBuf]) -> Option<PendingImage> {
+    let path = paths.first()?;
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("[pfp] failed to read {}: {e}", path.display());
+            return None;
+        }
+    };
+    let ext = path
+        .extension()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_lowercase();
+    let mime_type = match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        _ => "image/jpeg",
+    }
+    .to_string();
+    let image_base64 = base64::engine::general_purpose::STANDARD.encode(&data);
+    Some(PendingImage {
+        image_base64,
+        mime_type,
+    })
+}
+
 fn icon_input_row<'a>(
     icon_cp: &'a str,
     placeholder: &'a str,


### PR DESCRIPTION
- Add profile picture upload to the desktop profile page. Users can pick an image which previews immediately; the Blossom upload + kind-0 publish is deferred until Save Changes is clicked (save name/about first, then upload). Save button and avatar picker are disabled during upload.

- Render profile pictures next to received messages in group chats using a 28px avatar circle aligned to the left of the bubble gutter.

- Fix avatar rendering bug: strip ?v=<mtime> query parameter from file:// URLs before passing to std::fs::read. The cache key still uses the full URL so mtime changes bust the decode cache correctly.

- Use initial-letter fallback for group chat avatars in the sidebar and conversation header instead of a random member's picture.

- Add logout confirmation dialog to the profile page.

- Add tracing-subscriber so core log output is visible when running the desktop app from a terminal.