### PR TITLE
Skip App Store encryption compliance dialog

### DIFF
--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -69,6 +69,8 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
## Summary
- Sets `ITSAppUsesNonExemptEncryption=false` in `ios/Info.plist`
- Pika uses standard IETF algorithms (MLS) not built into iOS, and does not distribute in France
- Per [Apple's export compliance docs](https://developer.apple.com/help/app-store-connect/reference/app-information/export-compliance-documentation-for-encryption), this means no documentation is required in App Store Connect
- This eliminates the manual "App Encryption Documentation" dialog on every TestFlight upload

## Test plan
- [ ] Upload a build to TestFlight and confirm the encryption compliance dialog no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)