### PR TITLE
Add pressed state to chat list rows

### DIFF
--- a/ios/Sources/Views/ChatListView.swift
+++ b/ios/Sources/Views/ChatListView.swift
@@ -59,7 +59,7 @@ struct ChatListView: View {
                     row
                 }
             }
-            .buttonStyle(.plain)
+            .tint(.primary)
             .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                 Button(role: .destructive) {
                     onArchiveChat(chat.chatId)


### PR DESCRIPTION
## Summary
- Replace `.buttonStyle(.plain)` with `.tint(.primary)` on chat list row buttons
- Gives rows the standard iOS tap highlight while keeping text colors neutral

## Test plan
- [ ] Tap a chat row and verify you see a pressed highlight
- [ ] Verify text colors look the same as before (not accent-tinted)
- [ ] Verify swipe-to-archive still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)