### PR TITLE
Fix flaky paging test timeout

### DIFF
--- a/rust/tests/app_flows.rs
+++ b/rust/tests/app_flows.rs
@@ -866,7 +866,7 @@ fn paging_loads_older_messages_in_pages() {
     }
     wait_until(
         "all messages visible in list",
-        Duration::from_secs(5),
+        Duration::from_secs(10),
         || {
             app.state()
                 .chat_list


### PR DESCRIPTION
## Summary
- Increase timeout from 5s to 10s for the `paging_loads_older_messages_in_pages` test's "all messages visible in list" wait
- The test sends 81 messages and under CPU contention from parallel execution the 5s timeout wasn't enough

Fixes #447

## Test plan
- [x] `cargo test -p pika_core --test app_flows paging_loads_older_messages_in_pages` passes
- [ ] Full `cargo test -p pika_core` no longer flakes on this test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for message pagination by adjusting timeout parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
