### PR TITLE
pika-news: fix stuck pending tasks and improve reliability

### DIFF
--- a/crates/pika-news/src/main.rs
+++ b/crates/pika-news/src/main.rs
@@ -24,6 +24,14 @@ fn main() -> anyhow::Result<()> {
             let store = storage::Store::open(&args.db).context("initialize sqlite storage")?;
             let max_prs = args.max_prs;
             let bind_addr = args.bind_with_config(&config.bind_address, config.bind_port);
+
+            // Recover artifacts stuck in 'generating' from a previous unclean shutdown.
+            match store.recover_stale_generating() {
+                Ok(0) => {}
+                Ok(n) => eprintln!("recovered {} stale generating artifact(s)", n),
+                Err(err) => eprintln!("warning: failed to recover stale generating: {}", err),
+            }
+
             println!(
                 "serve: bind={} db={} repos={} poll_interval={}s model={}",
                 bind_addr,

--- a/crates/pika-news/src/model.rs
+++ b/crates/pika-news/src/model.rs
@@ -57,17 +57,24 @@ pub fn generate_with_anthropic(
 
     let stdout = run_claude_cli(
         &[
+            "-p",
             "--model",
             model,
             "--output-format",
             "json",
             "--max-turns",
             "1",
+            "--tools",
+            "",
         ],
         Some(&prompt),
     )?;
     let envelope: ClaudeCliResponse = serde_json::from_str(&stdout).map_err(|err| {
-        GenerationError::RetrySafe(format!("parse claude CLI JSON envelope: {}", err))
+        let prefix = truncate(&stdout, 200);
+        GenerationError::RetrySafe(format!(
+            "parse claude CLI JSON envelope: {} (stdout prefix: {})",
+            err, prefix
+        ))
     })?;
 
     if envelope.is_error {
@@ -77,7 +84,21 @@ pub fn generate_with_anthropic(
         )));
     }
 
-    let tutorial = parse_and_validate_tutorial(&envelope.result)?;
+    if envelope.subtype.as_deref() == Some("error_max_turns") {
+        return Err(GenerationError::RetrySafe(
+            "claude CLI hit max turns limit".to_string(),
+        ));
+    }
+
+    let tutorial = parse_and_validate_tutorial(&envelope.result).map_err(|err| {
+        let prefix = truncate(&envelope.result, 300);
+        match err {
+            GenerationError::RetrySafe(msg) => {
+                GenerationError::RetrySafe(format!("{} (result prefix: {})", msg, prefix))
+            }
+            other => other,
+        }
+    })?;
     Ok(GenerationOutput {
         tutorial,
         session_id: envelope.session_id,
@@ -90,6 +111,7 @@ pub fn chat_with_session(
 ) -> Result<ChatResponse, GenerationError> {
     let stdout = run_claude_cli(
         &[
+            "-p",
             "-r",
             base_session_id,
             "--output-format",
@@ -122,9 +144,14 @@ pub struct ChatResponse {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct ClaudeCliResponse {
+    #[serde(default)]
     result: String,
+    #[serde(default)]
     is_error: bool,
+    #[serde(default)]
+    subtype: Option<String>,
     session_id: Option<String>,
 }
 
@@ -227,6 +254,8 @@ fn validate_step(index: usize, step: &TutorialStep) -> Result<(), GenerationErro
 
 fn extract_json_payload(raw_output: &str) -> String {
     let trimmed = raw_output.trim();
+
+    // Try: output starts with ```json fence
     if let Some(rest) = trimmed.strip_prefix("```") {
         let without_lang = rest
             .strip_prefix("json")
@@ -237,6 +266,43 @@ fn extract_json_payload(raw_output: &str) -> String {
             return inner.trim().to_string();
         }
     }
+
+    // Try: find ```json ... ``` anywhere in the output (model often prefixes with prose)
+    if let Some(fence_start) = trimmed.find("```json") {
+        let after_fence = &trimmed[fence_start + 7..];
+        let content = after_fence.trim_start_matches('\n');
+        if let Some(fence_end) = content.find("```") {
+            return content[..fence_end].trim().to_string();
+        }
+    }
+    if let Some(fence_start) = trimmed.find("```JSON") {
+        let after_fence = &trimmed[fence_start + 7..];
+        let content = after_fence.trim_start_matches('\n');
+        if let Some(fence_end) = content.find("```") {
+            return content[..fence_end].trim().to_string();
+        }
+    }
+
+    // Try: find bare ``` ... ``` block
+    if let Some(fence_start) = trimmed.find("```\n") {
+        let after_fence = &trimmed[fence_start + 4..];
+        if let Some(fence_end) = after_fence.find("```") {
+            let inner = after_fence[..fence_end].trim();
+            if inner.starts_with('{') {
+                return inner.to_string();
+            }
+        }
+    }
+
+    // Try: extract outermost JSON object by finding first { and last }
+    if let Some(start) = trimmed.find('{') {
+        if let Some(end) = trimmed.rfind('}') {
+            if end > start {
+                return trimmed[start..=end].to_string();
+            }
+        }
+    }
+
     trimmed.to_string()
 }
 
@@ -291,6 +357,21 @@ mod tests {
             "```json\n{\"executive_summary\":\"ok\",\"media_links\":[],\"steps\":[]}\n```",
         );
         assert!(payload.starts_with('{'));
+    }
+
+    #[test]
+    fn extracts_json_with_prose_prefix() {
+        let payload = extract_json_payload(
+            "Here is the PR tutorial JSON:\n\n```json\n{\"executive_summary\":\"ok\"}\n```",
+        );
+        assert_eq!(payload, "{\"executive_summary\":\"ok\"}");
+    }
+
+    #[test]
+    fn extracts_json_from_bare_braces() {
+        let payload =
+            extract_json_payload("Sure, here is the tutorial:\n{\"executive_summary\":\"ok\"}");
+        assert_eq!(payload, "{\"executive_summary\":\"ok\"}");
     }
 
     #[test]

--- a/crates/pika-news/src/storage.rs
+++ b/crates/pika-news/src/storage.rs
@@ -335,6 +335,22 @@ impl Store {
             .context("query PR detail")
         })
     }
+    /// Reset any artifacts stuck in `generating` state back to `pending`.
+    /// Called on startup to recover from unclean shutdowns.
+    pub fn recover_stale_generating(&self) -> anyhow::Result<usize> {
+        self.with_connection(|conn| {
+            let rows = conn
+                .execute(
+                    "UPDATE generated_artifacts
+                     SET status='pending', updated_at=CURRENT_TIMESTAMP
+                     WHERE status='generating'",
+                    [],
+                )
+                .context("recover stale generating artifacts")?;
+            Ok(rows)
+        })
+    }
+
     pub fn reset_artifact_to_pending(&self, pr_id: i64) -> anyhow::Result<bool> {
         self.with_connection(|conn| {
             let rows = conn
@@ -813,5 +829,50 @@ mod tests {
             .expect("reclaim pending job");
         assert_eq!(reclaimed.len(), 1);
         assert_eq!(reclaimed[0].artifact_id, artifact_id);
+    }
+
+    #[test]
+    fn recover_stale_generating_resets_to_pending() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let db_path = dir.path().join("pika-news.db");
+        let store = Store::open(&db_path).expect("open store");
+
+        let input = PrUpsertInput {
+            repo: "sledtools/pika".to_string(),
+            pr_number: 99,
+            title: "Stuck generating".to_string(),
+            url: "https://github.com/sledtools/pika/pull/99".to_string(),
+            state: "merged".to_string(),
+            head_sha: "stuck-sha".to_string(),
+            base_ref: "master".to_string(),
+            author_login: Some("bob".to_string()),
+            updated_at: "2026-03-03T00:00:00Z".to_string(),
+            merged_at: Some("2026-03-03T00:00:00Z".to_string()),
+        };
+        store.upsert_pull_request(&input).expect("upsert PR");
+
+        // Claim the job (moves to 'generating')
+        let claimed = store
+            .claim_pending_generation_jobs(1)
+            .expect("claim pending job");
+        assert_eq!(claimed.len(), 1);
+
+        // Verify it's now generating and not claimable
+        let empty = store
+            .claim_pending_generation_jobs(1)
+            .expect("try claim again");
+        assert_eq!(empty.len(), 0);
+
+        // Recover stale generating items
+        let recovered = store
+            .recover_stale_generating()
+            .expect("recover stale generating");
+        assert_eq!(recovered, 1);
+
+        // Now it should be claimable again
+        let reclaimed = store
+            .claim_pending_generation_jobs(1)
+            .expect("reclaim after recovery");
+        assert_eq!(reclaimed.len(), 1);
     }
 }

--- a/crates/pika-news/src/web.rs
+++ b/crates/pika-news/src/web.rs
@@ -107,11 +107,32 @@ pub async fn serve(
             .await
             {
                 Ok((poll_result, worker_result)) => {
-                    if let Err(err) = poll_result {
-                        eprintln!("pika-news background poller error: {}", err);
+                    match poll_result {
+                        Ok(pr) if pr.prs_seen > 0 || pr.queued_regenerations > 0 => {
+                            eprintln!(
+                                "poll: repos={} prs_seen={} queued={} head_changes={}",
+                                pr.repos_polled,
+                                pr.prs_seen,
+                                pr.queued_regenerations,
+                                pr.head_sha_changes
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(err) => {
+                            eprintln!("pika-news background poller error: {}", err);
+                        }
                     }
-                    if let Err(err) = worker_result {
-                        eprintln!("pika-news background worker error: {}", err);
+                    match worker_result {
+                        Ok(wr) if wr.claimed > 0 => {
+                            eprintln!(
+                                "worker: claimed={} ready={} failed={} retry={}",
+                                wr.claimed, wr.ready, wr.failed, wr.retry_scheduled
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(err) => {
+                            eprintln!("pika-news background worker error: {}", err);
+                        }
                     }
                 }
                 Err(err) => {


### PR DESCRIPTION
## Summary
- Fix stale `generating` artifacts never recovering after service restart by adding startup recovery
- Fix Claude CLI tool usage causing `error_max_turns` by passing `--tools ""` and `-p`
- Fix JSON extraction failing when model prefixes output with prose before fenced JSON
- Add structured poll/worker logging and better error diagnostics

## Test plan
- [x] 15 unit tests pass (including 3 new tests for extraction and recovery)
- [x] Deployed to pika-build and verified: consecutive cycles show `ready=1, failed=0, retry=0`
- [x] DB went from 21→23 ready items after deploy, pending items steadily processing
- [x] Public site at news.pikachat.org serving correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed artifacts becoming stuck in generating state after unclean shutdowns—system now automatically recovers them on startup.
  * Improved resilience to Claude API timeouts and errors with enhanced retry handling.
  * Enhanced JSON parsing robustness to handle various Claude API response formats.

* **Chores**
  * Improved internal logging for debugging poll and worker operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->