### PR TITLE
pika-news: resizable chat panel + toggle hotkey

### DIFF
--- a/crates/pika-news/templates/detail.html
+++ b/crates/pika-news/templates/detail.html
@@ -49,7 +49,10 @@
       /* Chat sidebar */
       .page-layout { display: flex; gap: 1.5rem; }
       .page-layout .shell { flex: 1; min-width: 0; }
-      .chat-sidebar { width: 360px; flex-shrink: 0; position: sticky; top: 4rem; height: calc(100vh - 5rem); display: flex; flex-direction: column; background: var(--surface-solid); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; }
+      .chat-sidebar { width: 360px; flex-shrink: 0; position: sticky; top: 4rem; height: calc(100vh - 5rem); display: flex; flex-direction: column; background: var(--surface-solid); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; transition: width 0.15s ease; }
+      .chat-sidebar.hidden { display: none; }
+      .chat-resize-handle { position: absolute; left: -3px; top: 0; bottom: 0; width: 6px; cursor: col-resize; z-index: 10; border-radius: 3px; }
+      .chat-resize-handle:hover, .chat-resize-handle.dragging { background: var(--link); opacity: 0.4; }
       .chat-sidebar h3 { margin: 0; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border); font-size: 0.95rem; background: var(--badge-bg); }
       .chat-messages { flex: 1; overflow-y: auto; padding: 0.75rem; display: flex; flex-direction: column; gap: 0.5rem; }
       .chat-msg { padding: 0.5rem 0.75rem; border-radius: 10px; font-size: 0.88rem; line-height: 1.4; max-width: 90%; word-wrap: break-word; }
@@ -165,7 +168,8 @@
 
     {% if chat_enabled %}
     <aside class="chat-sidebar" id="chat-sidebar">
-      <h3>Chat with Tutorial</h3>
+      <div class="chat-resize-handle" id="chat-resize-handle"></div>
+      <h3 id="chat-header">Chat with Tutorial</h3>
       <div id="chat-disabled" class="chat-disabled">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" /></svg>
         <p style="font-size:0.85rem;margin:0 0 0.5rem 0;">Chat is available to contributors with whitelisted pubkeys.</p>
@@ -385,6 +389,60 @@
         if (window.pikaAuth && window.pikaAuth.isAuthed()) {
           onAuthed();
         }
+
+        // --- Resize handle ---
+        var handle = document.getElementById('chat-resize-handle');
+        if (handle && sidebar) {
+          var savedWidth = localStorage.getItem('pika_news_chat_width');
+          if (savedWidth) sidebar.style.width = savedWidth + 'px';
+
+          var startX, startW;
+          handle.addEventListener('mousedown', function (e) {
+            e.preventDefault();
+            startX = e.clientX;
+            startW = sidebar.offsetWidth;
+            handle.classList.add('dragging');
+            sidebar.style.transition = 'none';
+            document.addEventListener('mousemove', onDrag);
+            document.addEventListener('mouseup', onUp);
+          });
+          function onDrag(e) {
+            var newW = startW - (e.clientX - startX);
+            if (newW < 200) newW = 200;
+            if (newW > 800) newW = 800;
+            sidebar.style.width = newW + 'px';
+          }
+          function onUp() {
+            handle.classList.remove('dragging');
+            sidebar.style.transition = '';
+            localStorage.setItem('pika_news_chat_width', sidebar.offsetWidth);
+            document.removeEventListener('mousemove', onDrag);
+            document.removeEventListener('mouseup', onUp);
+          }
+        }
+
+        // --- Toggle chat: Cmd+. / Ctrl+. ---
+        var chatHeader = document.getElementById('chat-header');
+        if (chatHeader) {
+          var mod = /Mac|iPhone|iPad/.test(navigator.platform) ? '\u2318' : 'Ctrl';
+          var kbd = document.createElement('kbd');
+          kbd.textContent = mod + '.';
+          kbd.style.cssText = 'float:right;font-size:0.7rem;opacity:0.5;font-weight:normal;';
+          chatHeader.appendChild(kbd);
+        }
+
+        if (localStorage.getItem('pika_news_chat_hidden') === '1' && sidebar) {
+          sidebar.classList.add('hidden');
+        }
+
+        window.addEventListener('keydown', function (e) {
+          if (e.key === '.' && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+            e.preventDefault();
+            if (!sidebar) return;
+            sidebar.classList.toggle('hidden');
+            localStorage.setItem('pika_news_chat_hidden', sidebar.classList.contains('hidden') ? '1' : '0');
+          }
+        });
       })();
 
       // Auto-refresh while generation is in progress


### PR DESCRIPTION
## Summary
- Drag left edge of chat sidebar to resize (200-800px, persisted to localStorage)
- Cmd+. (macOS) / Ctrl+. (other) toggles chat panel visibility (persisted)
- Subtle hotkey hint in chat header with platform-appropriate modifier

## Test plan
- [x] Build passes
- [ ] Verify resize drag works on news.pikachat.org
- [ ] Verify Cmd+. toggles chat, persists across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat sidebar is now resizable—drag the resize handle to adjust width as needed.
  * Toggle chat visibility on/off using Cmd/Ctrl + . keyboard shortcut.
  * Chat sidebar width and visibility state are automatically saved and restored between sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->