### PR TITLE
Fix own profile disappearing after failed relay fetch

### DIFF
--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -7390,4 +7390,52 @@ mod tests {
         // Not logged in — should be a no-op (no panic).
         core.handle_internal(crate::updates::InternalEvent::RefreshAfterForeground);
     }
+
+    #[test]
+    fn apply_my_profile_none_metadata_preserves_cached_profile() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().to_string_lossy().into_owned();
+        let mut core = make_core(data_dir.clone());
+        profile_pics::ensure_dir(&data_dir);
+
+        // Simulate a logged-in session with a cached profile.
+        let keys = nostr_sdk::prelude::Keys::generate();
+        let pk = keys.public_key().to_hex();
+
+        let cached = ProfileCache::from_metadata_json(
+            Some(
+                r#"{"name":"Alice","about":"Hello","picture":"https://example.com/pic.jpg"}"#
+                    .to_string(),
+            ),
+            1000,
+            1000,
+        );
+        core.profiles.insert(pk.clone(), cached);
+
+        // Set up a minimal session so apply_my_profile_metadata can find the pubkey.
+        let mdk = crate::mdk_support::open_mdk(&data_dir, &keys.public_key(), "").unwrap();
+        core.session = Some(super::Session {
+            pubkey: keys.public_key(),
+            local_keys: Some(keys),
+            mdk,
+            client: nostr_sdk::Client::default(),
+            alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            giftwrap_sub: None,
+            group_sub: None,
+            groups: std::collections::HashMap::new(),
+        });
+
+        // Build the initial my_profile state from the cache.
+        core.state.my_profile = core.my_profile_state();
+        assert_eq!(core.state.my_profile.name, "Alice");
+        assert_eq!(core.state.my_profile.about, "Hello");
+
+        // Simulate fetch_metadata returning None (relay unreachable / timeout).
+        core.apply_my_profile_metadata(None, None);
+
+        // The cached profile should be preserved.
+        assert_eq!(core.state.my_profile.name, "Alice");
+        assert_eq!(core.state.my_profile.about, "Hello");
+        assert!(core.profiles.get(&pk).unwrap().name.as_deref() == Some("Alice"));
+    }
 }

--- a/rust/src/core/profile.rs
+++ b/rust/src/core/profile.rs
@@ -235,15 +235,15 @@ impl AppCore {
         // Serialize to JSON and upsert into the shared profile cache —
         // same storage and picture-caching path as every other profile.
         if let Some(pk) = self.session.as_ref().map(|s| s.pubkey.to_hex()) {
-            let metadata_json = metadata.and_then(|m| serde_json::to_string(&m).ok());
-            self.upsert_profile(
-                pk.clone(),
-                ProfileCache::from_metadata_json(
-                    metadata_json,
-                    crate::state::now_seconds(),
-                    crate::state::now_seconds(),
-                ),
-            );
+            // When metadata is None (relay unreachable / timeout), keep the
+            // existing cached profile instead of overwriting it with empty data.
+            if let Some(m) = metadata {
+                let metadata_json = serde_json::to_string(&m).ok();
+                self.upsert_profile(
+                    pk.clone(),
+                    ProfileCache::from_metadata_json(metadata_json, now_seconds(), now_seconds()),
+                );
+            }
             // If the caller already has the image bytes (e.g. just-uploaded pfp),
             // write them to the cache directly so the UI can show the new picture
             // immediately without a redundant re-download from Blossom.


### PR DESCRIPTION
## Summary
- When `fetch_metadata` returns `None` (relay unreachable/timeout), `apply_my_profile_metadata` was overwriting the cached profile with empty data because it used `now_seconds()` as `event_created_at`, which is always newer than the real cached timestamp
- The `subs_force_reconnect` change (disconnects WebSockets on foreground) made this more frequent by creating a race between the relay disconnect and the concurrent profile fetch
- Fix: skip `upsert_profile` when metadata is `None`, preserving the existing cached profile

## Test plan
- [x] Added `apply_my_profile_none_metadata_preserves_cached_profile` test
- [ ] Manual: kill the app, disable network, relaunch — profile should still display from cache
- [ ] Manual: foreground the app on a slow network — profile should not flash empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where profile information could be lost when metadata retrieval returns no data.

* **Tests**
  * Added test coverage to verify profile data preservation when metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->