### PR TITLE
Remove x86_64 iOS simulator target

### DIFF
--- a/crates/rmp-cli/src/bindings.rs
+++ b/crates/rmp-cli/src/bindings.rs
@@ -538,38 +538,6 @@ fn build_ios_xcframework(
     }
 
     let mut libraries: Vec<PathBuf> = vec![];
-    let has_sim_arm64 = selected.contains(&"aarch64-apple-ios-sim");
-    let has_sim_x86_64 = selected.contains(&"x86_64-apple-ios");
-    if has_sim_arm64 && has_sim_x86_64 {
-        let sim_a = build_dir.join(format!("lib{core_lib}_sim.a"));
-        let status = Command::new("/usr/bin/xcrun")
-            .env("DEVELOPER_DIR", &dev_dir)
-            .arg("lipo")
-            .arg("-create")
-            .arg(ios_staticlib_path(
-                root,
-                "aarch64-apple-ios-sim",
-                core_lib,
-                profile,
-            ))
-            .arg(ios_staticlib_path(
-                root,
-                "x86_64-apple-ios",
-                core_lib,
-                profile,
-            ))
-            .arg("-output")
-            .arg(&sim_a)
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .status()
-            .map_err(|e| CliError::operational(format!("failed to run lipo: {e}")))?;
-        if !status.success() {
-            return Err(CliError::operational("lipo failed"));
-        }
-        libraries.push(sim_a);
-        selected.retain(|t| *t != "aarch64-apple-ios-sim" && *t != "x86_64-apple-ios");
-    }
     for target in selected {
         libraries.push(ios_staticlib_path(root, target, core_lib, profile));
     }
@@ -663,9 +631,7 @@ fn build_ios_staticlibs(
     for target in targets {
         let (sdkroot, min_flag) = match *target {
             "aarch64-apple-ios" => (sdk_ios.as_str(), "-miphoneos-version-min="),
-            "aarch64-apple-ios-sim" | "x86_64-apple-ios" => {
-                (sdk_sim.as_str(), "-mios-simulator-version-min=")
-            }
+            "aarch64-apple-ios-sim" => (sdk_sim.as_str(), "-mios-simulator-version-min="),
             _ => {
                 return Err(CliError::user(format!(
                     "unsupported iOS Rust target: {target}"
@@ -722,9 +688,6 @@ fn build_ios_staticlibs(
             }
             "aarch64-apple-ios-sim" => {
                 cmd.env("CARGO_TARGET_AARCH64_APPLE_IOS_SIM_LINKER", &cc);
-            }
-            "x86_64-apple-ios" => {
-                cmd.env("CARGO_TARGET_X86_64_APPLE_IOS_LINKER", &cc);
             }
             _ => {}
         }

--- a/crates/rmp-cli/src/init.rs
+++ b/crates/rmp-cli/src/init.rs
@@ -675,7 +675,6 @@ fn tpl_flake_nix() -> String {
             "x86_64-linux-android"
             "aarch64-apple-ios"
             "aarch64-apple-ios-sim"
-            "x86_64-apple-ios"
           ];
         };
 

--- a/crates/rmp-cli/src/run.rs
+++ b/crates/rmp-cli/src/run.rs
@@ -887,7 +887,6 @@ fn default_iced_package_name(project_name: &str) -> String {
 fn ios_sim_target_for_host() -> Result<(&'static str, &'static str), CliError> {
     match std::env::consts::ARCH {
         "aarch64" => Ok(("aarch64-apple-ios-sim", "arm64")),
-        "x86_64" => Ok(("x86_64-apple-ios", "x86_64")),
         arch => Err(CliError::operational(format!(
             "unsupported host arch for iOS simulator builds: {arch}"
         ))),

--- a/flake.nix
+++ b/flake.nix
@@ -165,7 +165,6 @@
             "x86_64-linux-android"
             "aarch64-apple-ios"
             "aarch64-apple-ios-sim"
-            "x86_64-apple-ios"
           ];
         };
 

--- a/justfile
+++ b/justfile
@@ -576,12 +576,11 @@ ios-rust:
     base_env=(env -u LIBRARY_PATH -u SDKROOT -u MACOSX_DEPLOYMENT_TARGET -u CC -u CXX -u AR -u RANLIB -u LD \
       DEVELOPER_DIR="$DEV_DIR" CC="$CC_BIN" CXX="$CXX_BIN" AR="$AR_BIN" RANLIB="$RANLIB_BIN" IPHONEOS_DEPLOYMENT_TARGET="$IOS_MIN" \
       CARGO_TARGET_AARCH64_APPLE_IOS_LINKER="$CC_BIN" \
-      CARGO_TARGET_AARCH64_APPLE_IOS_SIM_LINKER="$CC_BIN" \
-      CARGO_TARGET_X86_64_APPLE_IOS_LINKER="$CC_BIN"); \
+      CARGO_TARGET_AARCH64_APPLE_IOS_SIM_LINKER="$CC_BIN"); \
     for target in $TARGETS; do \
       case "$target" in \
         aarch64-apple-ios) SDKROOT="$SDKROOT_IOS"; MIN_FLAG="-miphoneos-version-min=" ;; \
-        aarch64-apple-ios-sim|x86_64-apple-ios) SDKROOT="$SDKROOT_SIM"; MIN_FLAG="-mios-simulator-version-min=" ;; \
+        aarch64-apple-ios-sim) SDKROOT="$SDKROOT_SIM"; MIN_FLAG="-mios-simulator-version-min=" ;; \
         *) echo "error: unsupported iOS Rust target: $target"; exit 2 ;; \
       esac; \
       if [ "$PROFILE" = "release" ]; then \
@@ -641,7 +640,7 @@ ios-appstore: ios-xcframework ios-xcodeproj
 
 # Build iOS app for simulator.
 ios-build-sim: ios-xcframework ios-xcodeproj
-    SIM_ARCH="${PIKA_IOS_SIM_ARCH:-$( [ "$(uname -m)" = "x86_64" ] && echo x86_64 || echo arm64 )}"; \
+    SIM_ARCH="${PIKA_IOS_SIM_ARCH:-arm64}"; \
     ./tools/xcode-run xcodebuild -project ios/Pika.xcodeproj -scheme Pika -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build build ARCHS="$SIM_ARCH" ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO PIKA_APP_BUNDLE_ID="${PIKA_IOS_BUNDLE_ID:-org.pikachat.pika.dev}" PIKA_IOS_URL_SCHEME="${PIKA_IOS_URL_SCHEME:-pika}"
 
 # Run iOS UI tests on simulator (skips E2E deployed-bot test).

--- a/tools/run-ios
+++ b/tools/run-ios
@@ -383,18 +383,10 @@ fi
 
 # Faster dev loop defaults: debug Rust and only the required simulator target.
 if [ -z "${PIKA_IOS_SIM_ARCH:-}" ]; then
-  if [ "$(uname -m)" = "x86_64" ]; then
-    export PIKA_IOS_SIM_ARCH="x86_64"
-  else
-    export PIKA_IOS_SIM_ARCH="arm64"
-  fi
+  export PIKA_IOS_SIM_ARCH="arm64"
 fi
 if [ -z "${PIKA_IOS_RUST_TARGETS:-}" ]; then
-  if [ "$PIKA_IOS_SIM_ARCH" = "x86_64" ]; then
-    export PIKA_IOS_RUST_TARGETS="x86_64-apple-ios"
-  else
-    export PIKA_IOS_RUST_TARGETS="aarch64-apple-ios-sim"
-  fi
+  export PIKA_IOS_RUST_TARGETS="aarch64-apple-ios-sim"
 fi
 
 just ios-build-sim


### PR DESCRIPTION
## Summary
- Removes `x86_64-apple-ios` target from all build paths — no devs are on Intel Macs
- Cleaned up: `justfile`, `tools/run-ios`, `flake.nix`, `rmp-cli` (bindings, init template, run)
- Drops the `lipo` fat binary step in rmp-cli that merged arm64+x86_64 simulator slices
- 6 files changed, 55 lines deleted

## Test plan
- [ ] `just ios-build-sim` still works (arm64 simulator)
- [ ] `just run-ios` still works
- [ ] `nix develop` still provides the Rust toolchain with correct targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)