### PR TITLE
pika-news: auto-refresh, markdown rendering, wider diffs

### DIFF
--- a/crates/pika-news/templates/detail.html
+++ b/crates/pika-news/templates/detail.html
@@ -6,10 +6,11 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" media="(prefers-color-scheme: light)" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" media="(prefers-color-scheme: dark)" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/diff2html@3.4.51/bundles/css/diff2html.min.css" />
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 {% endblock %}
 
 {% block styles %}
-      .shell { max-width: 1050px; margin: 0 auto; padding: 2rem 1rem; }
+      .shell { margin: 0 auto; padding: 2rem 1rem; }
       .meta { color: var(--text-secondary); font-size: 0.92rem; }
       .status { display: inline-block; border-radius: 999px; border: 1px solid var(--border-light); padding: 0.1rem 0.55rem; margin-right: 0.4rem; font-size: 0.8rem; }
       .panel { background: var(--surface-solid); border: 1px solid var(--border); border-radius: 14px; padding: 1rem; margin-top: 1rem; }
@@ -18,12 +19,14 @@
       .step { display: none; }
       .step.active { display: block; }
       .evidence { background: var(--badge-bg-alt); border-radius: 10px; padding: 0.75rem; }
+      .evidence pre { margin: 0.5rem 0; overflow-x: auto; white-space: pre-wrap; word-break: break-all; }
+      .evidence pre code { font-size: 0.82rem; background: none; padding: 0; }
       pre code.hljs { border-radius: 10px; }
       table { border-collapse: collapse; width: 100%; margin: 0.75rem 0; }
       th, td { border: 1px solid var(--border); padding: 0.4rem 0.75rem; text-align: left; font-size: 0.9rem; }
       th { background: var(--badge-bg); font-weight: 600; }
       tr:nth-child(even) { background: var(--badge-bg-row); }
-      .d2h-wrapper { border-radius: 10px; overflow: hidden; }
+      .d2h-wrapper { border-radius: 10px; overflow-x: auto; }
       .diff-view-toggle { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; }
       .diff-view-toggle button.active { background: var(--link); color: #fff; border-color: var(--link); }
 
@@ -58,13 +61,24 @@
       .chat-status { padding: 0.5rem 1rem; font-size: 0.82rem; color: var(--text-muted); text-align: center; }
       .chat-disabled { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 1.5rem; text-align: center; color: var(--text-muted); }
       .chat-disabled svg { width: 48px; height: 48px; margin-bottom: 0.75rem; opacity: 0.4; }
+      /* Markdown in panels */
+      .panel pre { overflow-x: auto; background: var(--badge-bg); border-radius: 8px; padding: 0.75rem; }
+      .panel code { font-size: 0.85rem; background: var(--badge-bg); padding: 0.1rem 0.3rem; border-radius: 3px; }
+      .panel pre code { background: none; padding: 0; }
+      /* Markdown in chat */
+      .chat-msg pre { overflow-x: auto; background: var(--badge-bg); border-radius: 6px; padding: 0.5rem; margin: 0.4rem 0; }
+      .chat-msg code { font-size: 0.82rem; }
+      .chat-msg p { margin: 0.3rem 0; }
+      .chat-msg p:first-child { margin-top: 0; }
+      .chat-msg p:last-child { margin-bottom: 0; }
+      .chat-msg ul, .chat-msg ol { margin: 0.3rem 0; padding-left: 1.2rem; }
       @media (max-width: 900px) { .chat-sidebar { width: 300px; } }
       @media (max-width: 640px) { .page-layout { flex-direction: column; } .chat-sidebar { width: 100%; position: static; height: 400px; } }
 {% endblock %}
 
 {% block body %}
     {% if chat_enabled %}
-    <div class="page-layout" style="max-width:1500px;margin:0 auto;padding:2rem 1rem;">
+    <div class="page-layout" style="margin:0 auto;padding:2rem 1rem;">
     {% endif %}
     <main class="shell">
       <p><a href="/news">Back to feed</a></p>
@@ -108,11 +122,9 @@
           <p><strong>Affected files:</strong> {{ step.affected_files }}</p>
           <div class="evidence">
             <strong>Evidence</strong>
-            <ul>
-              {% for evidence in step.evidence_snippets %}
-              <li><code>{{ evidence }}</code></li>
-              {% endfor %}
-            </ul>
+            {% for evidence in step.evidence_snippets %}
+            <pre><code>{{ evidence }}</code></pre>
+            {% endfor %}
           </div>
           <div>{{ step.body_html|safe }}</div>
         </article>
@@ -260,7 +272,11 @@
           if (!messagesDiv) return;
           const div = document.createElement('div');
           div.className = 'chat-msg ' + role;
-          div.textContent = content;
+          if (role === 'assistant' && window.marked) {
+            div.innerHTML = marked.parse(content);
+          } else {
+            div.textContent = content;
+          }
           messagesDiv.appendChild(div);
           messagesDiv.scrollTop = messagesDiv.scrollHeight;
         }
@@ -368,6 +384,14 @@
         // Check if already authed
         if (window.pikaAuth && window.pikaAuth.isAuthed()) {
           onAuthed();
+        }
+      })();
+
+      // Auto-refresh while generation is in progress
+      (function () {
+        var status = '{{ generation_status }}';
+        if (status === 'generating' || status === 'pending') {
+          setTimeout(function () { location.reload(); }, 10000);
         }
       })();
     </script>


### PR DESCRIPTION
## Summary
- Auto-reload detail page every 10s when generation status is `pending` or `generating`, stops once `ready`/`failed`
- Add marked.js for client-side markdown rendering in chat assistant responses
- Evidence snippets now render as `pre/code` blocks instead of inline `code` (with hljs syntax highlighting)
- Added CSS for markdown content in panels and chat messages
- Removed shell/page-layout max-width constraints so diffs use full viewport width
- Changed d2h-wrapper from `overflow: hidden` to `overflow-x: auto` (was clipping diff content)

## Test plan
- [x] Verified auto-refresh fires on generating pages, does not fire on ready pages
- [x] Verified evidence renders as highlighted code blocks
- [x] Verified diff view uses full width
- [x] Deployed to pika-build and tested on news.pikachat.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Markdown rendering support for assistant messages
  * Implemented auto-refresh functionality during content generation
  * Improved evidence block display with multi-line code formatting

* **Improvements**
  * Enhanced layout flexibility and visual styling
  * Better horizontal scrolling support for code and diff displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->