### PR TITLE
Distinguish suppressed notifications from errors

### DIFF
--- a/crates/pika-nse/src/lib.rs
+++ b/crates/pika-nse/src/lib.rs
@@ -30,8 +30,8 @@ pub enum PushNotificationResult {
         caller_picture_url: Option<String>,
         is_video: bool,
     },
-    /// Recognised but should not alert (self-message, call signal, etc.).
-    Suppress,
+    /// Something went wrong during decryption / processing.
+    Error { message: String },
 }
 
 #[derive(serde::Deserialize)]
@@ -63,14 +63,42 @@ pub fn decrypt_push_notification(
 ) -> Option<PushNotificationResult> {
     pika_tls::init_rustls_crypto_provider();
 
-    let keys = nostr::Keys::parse(&nsec).ok()?;
+    let keys = match nostr::Keys::parse(&nsec) {
+        Ok(k) => k,
+        Err(e) => {
+            return Some(PushNotificationResult::Error {
+                message: format!("failed to parse nsec: {e}"),
+            })
+        }
+    };
     let pubkey = keys.public_key();
 
-    let mdk = mdk_support::open_mdk(&data_dir, &pubkey, &keychain_group).ok()?;
+    let mdk = match mdk_support::open_mdk(&data_dir, &pubkey, &keychain_group) {
+        Ok(m) => m,
+        Err(e) => {
+            return Some(PushNotificationResult::Error {
+                message: format!("failed to open mdk: {e}"),
+            })
+        }
+    };
 
-    let event: Event = serde_json::from_str(&event_json).ok()?;
+    let event: Event = match serde_json::from_str(&event_json) {
+        Ok(e) => e,
+        Err(e) => {
+            return Some(PushNotificationResult::Error {
+                message: format!("failed to parse event json: {e}"),
+            })
+        }
+    };
 
-    let result = mdk.process_message(&event).ok()?;
+    let result = match mdk.process_message(&event) {
+        Ok(r) => r,
+        Err(e) => {
+            return Some(PushNotificationResult::Error {
+                message: format!("failed to process message: {e}"),
+            })
+        }
+    };
 
     let msg = match result {
         MessageProcessingResult::ApplicationMessage(msg) => msg,
@@ -79,14 +107,26 @@ pub fn decrypt_push_notification(
 
     // Don't notify for self-messages.
     if msg.pubkey == pubkey {
-        return Some(PushNotificationResult::Suppress);
+        return None;
     }
 
-    let group = mdk.get_group(&msg.mls_group_id).ok()??;
-    let chat_id = hex::encode(group.nostr_group_id);
+    // Helper: fetch group only in branches that need it.
+    let get_group = || match mdk.get_group(&msg.mls_group_id) {
+        Ok(Some(g)) => Ok(g),
+        Ok(None) => Err("group not found".to_string()),
+        Err(e) => Err(format!("failed to get group: {e}")),
+    };
 
     match msg.kind {
         Kind::ChatMessage | Kind::Reaction => {
+            let group = match get_group() {
+                Ok(g) => g,
+                Err(e) => {
+                    return Some(PushNotificationResult::Error { message: e });
+                }
+            };
+            let chat_id = hex::encode(group.nostr_group_id);
+
             let media = match msg.kind {
                 Kind::ChatMessage => notif_media(&msg.tags),
                 _ => None,
@@ -101,7 +141,7 @@ pub fn decrypt_push_notification(
                             format!("{} {}", media.kind.emoji(), msg.content)
                         }
                     } else if msg.content.is_empty() {
-                        return Some(PushNotificationResult::Suppress);
+                        return None;
                     } else {
                         msg.content
                     }
@@ -150,10 +190,24 @@ pub fn decrypt_push_notification(
             })
         }
         Kind::Custom(10) => {
-            let probe: CallProbe = serde_json::from_str(&msg.content).ok()?;
+            let probe: CallProbe = match serde_json::from_str(&msg.content) {
+                Ok(p) => p,
+                Err(e) => {
+                    return Some(PushNotificationResult::Error {
+                        message: format!("failed to parse call probe: {e}"),
+                    })
+                }
+            };
             if probe.msg_type != "call.invite" {
-                return Some(PushNotificationResult::Suppress);
+                return None;
             }
+            let group = match get_group() {
+                Ok(g) => g,
+                Err(e) => {
+                    return Some(PushNotificationResult::Error { message: e });
+                }
+            };
+            let chat_id = hex::encode(group.nostr_group_id);
             let is_video = probe
                 .body
                 .as_ref()
@@ -170,7 +224,7 @@ pub fn decrypt_push_notification(
                 is_video,
             })
         }
-        _ => Some(PushNotificationResult::Suppress),
+        _ => None,
     }
 }
 

--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -75,21 +75,21 @@ class NotificationService: UNNotificationServiceExtension {
                 )
                 contentHandler(updated)
             }
-        case .callInvite(let info):
-            content.title = info.callerName
-            content.body = info.isVideo ? "Incoming video call" : "Incoming call"
+        case .callInvite(let chatId, let callId, let callerName, let callerPictureUrl, let isVideo):
+            content.title = callerName
+            content.body = isVideo ? "Incoming video call" : "Incoming call"
             content.sound = .defaultCritical
-            content.userInfo["chat_id"] = info.chatId
-            content.userInfo["call_id"] = info.callId
-            content.threadIdentifier = info.chatId
+            content.userInfo["chat_id"] = chatId
+            content.userInfo["call_id"] = callId
+            content.threadIdentifier = chatId
 
-            if let urlStr = info.callerPictureUrl, let url = URL(string: urlStr) {
+            if let urlStr = callerPictureUrl, let url = URL(string: urlStr) {
                 Self.downloadAvatar(url: url) { image in
                     let updated = Self.applyCommNotification(
                         to: content,
-                        senderName: info.callerName,
-                        senderPubkey: info.chatId,
-                        chatId: info.chatId,
+                        senderName: callerName,
+                        senderPubkey: chatId,
+                        chatId: chatId,
                         senderImage: image
                     )
                     contentHandler(updated)
@@ -97,17 +97,22 @@ class NotificationService: UNNotificationServiceExtension {
             } else {
                 let updated = Self.applyCommNotification(
                     to: content,
-                    senderName: info.callerName,
-                    senderPubkey: info.chatId,
-                    chatId: info.chatId,
+                    senderName: callerName,
+                    senderPubkey: chatId,
+                    chatId: chatId,
                     senderImage: nil
                 )
                 contentHandler(updated)
             }
-        case .suppress, nil:
-            // Suppress: self-message, call signal, already processed, or decrypt failure.
-            // Deliver a fresh empty content so iOS has no alert to display.
-            contentHandler(UNMutableNotificationContent())
+        case .error(let message):
+            let errContent = UNMutableNotificationContent()
+            errContent.body = "[error] \(message)"
+            contentHandler(errContent)
+        case nil:
+            // Suppressed: self-message, call signal, non-app MLS message, etc.
+            let suppressed = UNMutableNotificationContent()
+            suppressed.body = "[suppressed]"
+            contentHandler(suppressed)
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove `Suppress` variant from `PushNotificationResult` — `None`/`nil` now means legitimate suppression (self-messages, call signals, non-app MLS messages)
- Add `Error { message }` variant with descriptive error messages for actual failures (nsec parse, MDK open, MLS decryption, missing group, etc.)
- Notification body shows `[suppressed]` or `[error] <details>` so we can tell them apart while waiting on Apple approval for silent suppression

## Test plan
- [ ] Send a message to yourself — should show `[suppressed]`
- [ ] Receive a normal message — should show the decrypted content as before
- [ ] Trigger a decryption failure (e.g. stale MLS state) — should show `[error] failed to process message: ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded incoming call notifications with richer caller info, avatar support, video/voice distinction, and updated title/body content and sound.
  * Added explicit visible formats for error and suppressed notifications to clarify status to users.

* **Bug Fixes**
  * Notifications now show descriptive error messages for decryption, parsing, and lookup failures rather than failing silently.
  * Improved consistency and reliability of notification delivery and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->