### PR TITLE
Show display name instead of truncated pubkey in group toasts

### DIFF
--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -5477,6 +5477,10 @@ impl AppCore {
                 let fallback_kp_relays = self.key_package_relays();
                 let fallback_popular_relays = self.default_relays();
                 let chat_id_clone = chat_id.clone();
+                let peer_names: HashMap<PublicKey, String> = peer_pubkeys
+                    .iter()
+                    .map(|pk| (*pk, self.peer_display_name(pk)))
+                    .collect();
 
                 // Fetch key packages then add members.
                 self.runtime.spawn(async move {
@@ -5502,7 +5506,12 @@ impl AppCore {
                         let names: Vec<String> = fetched
                             .failed_peers
                             .iter()
-                            .map(|(pk, e)| format!("{}: {e}", &pk.to_hex()[..8]))
+                            .map(|(pk, e)| {
+                                let hex = pk.to_hex();
+                                let name =
+                                    peer_names.get(pk).map(|s| s.as_str()).unwrap_or(&hex[..8]);
+                                format!("{name}: {e}")
+                            })
                             .collect();
                         let _ = tx.send(CoreMsg::Internal(Box::new(InternalEvent::Toast(
                             format!("Failed to fetch key packages for: {}", names.join(", ")),


### PR DESCRIPTION
## Summary
- Add `peer_display_name()` helper that resolves a pubkey to the peer's profile name, username, or truncated hex as a last resort
- Use it in all three toast messages shown when adding group members fails (both sync and async paths)

## Test plan
- [ ] Create a group chat where one peer has no key packages — toast should show their name, not `a1b2c3d4`
- [ ] Verify peers with only a username (no display name) show the username
- [ ] Verify unknown peers still fall back to truncated hex

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved peer identification in error messages, failure notifications, and logs. The application now displays readable peer names from cached profiles instead of raw hexadecimal codes, with automatic fallback to shortened hex identifiers when profile data is unavailable, enhancing clarity across failure scenarios and key package operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->