### PR TITLE
Fix iOS device builds

### DIFF
--- a/ios/Pika.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Pika.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "d924c62a70fca5f43872f286dbd7cef0957f1c01",
-        "version" : "1.6.0"
+        "revision" : "4f47ebafed5f0b0172cf5c661454fa8e28fb2ac4",
+        "version" : "2.0.9"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -27,7 +27,7 @@ packages:
     from: "2.4.0"
   Perception:
     url: https://github.com/pointfreeco/swift-perception
-    from: "1.0.0"
+    from: "2.0.0"
 
 targets:
   Pika:

--- a/tools/pika-run
+++ b/tools/pika-run
@@ -130,12 +130,10 @@ def ios_connected_devices() -> List[Dict[str, Any]]:
         if ln.strip() == "== Devices ==":
             in_devices = True
             continue
-        if ln.strip() == "== Simulators ==":
+        if ln.strip() in ("== Simulators ==", "== Devices Offline =="):
             in_devices = False
             continue
         if not in_devices:
-            continue
-        if "iPhone" not in ln and "iPad" not in ln:
             continue
         m = _XCTRACE_LINE_RE.match(ln.strip())
         if not m:

--- a/tools/run-ios
+++ b/tools/run-ios
@@ -100,10 +100,12 @@ callback_scheme_for_bundle_id() {
 }
 
 list_connected_iphones() {
+  # Match lines with two sets of parentheses: (OS version) (UDID).
+  # This excludes Macs which only have (UDID).
   ./tools/xcode-run xcrun xctrace list devices 2>/dev/null | awk '
     $0 == "== Devices ==" { in_devices = 1; next }
-    $0 == "== Simulators ==" { in_devices = 0; next }
-    in_devices && $0 ~ /iPhone/ {
+    $0 == "== Simulators ==" || $0 == "== Devices Offline ==" { in_devices = 0; next }
+    in_devices && /\([0-9]+\.[0-9]+/ && /\([0-9A-Fa-f-]{25,}\)/ {
       print $0
     }
   '


### PR DESCRIPTION
## Summary
- Update swift-perception from 1.x to 2.x (resolves to 2.0.9) for Xcode 26.3 / Swift 6.2.4 compatibility, fixing the `Macro "PerceptionMacros" must be enabled` build error
- Fix device detection in `tools/pika-run` and `tools/run-ios` to handle custom-named devices (e.g. "Paulphone Air") and skip the `== Devices Offline ==` xctrace section

## Test plan
- [x] `xcodebuild` device build succeeds (BUILD SUCCEEDED)
- [x] App installs and launches on physical iPhone Air
- [x] `./tools/pika-run ios list-targets` correctly shows only connected devices
- [x] `just run-ios --device` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)