### PR TITLE
Centralize prod admin npubs

### DIFF
--- a/infra/nix/lib/prod-admins.nix
+++ b/infra/nix/lib/prod-admins.nix
@@ -1,0 +1,27 @@
+# Verified with `nak fetch ... -k 0` against public relays on 2026-03-06.
+[
+  {
+    id = "justinmoon";
+    displayName = "Justin Moon";
+    profileName = "justinmoon";
+    npub = "npub1zxu639qym0esxnn7rzrt48wycmfhdu3e5yvzwx7ja3t84zyc2r8qz8cx2y";
+    pubkey = "11b9a89404dbf3034e7e1886ba9dc4c6d376f239a118271bd2ec567a889850ce";
+    nip05 = null;
+  }
+  {
+    id = "futurepaul";
+    displayName = "Paul";
+    profileName = "Paul";
+    npub = "npub1p4kg8zxukpym3h20erfa3samj00rm2gt4q5wfuyu3tg0x3jg3gesvncxf8";
+    pubkey = "0d6c8388dcb049b8dd4fc8d3d8c3bb93de3da90ba828e4f09c8ad0f346488a33";
+    nip05 = "futurepaul@paul.lol";
+  }
+  {
+    id = "benthecarman";
+    displayName = "Carman";
+    profileName = "Carman";
+    npub = "npub1u8lnhlw5usp3t9vmpz60ejpyt649z33hu82wc2hpv6m5xdqmuxhs46turz";
+    pubkey = "e1ff3bfdd4e40315959b08b4fcc8245eaa514637e1d4ec2ae166b743341be1af";
+    nip05 = "_@benthecarman.com";
+  }
+]

--- a/infra/nix/modules/pika-news.nix
+++ b/infra/nix/modules/pika-news.nix
@@ -5,6 +5,9 @@ let
   serviceUser = "pika-news";
   serviceGroup = "pika-news";
   serviceStateDir = "/var/lib/pika-news";
+  prodAdmins = import ../lib/prod-admins.nix;
+  prodAdminNpubs = map (admin: admin.npub) prodAdmins;
+  allowedNpubsToml = lib.concatMapStringsSep "\n" (npub: ''      "${npub}",'') prodAdminNpubs;
   configFile = pkgs.writeText "pika-news.toml" ''
     repos = ["sledtools/pika"]
     poll_interval_secs = 300
@@ -16,18 +19,7 @@ let
     bind_address = "127.0.0.1"
     bind_port = ${toString servicePort}
     allowed_npubs = [
-      "npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc", # Gigi
-      "npub1trr5r2nrpsk6xkjk5a7p6pfcryyt6yzsflwjmz6r7uj7lfkjxxtq78hdpu", # Gladstein
-      "npub1qny3tkh0acurzla8x3zy4nhrjz5zd8l9sy9jys09umwng00manysew95gx", # Odell
-      "npub1u8lnhlw5usp3t9vmpz60ejpyt649z33hu82wc2hpv6m5xdqmuxhs46turz", # Carman
-      "npub15n94rarp3n7dz6edx9cugeshn0kcuxtugwu9nzprkpx7yekw7ygqplqru4", # Clark
-      "npub1dlkff8vcdwcty9hs3emc43yks8y7pr0tnn7jewvt63ph077sw48s4cc4qc", # Harrison
-      "npub1ye5ptcxfyyxl5vjvdjar2ua3f0hynkjzpx552mu5snj3qmx5pzjscpknpr", # hzrd
-      "npub1guh5grefa7vkay4ps6udxg8lrqxg2kgr3qh9n4gduxut64nfxq0q9y6hjy", # Marty
-      "npub1l2vyh47mk2p0qlsku7hg0vn29faehy9hy34ygaclpn66ukqp3afqutajft", # pablo
-      "npub1p4kg8zxukpym3h20erfa3samj00rm2gt4q5wfuyu3tg0x3jg3gesvncxf8", # Paul
-      "npub1330v3vee2mdvn2npdkquka2upmlrlsp0dl2c6kfnzwhpq6dvkjgq0d2k82", # Skyler
-      "npub1zxu639qym0esxnn7rzrt48wycmfhdu3e5yvzwx7ja3t84zyc2r8qz8cx2y", # justin
+${allowedNpubsToml}
     ]
   '';
 in

--- a/infra/nix/modules/pika-server.nix
+++ b/infra/nix/modules/pika-server.nix
@@ -8,6 +8,8 @@ let
   serviceUser = dbName;
   serviceGroup = dbName;
   serviceStateDir = "/var/lib/pika-server";
+  prodAdmins = import ../lib/prod-admins.nix;
+  prodAdminNpubs = map (admin: admin.npub) prodAdmins;
   startPikaServer = pkgs.writeShellScript "start-pika-server" ''
     set -euo pipefail
     export PIKA_ADMIN_SESSION_SECRET="$(${pkgs.coreutils}/bin/sha256sum ${serviceStateDir}/apns-key.p8 | ${pkgs.gawk}/bin/awk '{print $1}')"
@@ -106,7 +108,7 @@ in
       # Use the builder's stable tailnet IPv4 directly because MagicDNS
       # names may not resolve on this host.
       PIKA_AGENT_MICROVM_SPAWNER_URL=http://100.81.250.67:8080
-      PIKA_ADMIN_BOOTSTRAP_NPUBS=npub1zxu639qym0esxnn7rzrt48wycmfhdu3e5yvzwx7ja3t84zyc2r8qz8cx2y,npub1rtrxx9eyvag0ap3v73c4dvsqq5d2yxwe5d72qxrfpwe5svr96wuqed4p38,npub1p4kg8zxukpym3h20erfa3samj00rm2gt4q5wfuyu3tg0x3jg3gesvncxf8
+      PIKA_ADMIN_BOOTSTRAP_NPUBS=${lib.concatStringsSep "," prodAdminNpubs}
       RUST_LOG=info
     '';
   };


### PR DESCRIPTION
## Summary
- add a shared Nix registry for the three verified prod admin npubs
- use that registry for pika-server bootstrap admin login
- use the same registry to narrow pika-news prod access to the same three admins for now

## Validation
- verified the three profiles with nak kind-0 fetches from public relays
- evaluated the generated Nix strings with nix-instantiate

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized admin profile management configuration into a dedicated source
  * Updated server configurations to dynamically reference admin settings instead of hardcoded values, improving maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->