### PR TITLE
Fix iOS TestFlight CI: skip macro validation

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -41,6 +41,7 @@ jobs:
             -configuration Release \
             -archivePath "$RUNNER_TEMP/Pika.xcarchive" \
             -destination "generic/platform=iOS" \
+            -skipMacroValidation \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
             PIKA_APP_BUNDLE_ID=org.pikachat.pika \
             CODE_SIGN_STYLE=Automatic \


### PR DESCRIPTION
## Summary
- Add `-skipMacroValidation` to the `xcodebuild archive` step in the TestFlight workflow
- Fixes `PerceptionMacros` "must be enabled before it can be used" error on CI runners that can't interactively trust Swift macro packages
- The justfile already uses this flag for `ios-build-sim` and `ios-ui-test`; this aligns the TestFlight archive step

## Test plan
- [ ] Verify the TestFlight workflow passes on the next push to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)