### PR TITLE
Add animated GIF display and iOS sticker keyboard support

### DIFF
--- a/ios/Sources/Views/AvatarView.swift
+++ b/ios/Sources/Views/AvatarView.swift
@@ -1,4 +1,6 @@
+import ImageIO
 import SwiftUI
+import UIKit
 
 struct AvatarView: View {
     let name: String?
@@ -45,6 +47,7 @@ final class ImageCache: @unchecked Sendable {
 
     init() {
         cache.countLimit = 200
+        cache.totalCostLimit = 100 * 1024 * 1024 // 100 MB
     }
 
     func image(for url: URL) -> UIImage? {
@@ -52,7 +55,78 @@ final class ImageCache: @unchecked Sendable {
     }
 
     func setImage(_ image: UIImage, for url: URL) {
-        cache.setObject(image, forKey: url as NSURL)
+        let cost = image.images?.reduce(0) { $0 + cgImageCost($1) } ?? cgImageCost(image)
+        cache.setObject(image, forKey: url as NSURL, cost: cost)
+    }
+
+    private func cgImageCost(_ image: UIImage) -> Int {
+        guard let cg = image.cgImage else { return 0 }
+        return cg.bytesPerRow * cg.height
+    }
+}
+
+// MARK: - Animated GIF support
+
+/// Creates an animated `UIImage` from GIF data using ImageIO.
+/// Returns `nil` if the data is not a multi-frame GIF.
+private func animatedImageFromGIFData(_ data: Data) -> UIImage? {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+    let count = CGImageSourceGetCount(source)
+    guard count > 1 else { return nil }
+
+    var images: [UIImage] = []
+    var totalDuration: Double = 0
+
+    for i in 0..<count {
+        guard let cgImage = CGImageSourceCreateImageAtIndex(source, i, nil) else { continue }
+        images.append(UIImage(cgImage: cgImage))
+
+        if let properties = CGImageSourceCopyPropertiesAtIndex(source, i, nil) as? [String: Any],
+           let gif = properties[kCGImagePropertyGIFDictionary as String] as? [String: Any] {
+            let delay = gif[kCGImagePropertyGIFUnclampedDelayTime as String] as? Double
+                ?? gif[kCGImagePropertyGIFDelayTime as String] as? Double
+                ?? 0.1
+            totalDuration += max(delay, 0.02)
+        } else {
+            totalDuration += 0.1
+        }
+    }
+
+    guard !images.isEmpty else { return nil }
+    return UIImage.animatedImage(with: images, duration: totalDuration)
+}
+
+/// Checks if the data starts with the GIF magic bytes (`GIF8`).
+private func isGIFData(_ data: Data) -> Bool {
+    data.count >= 4 && data.prefix(4).elementsEqual([0x47, 0x49, 0x46, 0x38])
+}
+
+/// Loads a `UIImage` from data, using animated decoding for GIFs.
+private func loadImage(from data: Data) -> UIImage? {
+    if isGIFData(data), let animated = animatedImageFromGIFData(data) {
+        return animated
+    }
+    return UIImage(data: data)
+}
+
+/// UIKit-based image view that supports animated `UIImage` (GIF playback).
+struct AnimatedImageView: UIViewRepresentable {
+    let image: UIImage
+    let contentMode: UIView.ContentMode
+
+    func makeUIView(context: Context) -> UIImageView {
+        let iv = UIImageView()
+        iv.contentMode = contentMode
+        iv.clipsToBounds = true
+        iv.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        iv.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        iv.image = image
+        return iv
+    }
+
+    func updateUIView(_ uiView: UIImageView, context: Context) {
+        uiView.image = image
+        uiView.contentMode = contentMode
     }
 }
 
@@ -72,8 +146,8 @@ final class ImageLoader: ObservableObject {
             return
         }
 
-        // Local files: read synchronously (tiny resized JPEGs, ~40KB).
-        if url.isFileURL {
+        // Small non-GIF local files: read synchronously (tiny resized JPEGs, ~40KB).
+        if url.isFileURL && !url.pathExtension.lowercased().hasSuffix("gif") {
             if let data = try? Data(contentsOf: url),
                let uiImage = UIImage(data: data) {
                 ImageCache.shared.setImage(uiImage, for: url)
@@ -82,10 +156,18 @@ final class ImageLoader: ObservableObject {
             return
         }
 
+        // Remote URLs and local GIFs: decode off main thread.
         task = Task {
             do {
-                let (data, _) = try await URLSession.shared.data(from: url)
-                guard !Task.isCancelled, let uiImage = UIImage(data: data) else { return }
+                let data: Data
+                if url.isFileURL {
+                    data = try Data(contentsOf: url)
+                } else {
+                    let (d, _) = try await URLSession.shared.data(from: url)
+                    data = d
+                }
+                let uiImage = await Task.detached { loadImage(from: data) }.value
+                guard !Task.isCancelled, let uiImage else { return }
                 ImageCache.shared.setImage(uiImage, for: url)
                 self.image = uiImage
             } catch {
@@ -97,15 +179,24 @@ final class ImageLoader: ObservableObject {
 
 struct CachedAsyncImage<Content: View, Placeholder: View>: View {
     let url: URL
+    var animatedContentMode: UIView.ContentMode = .scaleAspectFill
     @ViewBuilder let content: (Image) -> Content
     @ViewBuilder let placeholder: () -> Placeholder
 
     @StateObject private var loader = ImageLoader()
 
+    private var isAnimated: Bool {
+        loader.image?.images != nil
+    }
+
     var body: some View {
         Group {
             if let uiImage = loader.image {
-                content(Image(uiImage: uiImage))
+                if isAnimated {
+                    AnimatedImageView(image: uiImage, contentMode: animatedContentMode)
+                } else {
+                    content(Image(uiImage: uiImage))
+                }
             } else {
                 placeholder()
             }

--- a/ios/Sources/Views/ChatInputBar.swift
+++ b/ios/Sources/Views/ChatInputBar.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PhotosUI
+import UIKit
 import UniformTypeIdentifiers
 
 struct ChatInputBar: View {
@@ -13,6 +14,7 @@ struct ChatInputBar: View {
     @FocusState.Binding var isInputFocused: Bool
     let onSend: () -> Void
     let onStartVoiceRecording: () -> Void
+    var onImagePaste: ((Data, String) -> Void)? = nil
 
     @State private var showPhotoPicker = false
 
@@ -71,27 +73,24 @@ struct ChatInputBar: View {
                 }
 
                 HStack(spacing: 10) {
-                    TextEditor(text: $messageText)
-                        .focused($isInputFocused)
-                        .frame(minHeight: 36, maxHeight: 150)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .scrollContentBackground(.hidden)
-                        .onAppear {
-                            if ProcessInfo.processInfo.isiOSAppOnMac {
-                                isInputFocused = true
-                            }
+                    StickerAwareTextView(
+                        text: $messageText,
+                        isFocused: $isInputFocused,
+                        maxHeight: 150,
+                        onSend: onSend,
+                        onImagePaste: onImagePaste
+                    )
+                    .frame(minHeight: 36)
+                    .overlay(alignment: .topLeading) {
+                        if messageText.isEmpty {
+                            Text("Message")
+                                .foregroundStyle(.tertiary)
+                                .padding(.leading, 5)
+                                .padding(.top, 8)
+                                .allowsHitTesting(false)
                         }
-                        .modifier(ReturnKeyPressModifier(onSend: onSend))
-                        .overlay(alignment: .topLeading) {
-                            if messageText.isEmpty {
-                                Text("Message")
-                                    .foregroundStyle(.tertiary)
-                                    .padding(.leading, 5)
-                                    .padding(.top, 8)
-                                    .allowsHitTesting(false)
-                            }
-                        }
-                        .accessibilityIdentifier(TestIds.chatMessageInput)
+                    }
+                    .accessibilityIdentifier(TestIds.chatMessageInput)
 
                     let isEmpty = messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                         && stagedMedia.isEmpty
@@ -161,6 +160,234 @@ private struct StagedMediaThumbnail: View {
             }
             .offset(x: 4, y: -4)
         }
+    }
+}
+
+// MARK: - Sticker-aware text view
+
+/// A `UITextView` wrapper that intercepts image paste from sticker keyboards
+/// and forwards image data via `onImagePaste`.
+struct StickerAwareTextView: UIViewRepresentable {
+    @Binding var text: String
+    var isFocused: FocusState<Bool>.Binding
+    var maxHeight: CGFloat = 150
+    var onSend: (() -> Void)?
+    var onImagePaste: ((Data, String) -> Void)?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> PastableTextView {
+        let tv = PastableTextView()
+        tv.delegate = context.coordinator
+        tv.pasteDelegate = context.coordinator
+        tv.maxAllowedHeight = maxHeight
+        tv.onImagePaste = { data, mime in
+            onImagePaste?(data, mime)
+        }
+        tv.onReturnKey = { onSend?() }
+        tv.font = .preferredFont(forTextStyle: .body)
+        tv.backgroundColor = .clear
+        tv.textContainerInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+        tv.textContainer.lineFragmentPadding = 5
+        tv.isScrollEnabled = false
+        tv.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        tv.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        // Auto-focus on Mac Catalyst
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            DispatchQueue.main.async { tv.becomeFirstResponder() }
+        }
+        return tv
+    }
+
+    func updateUIView(_ uiView: PastableTextView, context: Context) {
+        context.coordinator.parent = self
+
+        if uiView.text != text {
+            uiView.text = text
+            uiView.recalculateHeight()
+        }
+        uiView.onImagePaste = { data, mime in
+            onImagePaste?(data, mime)
+        }
+        uiView.onReturnKey = { onSend?() }
+    }
+
+    class Coordinator: NSObject, UITextViewDelegate, UITextPasteDelegate {
+        var parent: StickerAwareTextView
+
+        init(parent: StickerAwareTextView) {
+            self.parent = parent
+        }
+
+        // MARK: - UITextPasteDelegate
+
+        func textPasteConfigurationSupporting(
+            _ textPasteConfigurationSupporting: UITextPasteConfigurationSupporting,
+            transform item: UITextPasteItem
+        ) {
+            if item.itemProvider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+                item.itemProvider.loadDataRepresentation(forTypeIdentifier: UTType.image.identifier) { [weak self] data, _ in
+                    guard let data = data else { return }
+                    DispatchQueue.main.async {
+                        guard let tv = textPasteConfigurationSupporting as? PastableTextView else { return }
+                        tv.onImagePaste?(data, "image/png")
+                        self?.stripAttachments(in: tv)
+                    }
+                }
+                item.setNoResult()
+                return
+            }
+            item.setDefaultResult()
+        }
+
+        // MARK: - UITextViewDelegate
+
+        func textViewDidChange(_ textView: UITextView) {
+            (textView as? PastableTextView)?.recalculateHeight()
+
+            guard textView.text.contains("\u{FFFC}") else {
+                parent.text = textView.text
+                return
+            }
+
+            if let data = extractStickerImage(from: textView) {
+                stripAttachments(in: textView)
+                (textView as? PastableTextView)?.onImagePaste?(data, "image/png")
+                return
+            }
+
+            parent.text = textView.text
+        }
+
+        // MARK: - Helpers
+
+        /// Extracts image data from sticker content (NSAdaptiveImageGlyph or NSTextAttachment).
+        private func extractStickerImage(from textView: UITextView) -> Data? {
+            let storage = textView.textStorage
+            let range = NSRange(location: 0, length: storage.length)
+
+            // iOS 18+: NSAdaptiveImageGlyph (used by sticker keyboard)
+            if #available(iOS 18.0, *) {
+                var result: Data?
+                storage.enumerateAttributes(in: range) { attrs, _, stop in
+                    for (_, value) in attrs {
+                        if let glyph = value as? NSAdaptiveImageGlyph,
+                           let image = UIImage(data: glyph.imageContent),
+                           let pngData = image.pngData() {
+                            result = pngData
+                            stop.pointee = true
+                            return
+                        }
+                    }
+                }
+                if result != nil { return result }
+            }
+
+            // Fallback: NSTextAttachment
+            var result: Data?
+            storage.enumerateAttribute(.attachment, in: range) { value, _, stop in
+                guard let attachment = value as? NSTextAttachment else { return }
+                if let data = attachment.contents {
+                    result = data
+                } else if let image = attachment.image, let data = image.pngData() {
+                    result = data
+                } else if let fw = attachment.fileWrapper, let data = fw.regularFileContents {
+                    result = data
+                } else if let image = attachment.image(forBounds: attachment.bounds, textContainer: nil, characterIndex: 0),
+                          let data = image.pngData() {
+                    result = data
+                }
+                if result != nil { stop.pointee = true }
+            }
+            return result
+        }
+
+        /// Strips object-replacement characters and syncs the text binding.
+        private func stripAttachments(in textView: UITextView) {
+            let plain = textView.text.replacingOccurrences(of: "\u{FFFC}", with: "")
+            textView.text = plain
+            parent.text = plain
+        }
+
+        func textViewDidBeginEditing(_ textView: UITextView) {
+            parent.isFocused.wrappedValue = true
+        }
+
+        func textViewDidEndEditing(_ textView: UITextView) {
+            parent.isFocused.wrappedValue = false
+        }
+    }
+}
+
+/// UITextView subclass that intercepts paste, manages dynamic height, and detects image content.
+class PastableTextView: UITextView {
+    var onImagePaste: ((Data, String) -> Void)?
+    var onReturnKey: (() -> Void)?
+    var maxAllowedHeight: CGFloat = 150
+
+    override var intrinsicContentSize: CGSize {
+        let size = sizeThatFits(CGSize(width: bounds.width, height: .greatestFiniteMagnitude))
+        let clamped = min(size.height, maxAllowedHeight)
+        return CGSize(width: UIView.noIntrinsicMetric, height: clamped)
+    }
+
+    /// Recalculates intrinsic height and toggles scrolling when content exceeds max.
+    func recalculateHeight() {
+        let contentHeight = sizeThatFits(CGSize(width: bounds.width, height: .greatestFiniteMagnitude)).height
+        let shouldScroll = contentHeight > maxAllowedHeight
+        if isScrollEnabled != shouldScroll {
+            isScrollEnabled = shouldScroll
+        }
+        invalidateIntrinsicContentSize()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        recalculateHeight()
+    }
+
+    override func paste(_ sender: Any?) {
+        let pb = UIPasteboard.general
+
+        // Check for GIF data first (preserves animation)
+        if let gifData = pb.data(forPasteboardType: "com.compuserve.gif") {
+            onImagePaste?(gifData, "image/gif")
+            return
+        }
+
+        // Check for PNG data
+        if let pngData = pb.data(forPasteboardType: "public.png") {
+            onImagePaste?(pngData, "image/png")
+            return
+        }
+
+        // Fallback: any image on pasteboard
+        if pb.hasImages, let image = pb.image, let pngData = image.pngData() {
+            onImagePaste?(pngData, "image/png")
+            return
+        }
+
+        super.paste(sender)
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)) && UIPasteboard.general.hasImages {
+            return true
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        // Handle Return key to send (without Shift)
+        if let key = presses.first?.key,
+           key.keyCode == .keyboardReturnOrEnter,
+           !key.modifierFlags.contains(.shift) {
+            onReturnKey?()
+            return
+        }
+        super.pressesBegan(presses, with: event)
     }
 }
 

--- a/ios/Sources/Views/ChatView.swift
+++ b/ios/Sources/Views/ChatView.swift
@@ -665,7 +665,14 @@ struct ChatView: View {
                     showMicButton: onSendMedia != nil,
                     isInputFocused: $isInputFocused,
                     onSend: { sendMessage() },
-                    onStartVoiceRecording: { startVoiceRecording() }
+                    onStartVoiceRecording: { startVoiceRecording() },
+                    onImagePaste: onSendMedia == nil ? nil : { data, mimeType in
+                        let ext = mimeType == "image/gif" ? "gif" : "png"
+                        let filename = "sticker.\(ext)"
+                        let caption = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !caption.isEmpty { messageText = "" }
+                        onSendMedia?(chatId, data, "", filename, caption)
+                    }
                 )
                 .onChangeCompat(of: messageText) { newValue in
                     if chat.isGroup {

--- a/ios/Sources/Views/FullscreenImageViewer.swift
+++ b/ios/Sources/Views/FullscreenImageViewer.swift
@@ -92,7 +92,10 @@ struct FullscreenImageViewer: View {
     @ViewBuilder
     private func imageContent(attachment: ChatMediaAttachment, geo: GeometryProxy) -> some View {
         if let localPath = attachment.localPath {
-            CachedAsyncImage(url: URL(fileURLWithPath: localPath)) { image in
+            CachedAsyncImage(
+                url: URL(fileURLWithPath: localPath),
+                animatedContentMode: .scaleAspectFit
+            ) { image in
                 image
                     .resizable()
                     .scaledToFit()


### PR DESCRIPTION
## Summary

- **Animated GIF display**: GIFs now play inline in chat bubbles and fullscreen viewer instead of showing a static first frame. Uses ImageIO for frame extraction and UIImageView for native playback.
- **iOS sticker keyboard**: Stickers from the iOS keyboard (Memoji, emoji stickers, etc.) are now detected via `NSAdaptiveImageGlyph` (iOS 18+) and sent as images through the existing media upload pipeline. Also supports pasting copied images and `NSTextAttachment`-based stickers.

## Test plan

- [ ] Send a GIF via the photo picker — verify it animates in the chat bubble
- [ ] Tap an animated GIF to open fullscreen — verify it animates there too
- [ ] Open the iOS sticker keyboard and tap a sticker — verify it sends as an image (not empty text)
- [ ] Copy an image from another app, paste into the chat input — verify it sends as media
- [ ] Type a normal text message — verify keyboard stays up and send works as before
- [ ] Verify on Mac Catalyst: keyboard auto-focuses on chat open

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message search with optional per-chat filtering, searchable result display, and clear-search support.
  * GIF & animated image support: decoding, caching, and proper animated rendering (fit/scale options).
  * Paste images/stickers into chat input and send as media with constructed filename and optional caption.

* **Chores**
  * Updated workspace dependencies to new sources and revisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->