### PR TITLE
fix: reply text wrapping and preview visibility

### DIFF
--- a/ios/Sources/Views/MessageBubbleViews.swift
+++ b/ios/Sources/Views/MessageBubbleViews.swift
@@ -841,6 +841,7 @@ private struct ReplyPreviewCard: View {
                     .lineLimit(1)
             }
             Spacer(minLength: 0)
+            mediaThumbnail
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
@@ -865,6 +866,9 @@ private struct ReplyPreviewCard: View {
         guard let target else { return "Original message not loaded" }
         let trimmed = target.displayContent.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
+            if let firstMedia = target.media.first {
+                return mediaLabel(for: firstMedia.kind)
+            }
             return "(empty message)"
         }
         if let first = trimmed.split(separator: "\n").first {
@@ -878,6 +882,51 @@ private struct ReplyPreviewCard: View {
             return String(trimmed.prefix(80)) + "…"
         }
         return trimmed
+    }
+
+    private func mediaLabel(for kind: ChatMediaKind) -> String {
+        switch kind {
+        case .image: return "Photo"
+        case .video: return "Video"
+        case .voiceNote: return "Voice Message"
+        case .file: return "File"
+        }
+    }
+
+    private var firstVisualMedia: ChatMediaAttachment? {
+        target?.media.first { $0.kind == .image || $0.kind == .video }
+    }
+
+    @ViewBuilder
+    private var mediaThumbnail: some View {
+        if let media = firstVisualMedia {
+            let size: CGFloat = 34
+            Group {
+                if let localPath = media.localPath {
+                    CachedAsyncImage(url: URL(fileURLWithPath: localPath)) { image in
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    } placeholder: {
+                        thumbnailPlaceholder(media: media, size: size)
+                    }
+                } else {
+                    thumbnailPlaceholder(media: media, size: size)
+                }
+            }
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        }
+    }
+
+    @ViewBuilder
+    private func thumbnailPlaceholder(media: ChatMediaAttachment, size: CGFloat) -> some View {
+        if let hash = media.blurhash {
+            BlurhashView(hash: hash, size: CGSize(width: size, height: size))
+        } else {
+            Rectangle()
+                .fill(isMine ? Color.white.opacity(0.15) : Color.gray.opacity(0.2))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Long reply message text now wraps instead of truncating with "..."
- Reply preview card is now visible inside the blue bubble (was invisible due to white-on-white styling outside the bubble background)

<img width="505" height="1016" alt="Screenshot 2026-03-05 at 4 21 35 PM" src="https://github.com/user-attachments/assets/8c7deda3-92c0-4802-8054-6f1b6d1ec8af" />

Closes #443

## Test plan
- [ ] Send a reply with long text — verify it wraps to multiple lines
- [ ] Verify the reply preview card (showing the original message) is visible inside the bubble
- [ ] Check both outgoing (blue) and incoming (gray) reply bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reply previews now include media thumbnails and a derived media label (Photo, Video, Voice Message, File) when the original message contains media.

* **Refactor**
  * Reply previews are rendered inline above bubble content and consistently shown for replies across text, Markdown, HTML, media, and mixed content.
  * Text and media rendering paths unified for consistent preview placement and styling; bubble background now considers reply status.

* **Bug Fixes**
  * Multi-line Markdown/HTML expand correctly with adjusted timestamps and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->