### PR TITLE
Fix iOS CI cert quota exhaustion

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -37,7 +37,9 @@ jobs:
             -T /usr/bin/codesign \
             -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          existing=$(security list-keychains -d user | tr -d '"')
+          # shellcheck disable=SC2086
+          security list-keychains -d user -s "$KEYCHAIN" $existing
           rm "$RUNNER_TEMP/cert.p12"
 
       - name: Write App Store Connect API key


### PR DESCRIPTION
## Summary
- Install a pre-exported distribution certificate (.p12) into a temporary keychain on the CI runner before archiving
- Prevents xcodebuild from auto-creating new certs on every run, which was exhausting Apple's per-account certificate limit

## Setup required
Two new GitHub Actions secrets must be configured (already done):
- `IOS_DIST_CERT_P12` — base64-encoded .p12 export of the Apple Distribution cert
- `IOS_DIST_CERT_PASSWORD` — password for the .p12

## Test plan
- [ ] Trigger a manual workflow dispatch of the iOS TestFlight workflow
- [ ] Verify the "Install distribution certificate" step succeeds
- [ ] Verify the archive and export steps sign correctly without creating new certs
- [ ] Check Apple Developer portal to confirm no new certs were created

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * iOS TestFlight CI workflow updated to include an automated certificate install and cleanup step, improving certificate handling during builds.
  * Change is limited to the workflow step; no other build behaviors or app artifacts were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->