### PR TITLE
Guard against duplicate DM creation from double-tap

### DIFF
--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -4869,6 +4869,9 @@ impl AppCore {
                     }
                 };
 
+                if self.state.busy.creating_chat {
+                    return;
+                }
                 self.set_busy(|b| b.creating_chat = true);
 
                 // Allow "note to self" flow for local/offline testing.
@@ -7301,6 +7304,7 @@ mod tests {
     mod group_management_validation {
         use super::*;
         use crate::actions::AppAction;
+        use nostr_sdk::{Keys, ToBech32};
 
         /// Create a core with a minimal session (logged in, no groups registered).
         fn make_logged_in_core() -> (AppCore, tempfile::TempDir) {
@@ -7375,6 +7379,25 @@ mod tests {
                 .as_deref()
                 .unwrap()
                 .contains("Invalid npub"));
+        }
+
+        #[test]
+        fn create_chat_ignores_second_dispatch_while_busy() {
+            let (mut core, _tmp) = make_logged_in_core();
+            let peer_keys = Keys::generate();
+            let peer_npub = peer_keys.public_key().to_bech32().unwrap();
+
+            // Simulate first dispatch already in progress.
+            core.set_busy(|b| b.creating_chat = true);
+
+            core.handle_action(AppAction::CreateChat {
+                peer_npub: peer_npub.clone(),
+            });
+
+            // Should be a no-op: no toast, no navigation, still busy.
+            assert!(core.state.toast.is_none());
+            assert!(core.state.router.screen_stack.is_empty());
+            assert!(core.state.busy.creating_chat);
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- When `CreateChat` is dispatched while a previous creation is still in flight (async key package fetch), the second dispatch is now ignored instead of creating a duplicate MLS group
- Adds a unit test verifying the guard

## Test plan
- [x] `cargo test -p pika_core --lib -- create_chat_ignores` passes
- [ ] Manual: tap "create DM" rapidly — only one DM should be created

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate chat creation attempts when a creation is already in progress. The app will no longer process subsequent creation requests while one is active.

* **Tests**
  * Added test to verify that duplicate chat creation requests are ignored while a creation is in flight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->