### PR TITLE
pikaci: stage linux rust prepare/execute lane

### DIFF
--- a/crates/pikaci/src/executor.rs
+++ b/crates/pikaci/src/executor.rs
@@ -22,6 +22,8 @@ pub struct HostContext {
     pub guest_log_path: PathBuf,
     pub shared_cargo_home_dir: PathBuf,
     pub shared_target_dir: PathBuf,
+    pub staged_linux_rust_workspace_deps_dir: Option<PathBuf>,
+    pub staged_linux_rust_workspace_build_dir: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -30,6 +32,15 @@ struct GuestResult {
     exit_code: i32,
     finished_at: String,
     message: Option<String>,
+}
+
+struct GuestFlakePaths<'a> {
+    artifacts_dir: &'a Path,
+    cargo_home_dir: &'a Path,
+    target_dir: &'a Path,
+    staged_linux_rust_workspace_deps_dir: Option<&'a Path>,
+    staged_linux_rust_workspace_build_dir: Option<&'a Path>,
+    socket_path: &'a Path,
 }
 
 const TART_BASE_VM_ENV: &str = "PIKACI_TART_BASE_VM";
@@ -199,10 +210,18 @@ pub(crate) fn materialize_vfkit_runner_flake(
         job,
         &ctx.workspace_snapshot_dir,
         ctx.workspace_read_only,
-        &artifacts_dir,
-        &ctx.shared_cargo_home_dir,
-        &ctx.shared_target_dir,
-        &socket_path,
+        &GuestFlakePaths {
+            artifacts_dir: &artifacts_dir,
+            cargo_home_dir: &ctx.shared_cargo_home_dir,
+            target_dir: &ctx.shared_target_dir,
+            staged_linux_rust_workspace_deps_dir: ctx
+                .staged_linux_rust_workspace_deps_dir
+                .as_deref(),
+            staged_linux_rust_workspace_build_dir: ctx
+                .staged_linux_rust_workspace_build_dir
+                .as_deref(),
+            socket_path: &socket_path,
+        },
     )?;
     fs::write(flake_dir.join("flake.nix"), flake_nix)
         .with_context(|| format!("write {}", flake_dir.join("flake.nix").display()))?;
@@ -937,18 +956,23 @@ fn render_guest_flake(
     job: &JobSpec,
     workspace_dir: &Path,
     workspace_read_only: bool,
-    artifacts_dir: &Path,
-    cargo_home_dir: &Path,
-    target_dir: &Path,
-    socket_path: &Path,
+    paths: &GuestFlakePaths<'_>,
 ) -> anyhow::Result<String> {
     let (host_uid, host_gid) = ownership_ids(workspace_dir)?;
     let (guest_command, run_as_root) = compiled_guest_command(job);
     let workspace_dir = nix_escape(&workspace_dir.display().to_string());
-    let artifacts_dir = nix_escape(&artifacts_dir.display().to_string());
-    let cargo_home_dir = nix_escape(&cargo_home_dir.display().to_string());
-    let target_dir = nix_escape(&target_dir.display().to_string());
-    let socket_path = nix_escape(&socket_path.display().to_string());
+    let artifacts_dir = nix_escape(&paths.artifacts_dir.display().to_string());
+    let cargo_home_dir = nix_escape(&paths.cargo_home_dir.display().to_string());
+    let target_dir = nix_escape(&paths.target_dir.display().to_string());
+    let staged_linux_rust_workspace_deps_dir = paths
+        .staged_linux_rust_workspace_deps_dir
+        .map(|path| format!("\"{}\"", nix_escape(&path.display().to_string())))
+        .unwrap_or_else(|| "null".to_string());
+    let staged_linux_rust_workspace_build_dir = paths
+        .staged_linux_rust_workspace_build_dir
+        .map(|path| format!("\"{}\"", nix_escape(&path.display().to_string())))
+        .unwrap_or_else(|| "null".to_string());
+    let socket_path = nix_escape(&paths.socket_path.display().to_string());
     let guest_command = nix_escape(&guest_command);
     let workspace_read_only = if workspace_read_only { "true" } else { "false" };
     let cacert_bundle = nix_escape("/etc/ssl/certs/ca-bundle.crt");
@@ -976,6 +1000,8 @@ fn render_guest_flake(
           artifactsDir = "{artifacts_dir}";
           cargoHomeDir = "{cargo_home_dir}";
           cargoTargetDir = "{target_dir}";
+          stagedLinuxRustWorkspaceDepsDir = {staged_linux_rust_workspace_deps_dir};
+          stagedLinuxRustWorkspaceBuildDir = {staged_linux_rust_workspace_build_dir};
           socketPath = "{socket_path}";
           rustToolchain = pika.packages.aarch64-linux.rustToolchain;
           moqRelay = if pika.packages.aarch64-linux ? moqRelay then pika.packages.aarch64-linux.moqRelay else null;
@@ -997,6 +1023,10 @@ fn render_guest_flake(
 }
 
 pub(crate) fn compiled_guest_command(job: &JobSpec) -> (String, bool) {
+    if let Some(lane) = job.staged_linux_rust_lane() {
+        return (lane.execute_wrapper_command().to_string(), false);
+    }
+
     match job.guest_command {
         GuestCommand::ExactCargoTest { package, test_name } => (
             format!(
@@ -1077,7 +1107,9 @@ fn shell_escape(value: &str) -> String {
 mod tests {
     use std::path::Path;
 
-    use super::{builders_supports_aarch64_linux, render_guest_flake, vfkit_socket_path};
+    use super::{
+        GuestFlakePaths, builders_supports_aarch64_linux, render_guest_flake, vfkit_socket_path,
+    };
     use crate::model::{GuestCommand, JobSpec};
 
     #[test]
@@ -1096,10 +1128,14 @@ mod tests {
             &spec,
             Path::new("/tmp/pikaci/snapshot"),
             true,
-            Path::new("/tmp/pikaci/jobs/beachhead/artifacts"),
-            Path::new("/tmp/pikaci/cache/cargo-home"),
-            Path::new("/tmp/pikaci/cache/target"),
-            Path::new("/tmp/pikaci-beachhead.sock"),
+            &GuestFlakePaths {
+                artifacts_dir: Path::new("/tmp/pikaci/jobs/beachhead/artifacts"),
+                cargo_home_dir: Path::new("/tmp/pikaci/cache/cargo-home"),
+                target_dir: Path::new("/tmp/pikaci/cache/target"),
+                staged_linux_rust_workspace_deps_dir: None,
+                staged_linux_rust_workspace_build_dir: None,
+                socket_path: Path::new("/tmp/pikaci-beachhead.sock"),
+            },
         )
         .expect("render flake");
 
@@ -1161,10 +1197,14 @@ mod tests {
             &spec,
             Path::new("/tmp/pikaci/snapshot"),
             true,
-            Path::new("/tmp/pikaci/jobs/agent-control-plane-unit/artifacts"),
-            Path::new("/tmp/pikaci/cache/cargo-home"),
-            Path::new("/tmp/pikaci/cache/target"),
-            Path::new("/tmp/pikaci-agent-control-plane-unit.sock"),
+            &GuestFlakePaths {
+                artifacts_dir: Path::new("/tmp/pikaci/jobs/agent-control-plane-unit/artifacts"),
+                cargo_home_dir: Path::new("/tmp/pikaci/cache/cargo-home"),
+                target_dir: Path::new("/tmp/pikaci/cache/target"),
+                staged_linux_rust_workspace_deps_dir: None,
+                staged_linux_rust_workspace_build_dir: None,
+                socket_path: Path::new("/tmp/pikaci-agent-control-plane-unit.sock"),
+            },
         )
         .expect("render flake");
 
@@ -1188,10 +1228,14 @@ mod tests {
             &package_spec,
             Path::new("/tmp/pikaci/snapshot"),
             true,
-            Path::new("/tmp/pikaci/jobs/agent-microvm-tests/artifacts"),
-            Path::new("/tmp/pikaci/cache/cargo-home"),
-            Path::new("/tmp/pikaci/cache/target"),
-            Path::new("/tmp/pikaci-agent-microvm-tests.sock"),
+            &GuestFlakePaths {
+                artifacts_dir: Path::new("/tmp/pikaci/jobs/agent-microvm-tests/artifacts"),
+                cargo_home_dir: Path::new("/tmp/pikaci/cache/cargo-home"),
+                target_dir: Path::new("/tmp/pikaci/cache/target"),
+                staged_linux_rust_workspace_deps_dir: None,
+                staged_linux_rust_workspace_build_dir: None,
+                socket_path: Path::new("/tmp/pikaci-agent-microvm-tests.sock"),
+            },
         )
         .expect("render flake");
         assert!(
@@ -1213,10 +1257,14 @@ mod tests {
             &filtered_spec,
             Path::new("/tmp/pikaci/snapshot"),
             true,
-            Path::new("/tmp/pikaci/jobs/server-agent-api-tests/artifacts"),
-            Path::new("/tmp/pikaci/cache/cargo-home"),
-            Path::new("/tmp/pikaci/cache/target"),
-            Path::new("/tmp/pikaci-server-agent-api-tests.sock"),
+            &GuestFlakePaths {
+                artifacts_dir: Path::new("/tmp/pikaci/jobs/server-agent-api-tests/artifacts"),
+                cargo_home_dir: Path::new("/tmp/pikaci/cache/cargo-home"),
+                target_dir: Path::new("/tmp/pikaci/cache/target"),
+                staged_linux_rust_workspace_deps_dir: None,
+                staged_linux_rust_workspace_build_dir: None,
+                socket_path: Path::new("/tmp/pikaci-server-agent-api-tests.sock"),
+            },
         )
         .expect("render flake");
         assert!(filtered_flake.contains(
@@ -1239,10 +1287,14 @@ mod tests {
             &spec,
             Path::new("/tmp/pikaci/snapshot"),
             true,
-            Path::new("/tmp/pikaci/jobs/rmp-init-smoke-ci/artifacts"),
-            Path::new("/tmp/pikaci/cache/cargo-home"),
-            Path::new("/tmp/pikaci/cache/target"),
-            Path::new("/tmp/pikaci-rmp-init-smoke-ci.sock"),
+            &GuestFlakePaths {
+                artifacts_dir: Path::new("/tmp/pikaci/jobs/rmp-init-smoke-ci/artifacts"),
+                cargo_home_dir: Path::new("/tmp/pikaci/cache/cargo-home"),
+                target_dir: Path::new("/tmp/pikaci/cache/target"),
+                staged_linux_rust_workspace_deps_dir: None,
+                staged_linux_rust_workspace_build_dir: None,
+                socket_path: Path::new("/tmp/pikaci-rmp-init-smoke-ci.sock"),
+            },
         )
         .expect("render flake");
 
@@ -1267,10 +1319,14 @@ mod tests {
             &spec,
             Path::new("/tmp/pikaci/snapshot"),
             true,
-            Path::new("/tmp/pikaci/jobs/android-sdk-probe/artifacts"),
-            Path::new("/tmp/pikaci/cache/cargo-home"),
-            Path::new("/tmp/pikaci/cache/target"),
-            Path::new("/tmp/pikaci-android-sdk-probe.sock"),
+            &GuestFlakePaths {
+                artifacts_dir: Path::new("/tmp/pikaci/jobs/android-sdk-probe/artifacts"),
+                cargo_home_dir: Path::new("/tmp/pikaci/cache/cargo-home"),
+                target_dir: Path::new("/tmp/pikaci/cache/target"),
+                staged_linux_rust_workspace_deps_dir: None,
+                staged_linux_rust_workspace_build_dir: None,
+                socket_path: Path::new("/tmp/pikaci-android-sdk-probe.sock"),
+            },
         )
         .expect("render flake");
 
@@ -1278,5 +1334,42 @@ mod tests {
         assert!(flake.contains("nix develop .#default -c bash -lc"));
         assert!(flake.contains("command -v adb"));
         assert!(flake.contains("runAsRoot = true;"));
+    }
+
+    #[test]
+    fn guest_flake_mounts_staged_linux_rust_outputs_for_pika_core_lane() {
+        let spec = JobSpec {
+            id: "pika-core-lib-tests",
+            description: "test",
+            timeout_secs: 120,
+            writable_workspace: false,
+            guest_command: GuestCommand::ShellCommand {
+                command: "cargo test -p pika_core --lib --tests -- --nocapture",
+            },
+        };
+        let flake = render_guest_flake(
+            &spec,
+            Path::new("/tmp/pikaci/snapshot"),
+            true,
+            &GuestFlakePaths {
+                artifacts_dir: Path::new("/tmp/pikaci/jobs/pika-core-lib-tests/artifacts"),
+                cargo_home_dir: Path::new("/tmp/pikaci/cache/cargo-home"),
+                target_dir: Path::new("/tmp/pikaci/cache/target"),
+                staged_linux_rust_workspace_deps_dir: Some(Path::new("/nix/store/workspace-deps")),
+                staged_linux_rust_workspace_build_dir: Some(Path::new(
+                    "/nix/store/workspace-build",
+                )),
+                socket_path: Path::new("/tmp/pikaci-pika-core-lib-tests.sock"),
+            },
+        )
+        .expect("render flake");
+
+        assert!(flake.contains(
+            "guestCommand = \"/staged/linux-rust/workspace-build/bin/run-pika-core-lib-tests\";"
+        ));
+        assert!(flake.contains("stagedLinuxRustWorkspaceDepsDir = \"/nix/store/workspace-deps\";"));
+        assert!(
+            flake.contains("stagedLinuxRustWorkspaceBuildDir = \"/nix/store/workspace-build\";")
+        );
     }
 }

--- a/crates/pikaci/src/model.rs
+++ b/crates/pikaci/src/model.rs
@@ -85,6 +85,13 @@ impl JobSpec {
         }
     }
 
+    pub fn staged_linux_rust_lane(&self) -> Option<StagedLinuxRustLane> {
+        match self.id {
+            "pika-core-lib-tests" => Some(StagedLinuxRustLane::PikaCoreLibTests),
+            _ => None,
+        }
+    }
+
     pub fn host_setup_command(&self) -> Option<&'static str> {
         match self.id {
             "tart-beachhead" => Some(concat!(
@@ -98,6 +105,33 @@ impl JobSpec {
                 "just ios-xcframework ios-xcodeproj",
             )),
             _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StagedLinuxRustLane {
+    PikaCoreLibTests,
+}
+
+impl StagedLinuxRustLane {
+    pub fn workspace_deps_output_name(self) -> &'static str {
+        match self {
+            Self::PikaCoreLibTests => "ci.aarch64-linux.workspaceDeps",
+        }
+    }
+
+    pub fn workspace_build_output_name(self) -> &'static str {
+        match self {
+            Self::PikaCoreLibTests => "ci.aarch64-linux.workspaceBuild",
+        }
+    }
+
+    pub fn execute_wrapper_command(self) -> &'static str {
+        match self {
+            Self::PikaCoreLibTests => {
+                "/staged/linux-rust/workspace-build/bin/run-pika-core-lib-tests"
+            }
         }
     }
 }

--- a/crates/pikaci/src/run.rs
+++ b/crates/pikaci/src/run.rs
@@ -1,5 +1,6 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
+use std::os::unix::fs as unix_fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -12,7 +13,7 @@ use crate::executor::{
 };
 use crate::model::{
     ExecuteNode, JobRecord, JobSpec, PlanExecutorKind, PlanNodeRecord, PlanScope, PrepareNode,
-    RunPlanRecord, RunRecord, RunStatus, RunnerKind,
+    RunPlanRecord, RunRecord, RunStatus, RunnerKind, StagedLinuxRustLane,
 };
 use crate::snapshot::{create_snapshot, git_dirty, git_head, materialize_workspace};
 
@@ -138,6 +139,7 @@ fn run_jobs_against_snapshot(
             &planned_job.job,
             &planned_job.execute_node_id,
             &planned_job.ctx,
+            planned_job.staged_linux_rust_prepare.as_ref(),
         )?;
         if job_record.status == RunStatus::Failed {
             run_failed = true;
@@ -194,7 +196,12 @@ pub fn record_skipped_run(
     Ok(run_record)
 }
 
-fn run_one_job(job: &JobSpec, plan_node_id: &str, ctx: &HostContext) -> anyhow::Result<JobRecord> {
+fn run_one_job(
+    job: &JobSpec,
+    plan_node_id: &str,
+    ctx: &HostContext,
+    staged_linux_rust_prepare: Option<&StagedLinuxRustPrepare>,
+) -> anyhow::Result<JobRecord> {
     let job_dir = ctx.job_dir.clone();
     let host_log_path = ctx.host_log_path.clone();
     let guest_log_path = ctx.guest_log_path.clone();
@@ -217,7 +224,12 @@ fn run_one_job(job: &JobSpec, plan_node_id: &str, ctx: &HostContext) -> anyhow::
     };
     write_job_record(&job_dir, &job_record)?;
 
-    let outcome = run_job_on_runner(job, ctx);
+    let mut ctx = ctx.clone();
+    if let Some(staged_linux_rust_prepare) = staged_linux_rust_prepare {
+        prepare_staged_linux_rust_host_context(&mut ctx, staged_linux_rust_prepare)?;
+    }
+
+    let outcome = run_job_on_runner(job, &ctx);
 
     let finished_at = Utc::now().to_rfc3339();
     match outcome {
@@ -388,11 +400,17 @@ struct PlannedJob {
     job: JobSpec,
     execute_node_id: String,
     ctx: HostContext,
+    staged_linux_rust_prepare: Option<StagedLinuxRustPrepare>,
 }
 
 struct RunPlan {
     record: RunPlanRecord,
     jobs: Vec<PlannedJob>,
+}
+
+struct StagedLinuxRustPrepare {
+    workspace_deps_installable: String,
+    workspace_build_installable: String,
 }
 
 struct PreparedRun {
@@ -423,6 +441,7 @@ fn build_run_plan(
 
     for job in jobs {
         let job_dir = prepared.jobs_dir.join(job.id);
+        fs::create_dir_all(&job_dir).with_context(|| format!("create {}", job_dir.display()))?;
         let ctx = HostContext {
             workspace_snapshot_dir: prepare_job_workspace(job, &snapshot.snapshot_dir, &job_dir)?,
             workspace_read_only: !job.writable_workspace,
@@ -431,8 +450,48 @@ fn build_run_plan(
             guest_log_path: job_dir.join("artifacts/guest.log"),
             shared_cargo_home_dir: prepared.shared_cargo_home_dir.clone(),
             shared_target_dir: prepared.run_target_dir.clone(),
+            staged_linux_rust_workspace_deps_dir: job
+                .staged_linux_rust_lane()
+                .map(|_| job_dir.join("staged-linux-rust").join("workspace-deps")),
+            staged_linux_rust_workspace_build_dir: job
+                .staged_linux_rust_lane()
+                .map(|_| job_dir.join("staged-linux-rust").join("workspace-build")),
         };
         let mut depends_on = Vec::new();
+        let staged_linux_rust_prepare = job.staged_linux_rust_lane().map(|lane| {
+            let deps_node_id = format!("prepare-{}-workspace-deps", job.id);
+            let build_node_id = format!("prepare-{}-workspace-build", job.id);
+            let workspace_deps_installable =
+                staged_linux_rust_installable(&snapshot.snapshot_dir, lane, true);
+            let workspace_build_installable =
+                staged_linux_rust_installable(&snapshot.snapshot_dir, lane, false);
+            nodes.push(PlanNodeRecord::Prepare {
+                id: deps_node_id.clone(),
+                description: format!("Build staged Linux Rust dependencies for `{}`", job.id),
+                executor: PlanExecutorKind::HostLocal,
+                depends_on: Vec::new(),
+                prepare: PrepareNode::NixBuild {
+                    installable: workspace_deps_installable.clone(),
+                    output_name: lane.workspace_deps_output_name().to_string(),
+                },
+            });
+            nodes.push(PlanNodeRecord::Prepare {
+                id: build_node_id.clone(),
+                description: format!("Build staged Linux Rust test artifacts for `{}`", job.id),
+                executor: PlanExecutorKind::HostLocal,
+                depends_on: vec![deps_node_id.clone()],
+                prepare: PrepareNode::NixBuild {
+                    installable: workspace_build_installable.clone(),
+                    output_name: lane.workspace_build_output_name().to_string(),
+                },
+            });
+            depends_on.push(deps_node_id);
+            depends_on.push(build_node_id);
+            StagedLinuxRustPrepare {
+                workspace_deps_installable,
+                workspace_build_installable,
+            }
+        });
         if job.runner_kind() == RunnerKind::VfkitLocal {
             let prepare_node_id = format!("prepare-{}-runner", job.id);
             let installable = materialize_vfkit_runner_flake(job, &ctx)?;
@@ -468,6 +527,7 @@ fn build_run_plan(
             job: job.clone(),
             execute_node_id,
             ctx,
+            staged_linux_rust_prepare,
         });
     }
 
@@ -487,6 +547,130 @@ fn build_run_plan(
         },
         jobs: planned_jobs,
     })
+}
+
+fn staged_linux_rust_installable(
+    snapshot_dir: &Path,
+    lane: StagedLinuxRustLane,
+    deps_only: bool,
+) -> String {
+    let output_name = if deps_only {
+        lane.workspace_deps_output_name()
+    } else {
+        lane.workspace_build_output_name()
+    };
+    format!("path:{}#{output_name}", snapshot_dir.display())
+}
+
+fn prepare_staged_linux_rust_host_context(
+    ctx: &mut HostContext,
+    staged_linux_rust_prepare: &StagedLinuxRustPrepare,
+) -> anyhow::Result<()> {
+    let workspace_deps_output = realize_nix_build_output(
+        &staged_linux_rust_prepare.workspace_deps_installable,
+        "workspaceDeps",
+        &ctx.host_log_path,
+    )?;
+    let workspace_build_output = realize_nix_build_output(
+        &staged_linux_rust_prepare.workspace_build_installable,
+        "workspaceBuild",
+        &ctx.host_log_path,
+    )?;
+    let workspace_deps_dir = ctx
+        .staged_linux_rust_workspace_deps_dir
+        .as_ref()
+        .ok_or_else(|| anyhow!("missing staged Linux Rust workspaceDeps mount path"))?;
+    let workspace_build_dir = ctx
+        .staged_linux_rust_workspace_build_dir
+        .as_ref()
+        .ok_or_else(|| anyhow!("missing staged Linux Rust workspaceBuild mount path"))?;
+    repoint_prepare_mount(workspace_deps_dir, &workspace_deps_output)?;
+    repoint_prepare_mount(workspace_build_dir, &workspace_build_output)?;
+    append_log_line(
+        &ctx.host_log_path,
+        &format!(
+            "[pikaci] staged Linux Rust outputs ready: workspaceDeps={} workspaceBuild={}",
+            workspace_deps_dir.display(),
+            workspace_build_dir.display()
+        ),
+    )?;
+    Ok(())
+}
+
+fn repoint_prepare_mount(mount_path: &Path, output_path: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = mount_path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    if mount_path.exists() || mount_path.is_symlink() {
+        fs::remove_file(mount_path)
+            .or_else(|_| fs::remove_dir_all(mount_path))
+            .with_context(|| format!("remove {}", mount_path.display()))?;
+    }
+    unix_fs::symlink(output_path, mount_path).with_context(|| {
+        format!(
+            "symlink {} -> {}",
+            mount_path.display(),
+            output_path.display()
+        )
+    })
+}
+
+fn realize_nix_build_output(
+    installable: &str,
+    output_name: &str,
+    log_path: &Path,
+) -> anyhow::Result<PathBuf> {
+    append_log_line(
+        log_path,
+        &format!(
+            "[pikaci] prepare {output_name}: nix build --accept-flake-config --no-link --print-out-paths {installable}"
+        ),
+    )?;
+    let output = Command::new("nix")
+        .arg("build")
+        .arg("--accept-flake-config")
+        .arg("--no-link")
+        .arg("--print-out-paths")
+        .arg(installable)
+        .output()
+        .with_context(|| format!("run staged prepare `{output_name}`"))?;
+    append_command_output(log_path, &output.stdout, &output.stderr)?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "staged prepare `{output_name}` failed with {:?}; see {}",
+            output.status.code(),
+            log_path.display()
+        ));
+    }
+
+    let stdout = String::from_utf8(output.stdout).context("decode nix build output")?;
+    let path = stdout
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .ok_or_else(|| anyhow!("nix build for `{output_name}` did not return an output path"))?;
+    Ok(PathBuf::from(path.trim()))
+}
+
+fn append_log_line(path: &Path, line: &str) -> anyhow::Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open {}", path.display()))?;
+    writeln!(file, "{line}").with_context(|| format!("write {}", path.display()))
+}
+
+fn append_command_output(log_path: &Path, stdout: &[u8], stderr: &[u8]) -> anyhow::Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .with_context(|| format!("open {}", log_path.display()))?;
+    file.write_all(stdout)
+        .with_context(|| format!("write stdout to {}", log_path.display()))?;
+    file.write_all(stderr)
+        .with_context(|| format!("write stderr to {}", log_path.display()))
 }
 
 fn prepare_run(options: &RunOptions) -> anyhow::Result<PreparedRun> {
@@ -642,8 +826,63 @@ mod tests {
                 "workspace_snapshot_created".to_string()
             ]
         );
-        assert_eq!(plan.record.nodes.len(), 2);
+        assert_eq!(plan.record.nodes.len(), 4);
         match &plan.record.nodes[0] {
+            PlanNodeRecord::Prepare {
+                id,
+                executor,
+                prepare,
+                ..
+            } => {
+                assert_eq!(id, "prepare-pika-core-lib-tests-workspace-deps");
+                assert_eq!(*executor, PlanExecutorKind::HostLocal);
+                match prepare {
+                    PrepareNode::NixBuild {
+                        installable,
+                        output_name,
+                    } => {
+                        assert!(
+                            installable
+                                .contains("runs/run-1/snapshot#ci.aarch64-linux.workspaceDeps")
+                        );
+                        assert_eq!(output_name, "ci.aarch64-linux.workspaceDeps");
+                    }
+                }
+            }
+            other => panic!("expected prepare node, got {other:?}"),
+        }
+
+        match &plan.record.nodes[1] {
+            PlanNodeRecord::Prepare {
+                id,
+                executor,
+                depends_on,
+                prepare,
+                ..
+            } => {
+                assert_eq!(id, "prepare-pika-core-lib-tests-workspace-build");
+                assert_eq!(*executor, PlanExecutorKind::HostLocal);
+                assert_eq!(
+                    depends_on,
+                    &vec!["prepare-pika-core-lib-tests-workspace-deps".to_string()]
+                );
+                match prepare {
+                    PrepareNode::NixBuild {
+                        installable,
+                        output_name,
+                    } => {
+                        assert!(
+                            installable
+                                .contains("runs/run-1/snapshot#ci.aarch64-linux.workspaceBuild")
+                        );
+                        assert_eq!(output_name, "ci.aarch64-linux.workspaceBuild");
+                    }
+                }
+            }
+            other => panic!("expected staged build prepare node, got {other:?}"),
+        }
+
+        match &plan.record.nodes[2] {
             PlanNodeRecord::Prepare {
                 id,
                 executor,
@@ -667,10 +906,10 @@ mod tests {
                     }
                 }
             }
-            other => panic!("expected prepare node, got {other:?}"),
+            other => panic!("expected runner prepare node, got {other:?}"),
         }
 
-        match &plan.record.nodes[1] {
+        match &plan.record.nodes[3] {
             PlanNodeRecord::Execute {
                 id,
                 executor,
@@ -682,7 +921,11 @@ mod tests {
                 assert_eq!(*executor, PlanExecutorKind::VfkitLocal);
                 assert_eq!(
                     depends_on,
-                    &vec!["prepare-pika-core-lib-tests-runner".to_string()]
+                    &vec![
+                        "prepare-pika-core-lib-tests-workspace-deps".to_string(),
+                        "prepare-pika-core-lib-tests-workspace-build".to_string(),
+                        "prepare-pika-core-lib-tests-runner".to_string()
+                    ]
                 );
                 match execute {
                     ExecuteNode::VmCommand {
@@ -693,7 +936,7 @@ mod tests {
                     } => {
                         assert_eq!(
                             command,
-                            "bash --noprofile --norc -lc 'cargo test -p pika_core --lib --tests -- --nocapture'"
+                            "/staged/linux-rust/workspace-build/bin/run-pika-core-lib-tests"
                         );
                         assert!(!run_as_root);
                         assert_eq!(*timeout_secs, 1800);
@@ -706,6 +949,20 @@ mod tests {
 
         assert_eq!(plan.jobs.len(), 1);
         assert_eq!(plan.jobs[0].execute_node_id, "execute-pika-core-lib-tests");
+        let staged_linux_rust_prepare = plan.jobs[0]
+            .staged_linux_rust_prepare
+            .as_ref()
+            .expect("staged linux rust prepare");
+        assert!(
+            staged_linux_rust_prepare
+                .workspace_deps_installable
+                .contains("runs/run-1/snapshot#ci.aarch64-linux.workspaceDeps")
+        );
+        assert!(
+            staged_linux_rust_prepare
+                .workspace_build_installable
+                .contains("runs/run-1/snapshot#ci.aarch64-linux.workspaceBuild")
+        );
         assert!(
             prepared
                 .run_dir

--- a/nix/ci/linux-rust.nix
+++ b/nix/ci/linux-rust.nix
@@ -26,7 +26,19 @@ let
   # Linux Rust lane family (`pre-merge-pika-rust`) by compiling the deterministic
   # `pika_core` lib + test targets without executing them.
   laneCompileCommand = ''
-    cargo test --locked -p pika_core --lib --tests --no-run
+    export PIKACI_PIKA_CORE_LIB_TESTS_MANIFEST="$TMPDIR/pika-core-lib-tests.manifest"
+    target_root="''${CARGO_TARGET_DIR:-target}"
+    cargoBuildLog=$(mktemp cargoBuildLogXXXX.json)
+    cargo test --locked -p pika_core --lib --tests --no-run --message-format json-render-diagnostics >"$cargoBuildLog"
+    : >"$PIKACI_PIKA_CORE_LIB_TESTS_MANIFEST"
+    while IFS= read -r executable; do
+      printf '%s\n' "''${executable#"$target_root"/}" >>"$PIKACI_PIKA_CORE_LIB_TESTS_MANIFEST"
+    done < <(
+      ${pkgs.jq}/bin/jq -r '
+        select(.reason == "compiler-artifact" and .profile.test == true and .executable != null)
+        | .executable
+      ' <"$cargoBuildLog"
+    )
   '';
 in
 rec {
@@ -42,6 +54,28 @@ rec {
     doCheck = false;
     buildPhaseCargoCommand = laneCompileCommand;
     doInstallCargoArtifacts = true;
-    installPhaseCommand = "mkdir -p $out";
+    installCargoArtifactsMode = "use-symlink";
+    installPhaseCommand = ''
+      mkdir -p "$out/bin" "$out/share/pikaci"
+      cp "$PIKACI_PIKA_CORE_LIB_TESTS_MANIFEST" "$out/share/pikaci/pika-core-lib-tests.manifest"
+      cat >"$out/bin/run-pika-core-lib-tests" <<'EOF'
+      #!${pkgs.bash}/bin/bash
+      set -euo pipefail
+
+      root="$(cd "$(dirname "''${BASH_SOURCE[0]}")/.." && pwd)"
+      manifest="$root/share/pikaci/pika-core-lib-tests.manifest"
+      if [ ! -s "$manifest" ]; then
+        echo "missing staged pika_core test manifest at $manifest" >&2
+        exit 1
+      fi
+
+      while IFS= read -r relative; do
+        [ -n "$relative" ] || continue
+        echo "[pikaci] running staged pika_core test binary $relative"
+        "$root/target/$relative" --nocapture
+      done <"$manifest"
+      EOF
+      chmod +x "$out/bin/run-pika-core-lib-tests"
+    '';
   });
 }

--- a/nix/pikaci/guest-module.nix
+++ b/nix/pikaci/guest-module.nix
@@ -7,6 +7,8 @@
   artifactsDir,
   cargoHomeDir,
   cargoTargetDir,
+  stagedLinuxRustWorkspaceDepsDir ? null,
+  stagedLinuxRustWorkspaceBuildDir ? null,
   socketPath,
   rustToolchain ? null,
   moqRelay ? null,
@@ -245,6 +247,24 @@ EOF
         source = cargoTargetDir;
         mountPoint = "/cargo-target";
         readOnly = false;
+      }
+    ]
+    ++ lib.optionals (stagedLinuxRustWorkspaceDepsDir != null) [
+      {
+        proto = "virtiofs";
+        tag = "staged-linux-rust-workspace-deps";
+        source = stagedLinuxRustWorkspaceDepsDir;
+        mountPoint = "/staged/linux-rust/workspace-deps";
+        readOnly = true;
+      }
+    ]
+    ++ lib.optionals (stagedLinuxRustWorkspaceBuildDir != null) [
+      {
+        proto = "virtiofs";
+        tag = "staged-linux-rust-workspace-build";
+        source = stagedLinuxRustWorkspaceBuildDir;
+        mountPoint = "/staged/linux-rust/workspace-build";
+        readOnly = true;
       }
     ];
   };


### PR DESCRIPTION
## Summary
- Add linux rust prepare/execute lane to pikaci executor
- Extend model with staged lane types and guest NixOS module
- Wire up nix CI outputs for linux rust lane

## Test plan
- [ ] CI pre-merge checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sledtools/pika/pull/492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for staged Linux Rust workspace testing with a dedicated execution lane.
  * Introduced test artifact manifest generation that captures and executes pre-built test binaries via a wrapper script.
  * Enabled pre-staging of Rust workspace dependencies and build artifacts with read-only VM mounts.
  * Extended build configuration with symlink-based artifact installation for improved staging workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->