### PR TITLE
ci: cache Gradle in CI

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -163,6 +163,11 @@ jobs:
           key: ${{ github.repository }}-cargo-target-v1-${{ runner.os }}
           path: target
 
+      - uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-gradle-v1-${{ runner.os }}
+          path: ~/.gradle
+
       - run: nix develop .#default -c just pre-merge-pika
 
   check-pikachat:
@@ -507,6 +512,11 @@ jobs:
         with:
           key: ${{ github.repository }}-cargo-target-v1-${{ runner.os }}
           path: target
+
+      - uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-gradle-v1-${{ runner.os }}
+          path: ~/.gradle
 
       - run: |
           nix develop .#default -c ./tools/android-avd-ensure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,11 @@ jobs:
           key: ${{ github.repository }}-cargo-target-v1-${{ runner.os }}
           path: target
 
+      - uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-gradle-v1-${{ runner.os }}
+          path: ~/.gradle
+
       - name: Validate tag matches VERSION
         run: |
           set -euo pipefail
@@ -158,6 +163,11 @@ jobs:
         with:
           key: ${{ github.repository }}-cargo-target-v1-${{ runner.os }}
           path: target
+
+      - uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-gradle-v1-${{ runner.os }}
+          path: ~/.gradle
 
       - name: Build signed release APK
         env:


### PR DESCRIPTION
## Summary
- Add `~/.gradle` stickydisk cache to `check-pika`, `nightly-pika-ui-android`, and `build-android` jobs
- Avoids re-downloading Gradle dependencies on every CI run

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI/CD pipeline performance by implementing build dependency caching, reducing build execution time for merge checks and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->