### PR TITLE
fix: set group name in push notification communication intent

### DIFF
--- a/crates/pika-nse/src/lib.rs
+++ b/crates/pika-nse/src/lib.rs
@@ -122,25 +122,19 @@ pub fn decrypt_push_notification(
                 .filter(|m| m.kind == NotifMediaKind::Image)
                 .and_then(|m| download_and_decrypt_image(&mdk, &msg.mls_group_id, m.tag));
 
-            let all_groups = mdk.get_groups().ok()?;
-            let group_info = all_groups
-                .iter()
-                .find(|g| g.mls_group_id == msg.mls_group_id);
-
-            let group_name = group_info.and_then(|g| {
-                if g.name != "DM" && !g.name.is_empty() {
-                    Some(g.name.clone())
-                } else {
-                    None
-                }
-            });
+            let group_name = if group.name != "DM" && !group.name.is_empty() {
+                Some(group.name.clone())
+            } else {
+                None
+            };
 
             let members = mdk.get_members(&msg.mls_group_id).unwrap_or_default();
             let other_count = members.iter().filter(|p| *p != &pubkey).count();
-            let is_group = other_count > 1 || (group_name.is_some() && other_count > 0);
+            let is_group = group_name.is_some() || other_count > 1;
 
             let sender_hex = msg.pubkey.to_hex();
-            let (sender_name, sender_picture_url) = resolve_sender_profile(&data_dir, &sender_hex);
+            let (sender_name, sender_picture_url) =
+                resolve_sender_profile(&data_dir, &sender_hex, Some(&chat_id));
 
             Some(PushNotificationResult::Content {
                 content: PushNotificationContent {
@@ -166,7 +160,8 @@ pub fn decrypt_push_notification(
                 .map(|b| b.tracks.iter().any(|t| t.name == "video0"))
                 .unwrap_or(false);
             let sender_hex = msg.pubkey.to_hex();
-            let (caller_name, caller_picture_url) = resolve_sender_profile(&data_dir, &sender_hex);
+            let (caller_name, caller_picture_url) =
+                resolve_sender_profile(&data_dir, &sender_hex, Some(&chat_id));
             Some(PushNotificationResult::CallInvite {
                 chat_id,
                 call_id: probe.call_id,
@@ -281,7 +276,13 @@ fn download_and_decrypt_image(
 }
 
 /// Look up display name and picture URL from the SQLite profile cache.
-fn resolve_sender_profile(data_dir: &str, pubkey_hex: &str) -> (String, Option<String>) {
+/// If `chat_id` is provided, checks for a group-specific profile first,
+/// falling back to the global profile.
+fn resolve_sender_profile(
+    data_dir: &str,
+    pubkey_hex: &str,
+    chat_id: Option<&str>,
+) -> (String, Option<String>) {
     let fallback = (format!("{}...", &pubkey_hex[..8]), None);
 
     let db_path = std::path::Path::new(data_dir).join("profiles.sqlite3");
@@ -293,14 +294,30 @@ fn resolve_sender_profile(data_dir: &str, pubkey_hex: &str) -> (String, Option<S
         Err(_) => return fallback,
     };
 
-    let row: Option<(Option<String>, Option<String>, Option<String>)> = conn
-        .query_row(
-            "SELECT metadata->>'display_name', metadata->>'name', metadata->>'picture'
-             FROM profiles WHERE pubkey = ?1",
-            [pubkey_hex],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .ok();
+    // Try group profile first, then fall back to global profile.
+    let row: Option<(Option<String>, Option<String>, Option<String>)> = chat_id
+        .and_then(|cid| {
+            conn.query_row(
+                "SELECT metadata->>'display_name', metadata->>'name', metadata->>'picture'
+                 FROM profiles WHERE pubkey = ?1 AND chat_id = ?2",
+                rusqlite::params![pubkey_hex, cid],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .ok()
+            .filter(|(dn, n, _): &(Option<String>, Option<String>, _)| {
+                dn.as_ref().is_some_and(|s| !s.is_empty())
+                    || n.as_ref().is_some_and(|s| !s.is_empty())
+            })
+        })
+        .or_else(|| {
+            conn.query_row(
+                "SELECT metadata->>'display_name', metadata->>'name', metadata->>'picture'
+                 FROM profiles WHERE pubkey = ?1 AND chat_id IS NULL",
+                [pubkey_hex],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .ok()
+        });
 
     let Some((display_name, name_field, picture)) = row else {
         return fallback;
@@ -313,11 +330,16 @@ fn resolve_sender_profile(data_dir: &str, pubkey_hex: &str) -> (String, Option<S
 
     let picture_url = picture.filter(|s| !s.is_empty()).map(|url| {
         // Prefer locally cached profile picture if available.
-        let cached = std::path::Path::new(data_dir)
-            .join("profile_pics")
-            .join(pubkey_hex);
-        if cached.exists() {
-            format!("file://{}", cached.display())
+        // Check group-specific cache first, then global cache.
+        let base = std::path::Path::new(data_dir).join("profile_pics");
+        let group_cached = chat_id
+            .map(|cid| base.join(format!("group_{cid}")).join(pubkey_hex))
+            .filter(|p| p.exists());
+        let global_cached = base.join(pubkey_hex);
+        if let Some(path) = group_cached {
+            format!("file://{}", path.display())
+        } else if global_cached.exists() {
+            format!("file://{}", global_cached.display())
         } else {
             url
         }

--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -39,14 +39,7 @@ class NotificationService: UNNotificationServiceExtension {
 
         switch decryptPushNotification(dataDir: dataDir, nsec: nsec, eventJson: eventJson, keychainGroup: keychainGroup) {
         case .content(let msg):
-            if msg.isGroup {
-                content.title = msg.groupName ?? "Group"
-                content.subtitle = msg.senderName
-                content.body = msg.content
-            } else {
-                content.title = msg.senderName
-                content.body = msg.content
-            }
+            content.body = msg.content
             content.userInfo["chat_id"] = msg.chatId
             content.threadIdentifier = msg.chatId
 
@@ -64,6 +57,8 @@ class NotificationService: UNNotificationServiceExtension {
                         senderName: msg.senderName,
                         senderPubkey: msg.senderPubkey,
                         chatId: msg.chatId,
+                        isGroup: msg.isGroup,
+                        groupName: msg.groupName,
                         senderImage: image
                     )
                     contentHandler(updated)
@@ -74,6 +69,8 @@ class NotificationService: UNNotificationServiceExtension {
                     senderName: msg.senderName,
                     senderPubkey: msg.senderPubkey,
                     chatId: msg.chatId,
+                    isGroup: msg.isGroup,
+                    groupName: msg.groupName,
                     senderImage: nil
                 )
                 contentHandler(updated)
@@ -120,6 +117,8 @@ class NotificationService: UNNotificationServiceExtension {
         senderName: String,
         senderPubkey: String,
         chatId: String,
+        isGroup: Bool = false,
+        groupName: String? = nil,
         senderImage: INImage?
     ) -> UNNotificationContent {
         let handle = INPersonHandle(value: senderPubkey, type: .unknown)
@@ -131,11 +130,23 @@ class NotificationService: UNNotificationServiceExtension {
             contactIdentifier: nil,
             customIdentifier: senderPubkey
         )
+        // For groups, iOS requires recipients to treat the intent as a group
+        // conversation. Provide the sender as a recipient placeholder so that
+        // speakableGroupName is used as the title and sender as the subtitle.
+        let speakableGroup: INSpeakableString?
+        let recipients: [INPerson]?
+        if isGroup {
+            speakableGroup = INSpeakableString(spokenPhrase: groupName ?? "Group")
+            recipients = [sender]
+        } else {
+            speakableGroup = nil
+            recipients = nil
+        }
         let intent = INSendMessageIntent(
-            recipients: nil,
+            recipients: recipients,
             outgoingMessageType: .outgoingMessageText,
             content: nil,
-            speakableGroupName: nil,
+            speakableGroupName: speakableGroup,
             conversationIdentifier: chatId,
             serviceName: nil,
             sender: sender,
@@ -147,8 +158,7 @@ class NotificationService: UNNotificationServiceExtension {
         let interaction = INInteraction(intent: intent, response: nil)
         interaction.direction = .incoming
         interaction.donate(completion: nil)
-        let updated = try? content.updating(from: intent)
-        return updated ?? content
+        return (try? content.updating(from: intent)) ?? content
     }
 
     /// Save decrypted image data to a temp file and create a notification attachment.


### PR DESCRIPTION
## Summary
- Pass `isGroup` and `groupName` to `INSendMessageIntent` so iOS correctly renders group chat push notifications with the group name as the title and sender name as the subtitle
- Use `get_group()` instead of `get_groups()` in the NSE for more efficient group lookup
- Run `cargo fmt` on mdk_support.rs

## Test plan
- [ ] Send a message in a group chat and verify the push notification shows the group name as the title and the sender as the subtitle
- [ ] Send a DM and verify the push notification still shows just the sender name as the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group-aware sender profiles and profile pictures now resolve per-chat when available, falling back to global data.
  * Notifications include speakable group names and recipient metadata; image attachments for decrypted messages are supported.

* **Bug Fixes**
  * Group vs direct-message titles/subtitles display correctly and sender attribution is fixed across notification paths.

* **Refactor**
  * Simplified group detection and profile lookup for more consistent notification and avatar behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->