### PR TITLE
fix(agent): preserve durable VMs and surface error state

### DIFF
--- a/crates/pika-agent-microvm/src/lib.rs
+++ b/crates/pika-agent-microvm/src/lib.rs
@@ -44,6 +44,7 @@ pub struct CreateVmRequest {
     pub cpu: Option<u32>,
     pub memory_mb: Option<u32>,
     pub ttl_seconds: Option<u64>,
+    pub keep: bool,
     pub spawn_variant: Option<String>,
     pub guest_autostart: Option<GuestAutostartRequest>,
 }
@@ -225,6 +226,7 @@ pub fn build_create_vm_request(
         cpu: Some(resolved.cpu),
         memory_mb: Some(resolved.memory_mb),
         ttl_seconds: Some(resolved.ttl_seconds),
+        keep: resolved.keep,
         spawn_variant: Some(resolved.spawn_variant.clone()),
         guest_autostart: Some(GuestAutostartRequest {
             command: AUTOSTART_COMMAND.to_string(),
@@ -722,7 +724,7 @@ mod tests {
 
     #[test]
     fn build_create_vm_request_serializes_guest_autostart() {
-        let resolved = resolve_params(&MicrovmProvisionParams::default(), false);
+        let resolved = resolve_params(&MicrovmProvisionParams::default(), true);
         let keys = Keys::generate();
         let bot_keys = Keys::generate();
         let req = build_create_vm_request(
@@ -738,6 +740,7 @@ mod tests {
         let value = serde_json::to_value(req).expect("serialize create vm request");
 
         assert_eq!(value["spawn_variant"], "prebuilt-cow");
+        assert_eq!(value["keep"], true);
         assert_eq!(value["guest_autostart"]["command"], AUTOSTART_COMMAND);
         assert_eq!(
             value["guest_autostart"]["env"]["PIKA_OWNER_PUBKEY"],
@@ -805,6 +808,7 @@ mod tests {
             cpu: Some(2),
             memory_mb: Some(1024),
             ttl_seconds: Some(600),
+            keep: true,
             spawn_variant: Some("prebuilt-cow".to_string()),
             guest_autostart: Some(GuestAutostartRequest {
                 command: "/workspace/pika-agent/start-agent.sh".to_string(),
@@ -830,6 +834,7 @@ mod tests {
         assert_eq!(json["cpu"], 2);
         assert_eq!(json["memory_mb"], 1024);
         assert_eq!(json["ttl_seconds"], 600);
+        assert_eq!(json["keep"], true);
         assert_eq!(json["spawn_variant"], "prebuilt-cow");
         assert_eq!(
             json["guest_autostart"]["command"],
@@ -890,6 +895,7 @@ mod tests {
             cpu: None,
             memory_mb: None,
             ttl_seconds: None,
+            keep: false,
             spawn_variant: None,
             guest_autostart: None,
         };

--- a/crates/pika-server/src/agent_api.rs
+++ b/crates/pika-server/src/agent_api.rs
@@ -223,7 +223,7 @@ fn resolved_spawner_params() -> anyhow::Result<ResolvedMicrovmParams> {
         spawner_url: Some(spawner_url),
         ..MicrovmProvisionParams::default()
     };
-    let resolved = resolve_params(&params, false);
+    let resolved = resolve_params(&params, true);
     ensure_private_microvm_spawner_url(&resolved.spawner_url)
         .context("validate private microvm spawner URL")?;
     Ok(resolved)
@@ -317,6 +317,14 @@ pub async fn get_my_agent(
     let Some(active) = AgentInstance::find_active_by_owner(&mut conn, &requester.owner_npub)
         .map_err(|_| AgentApiError::from_code(AgentApiErrorCode::Internal))?
     else {
+        let Some(latest) = AgentInstance::find_latest_by_owner(&mut conn, &requester.owner_npub)
+            .map_err(|_| AgentApiError::from_code(AgentApiErrorCode::Internal))?
+        else {
+            return Err(AgentApiError::from_code(AgentApiErrorCode::AgentNotFound));
+        };
+        if latest.phase == AGENT_PHASE_ERROR {
+            return Ok(Json(map_row_to_response(latest)?));
+        }
         return Err(AgentApiError::from_code(AgentApiErrorCode::AgentNotFound));
     };
     let normalized = if active.phase == AGENT_PHASE_CREATING && active.vm_id.is_some() {

--- a/crates/pika-server/src/models/agent_instance.rs
+++ b/crates/pika-server/src/models/agent_instance.rs
@@ -85,6 +85,19 @@ impl AgentInstance {
         Ok(found)
     }
 
+    pub fn find_latest_by_owner(
+        conn: &mut PgConnection,
+        owner_npub: &str,
+    ) -> anyhow::Result<Option<Self>> {
+        let found = agent_instances::table
+            .filter(agent_instances::owner_npub.eq(owner_npub))
+            .order(agent_instances::created_at.desc())
+            .select(Self::as_select())
+            .first::<Self>(conn)
+            .optional()?;
+        Ok(found)
+    }
+
     pub fn update_phase(
         conn: &mut PgConnection,
         agent_id: &str,

--- a/crates/pika-server/src/models/mod.rs
+++ b/crates/pika-server/src/models/mod.rs
@@ -192,6 +192,43 @@ mod test {
             .expect("active row should exist");
         assert_eq!(active.agent_id, "agent-1");
 
+        let latest = AgentInstance::find_latest_by_owner(&mut conn, owner_npub)
+            .expect("query latest row")
+            .expect("latest row should exist");
+        assert_eq!(latest.agent_id, "agent-3");
+        assert_eq!(latest.phase, AGENT_PHASE_ERROR);
+
+        clear_database(&db_pool);
+    }
+
+    #[tokio::test]
+    async fn test_agent_instance_latest_owner_row_surfaces_error_without_active_row() {
+        let _guard = test_guard();
+        let db_pool = init_db_pool();
+        clear_database(&db_pool);
+        let mut conn = db_pool.get().unwrap();
+        let owner_npub = "npub1ownererrortest";
+
+        let errored = AgentInstance::create(
+            &mut conn,
+            owner_npub,
+            "agent-error",
+            Some("vm-error"),
+            AGENT_PHASE_ERROR,
+        )
+        .expect("insert error row");
+        assert_eq!(errored.phase, AGENT_PHASE_ERROR);
+
+        let active =
+            AgentInstance::find_active_by_owner(&mut conn, owner_npub).expect("query active row");
+        assert!(active.is_none(), "error row must not be treated as active");
+
+        let latest = AgentInstance::find_latest_by_owner(&mut conn, owner_npub)
+            .expect("query latest row")
+            .expect("latest row should exist");
+        assert_eq!(latest.agent_id, "agent-error");
+        assert_eq!(latest.phase, AGENT_PHASE_ERROR);
+
         clear_database(&db_pool);
     }
 

--- a/crates/vm-spawner/src/manager.rs
+++ b/crates/vm-spawner/src/manager.rs
@@ -192,6 +192,7 @@ impl VmManager {
             .ttl_seconds
             .unwrap_or(self.cfg.default_ttl_seconds)
             .clamp(60, 86400);
+        let keep = req.keep;
 
         let variant_raw = req
             .spawn_variant
@@ -237,6 +238,7 @@ impl VmManager {
                     created_at,
                     expires_at,
                     status: "starting".into(),
+                    keep,
                     spawn_variant: variant.as_str().into(),
                 },
             );
@@ -543,7 +545,7 @@ impl VmManager {
             guard
                 .vms
                 .values()
-                .filter(|vm| vm.expires_at <= now)
+                .filter(|vm| is_vm_expired(vm, now))
                 .map(|vm| vm.id.clone())
                 .collect::<Vec<_>>()
         };
@@ -1014,6 +1016,10 @@ impl VmManager {
             .with_context(|| format!("write vm metadata {}", vm_json.display()))?;
         Ok(())
     }
+}
+
+fn is_vm_expired(vm: &PersistedVm, now: chrono::DateTime<Utc>) -> bool {
+    !vm.keep && vm.expires_at <= now
 }
 
 fn sanitize_flake_ref(value: String) -> anyhow::Result<String> {
@@ -1960,4 +1966,44 @@ fn total_memory_mb() -> Option<u64> {
 
 fn to_ms(duration: Duration) -> u64 {
     duration.as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration as ChronoDuration;
+
+    fn test_vm(keep: bool, expires_at: chrono::DateTime<Utc>) -> PersistedVm {
+        PersistedVm {
+            id: "vm-test".to_string(),
+            flake_ref: "github:sledtools/pika".to_string(),
+            dev_shell: "default".to_string(),
+            cpu: 1,
+            memory_mb: 1024,
+            ttl_seconds: 7200,
+            ip: "192.168.83.10".to_string(),
+            tap_name: "vm-test".to_string(),
+            mac_address: "02:00:00:00:00:01".to_string(),
+            microvm_state_dir: PathBuf::from("/tmp/vm-test"),
+            definition_dir: PathBuf::from("/tmp/vm-def"),
+            ssh_private_key_path: PathBuf::from("/tmp/ssh-key"),
+            ssh_public_key_path: PathBuf::from("/tmp/ssh-key.pub"),
+            llm_session_token: "session-vm-test".to_string(),
+            created_at: expires_at - ChronoDuration::seconds(60),
+            expires_at,
+            status: "running".to_string(),
+            keep,
+            spawn_variant: "prebuilt-cow".to_string(),
+        }
+    }
+
+    #[test]
+    fn keep_vms_are_not_considered_expired() {
+        let now = Utc::now();
+        let kept = test_vm(true, now - ChronoDuration::seconds(1));
+        assert!(!is_vm_expired(&kept, now));
+
+        let expiring = test_vm(false, now - ChronoDuration::seconds(1));
+        assert!(is_vm_expired(&expiring, now));
+    }
 }

--- a/crates/vm-spawner/src/models.rs
+++ b/crates/vm-spawner/src/models.rs
@@ -11,6 +11,8 @@ pub struct CreateVmRequest {
     pub cpu: Option<u32>,
     pub memory_mb: Option<u32>,
     pub ttl_seconds: Option<u64>,
+    #[serde(default)]
+    pub keep: bool,
     pub spawn_variant: Option<String>,
     pub guest_autostart: Option<GuestAutostartRequest>,
 }
@@ -36,6 +38,7 @@ pub struct VmResponse {
     pub status: String,
     pub created_at: DateTime<Utc>,
     pub ttl_seconds: u64,
+    pub keep: bool,
     pub flake_ref: String,
     pub dev_shell: String,
     pub spawn_variant: String,
@@ -83,6 +86,8 @@ pub struct PersistedVm {
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
     pub status: String,
+    #[serde(default)]
+    pub keep: bool,
     #[serde(default = "default_spawn_variant")]
     pub spawn_variant: String,
 }
@@ -105,6 +110,7 @@ impl PersistedVm {
             status: self.status.clone(),
             created_at: self.created_at,
             ttl_seconds: self.ttl_seconds,
+            keep: self.keep,
             flake_ref: self.flake_ref.clone(),
             dev_shell: self.dev_shell.clone(),
             spawn_variant: self.spawn_variant.clone(),

--- a/todos/microvm-v1.md
+++ b/todos/microvm-v1.md
@@ -68,19 +68,7 @@ Acceptance criteria: app shows button only for whitelisted npubs, calls `ensure`
 11. Execute 3-dev checkpoint gate.
 Acceptance criteria: Justin, Ben, and Paul each complete create -> ready -> Marmot exchange; at least one restart/recover preserves state/files.
 
-## Deferred Follow-Ups (Post-PR)
+## Carryover Tracking
 
 Decision update (2026-03-05):
-Ship the v1 baseline now and iterate on master. The items below are intentionally deferred and should be completed next.
-
-1. Readiness semantics hardening.
-Current behavior can promote `creating` to `ready` based on DB/VM-id heuristics before the guest daemon is actually usable.
-Follow-up: gate `ready` on runtime-verified status from vm-spawner.
-
-2. App-side dogfood button gating alignment.
-Current iOS dogfood UI gating is signer-mode based and not allowlist-aware.
-Follow-up: make button visibility/prompting align with server allowlist outcomes to reduce dead-end UX.
-
-3. Deterministic reply-path coverage.
-Current deterministic CI focuses on ensure/me/recover contracts and does not assert end-to-end chat reply readiness.
-Follow-up: add deterministic `agent chat` reply-path coverage so regressions are caught pre-merge.
+The remaining post-v1 dogfood carryovers are now tracked in `todos/microvm-v2.md` under a dedicated end-of-file section so the next phase has one home for unfinished work.

--- a/todos/microvm-v2.md
+++ b/todos/microvm-v2.md
@@ -47,3 +47,19 @@ Acceptance criteria: admin tools show owner, vm id, lifecycle phase, and last fa
 
 6. Execute pilot opening gate for first-100.
 Acceptance criteria: team validates allowlist flow, capacity behavior, isolation checks, and recovery workflow before enabling broader onboarding.
+
+## Carryover From v1 Dogfood Baseline
+
+These items were intentionally deferred from `microvm-v1.md` and should be completed before treating the dogfood baseline as fully hardened.
+
+1. Readiness semantics hardening.
+Current behavior can promote `creating` to `ready` based on DB/VM-id heuristics before the guest daemon is actually usable.
+Follow-up: gate `ready` on runtime-verified status from vm-spawner.
+
+2. App-side dogfood button gating alignment.
+Current iOS dogfood UI gating is signer-mode based and not allowlist-aware.
+Follow-up: make button visibility/prompting align with server allowlist outcomes to reduce dead-end UX.
+
+3. Deterministic reply-path coverage.
+Current deterministic CI focuses on ensure/me/recover contracts and does not assert end-to-end chat reply readiness.
+Follow-up: add deterministic `agent chat` reply-path coverage so regressions are caught pre-merge.


### PR DESCRIPTION
## Summary
- move the deferred microvm v1 carryovers into a dedicated section at the end of `todos/microvm-v2.md`
- stop personal-agent VMs from being reaped on the generic TTL path by marking them `keep`
- let `GET /v1/agents/me` surface the latest `error` lifecycle row when no active row exists

## Testing
- cargo fmt
- cargo test -p pika-agent-microvm
- cargo test -p vm-spawner keep_vms_are_not_considered_expired -- --nocapture
- cargo test -p pika-server agent_api::tests -- --nocapture
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
